### PR TITLE
重新为“永恒的天气”添加可视化的选项

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -198,7 +198,7 @@ jobs:
       shell: bash
 
     - name: Don't upload vcpkg cache on failure or PRs
-      if: ${{ failure() || cancelled() || github.ref_name != 'master' }}
+      if: ${{ failure() || cancelled() || github.ref_name != 'main' }}
       run: |
         echo "RUNVCPKG_NO_CACHE=1" >> $GITHUB_ENV
       shell: bash

--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -348,12 +348,5 @@
     "info": "Determines frequency (in minutes) of displaying music description in sidebar when listening to MP3-players and the like.",
     "stype": "int",
     "value": 5
-  },
-  {
-    "type": "EXTERNAL_OPTION",
-    "name": "ETERNAL_WEATHER",
-    "info": "Sets eternal weather.  Possible values are 'normal', 'clear', 'cloudy', 'light_drizzle', 'drizzle', 'rain', 'rainstorm', 'thunder', 'lightning', 'flurries', 'snowing', 'snowstorm', 'early_portal_storm', 'portal_storm'.  'normal' clears all eternal weather overrides and sets normal weather pattern.  Requires restart of the game after changing value to take effect.",
-    "stype": "string_input",
-    "value": "normal"
   }
 ]

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2524,6 +2524,25 @@ void options_manager::add_options_world_default()
     }, "normal"
        );
 
+    // 标记 对于永恒天气，添加可视化的选项   
+    add( "ETERNAL_WEATHER", "world_default", to_translation( "Eternal weather" ),
+    to_translation( "Sets eternal weather.  'Normal' clears all eternal weather overrides and sets normal weather pattern." ), {
+        { "normal", to_translation( "Normal" ) },
+        { "clear", to_translation( "Clear weather" ) },
+        { "cloudy", to_translation( "Cloudy weather" ) },
+        { "light_drizzle", to_translation( "Light drizzle" ) },
+        { "drizzle", to_translation( "Drizzle" ) },
+        { "rain", to_translation( "Rain" ) },
+        { "thunder", to_translation( "Thunder storm" ) },
+        { "lightning", to_translation( "Lightning storm" ) },
+        { "flurries", to_translation( "Flurries" ) },
+        { "snowing", to_translation( "Snow" ) },
+        { "snowstorm", to_translation( "Snow storm" ) },
+        { "early_portal_storm", to_translation( "Light portal storm" ) },
+        { "portal_storm", to_translation( "Portal storm" ) },
+    }, "normal"
+       );
+
     add_empty_line();
 
     add( "WANDER_SPAWNS", "world_default", to_translation( "Wandering hordes" ),


### PR DESCRIPTION
#### Summary
None
#### Purpose of change

来自 https://github.com/CleverRaven/Cataclysm-DDA/pull/59707

#### Describe the solution

在“options.cpp“里重新添加选项，移除“game_balance.json”中的相关内容

#### Describe alternatives you've considered

#### Testing

#### Additional context

