### PR TITLE
调整玩家与机甲被击飞时的绘制顺序

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11546,7 +11546,7 @@ void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
         if( animate && ( seen || u.sees( *c ) ) ) {
             invalidate_main_ui_adaptor();
             inp_mngr.pump_events();
-            ui_manager::redraw_invalidated();
+            
            
             
 
@@ -11567,7 +11567,7 @@ void game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
 
         }
 
-
+            ui_manager::redraw_invalidated();
             refresh_display();
 
        


### PR DESCRIPTION
调整玩家乘坐机甲被击飞时画面的重绘时机，使机甲与玩家在击飞时的画面表现上不分离，表现的更加自然