### PR TITLE
继续提升当周围有大量电器时的游戏速度，大幅加快traverse_vehicle_graph()

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5199,16 +5199,16 @@ int vehicle::traverse_vehicle_graph( Vehicle *start_veh, int amount, Func action
         return amount;
     }
     // Breadth-first search! Initialize the queue with a pointer to ourselves and go!
-    std::vector< std::pair<Vehicle *, int> > connected_vehs = std::vector< std::pair<Vehicle *, int> > { std::make_pair( start_veh, 0 ) };
+    std::map<int, Vehicle*> connected_vehs = { {0,start_veh} };
     phmap::flat_hash_set<Vehicle *> visited_vehs;
     phmap::flat_hash_set<tripoint> visited_targets;
     while( amount > 0 && !connected_vehs.empty() ) {
-        auto current_node = connected_vehs.back();
-        Vehicle *current_veh = current_node.first;
-        int current_loss = current_node.second;
+        auto current_node = --connected_vehs.end();
+        Vehicle *current_veh = current_node->second;
+        int current_loss = current_node->first;
         
         visited_vehs.insert( current_veh );
-        connected_vehs.pop_back();
+        connected_vehs.erase(current_loss);
 
         add_msg_debug( debugmode::DF_VEHICLE, "Traversing graph with %d power", amount );
 
@@ -5235,7 +5235,7 @@ int vehicle::traverse_vehicle_graph( Vehicle *start_veh, int amount, Func action
             // Add this connected vehicle to the queue of vehicles to search next,
             // but only if we haven't seen this one before (checked above)
             int target_loss = current_loss + current_veh->part_info( p ).epower;
-            connected_vehs.push_back( std::make_pair( target_veh, target_loss ) );
+            connected_vehs.insert( std::make_pair( target_loss,target_veh ) );
             // current_veh could be invalid after this point
 
             float loss_amount = ( static_cast<float>( amount ) * static_cast<float>( target_loss ) ) / 100.0f;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
继续提升当周围有大量电器时的游戏速度
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
虽然在 #454 中已经提升了traverse_vehicle_graph()的速度，再此，我们在做进一步优化。最终效果十分的显著。
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
`connected_vehs` 在不断吞吐元素的过程中，仅仅保持容器中要么有一个元素，要么没有，此vector不断的舍去最后一个元素，不断的再往容器后面插入元素，此两个操作的时间复杂度在此场景下都为O(1)，也因此，vector的大小变化很大，容易在分配内存上引起额外的开销，同时在此场景下，用vector存储pair也有些奇怪。显而易见的是，用map去维护`connected_vehs`是更好的选择，同时它的插入和删除的时间复杂度都为O(log n)，在维持容器中仅仅有一个元素时更具优势。
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
依然是  #454 测试中的场景，在原有优化的基础上，此次优化使得`traverse_vehicle_graph()` 对cpu占用的下降到约9%。
相比一开始，使traverse_vehicle_graph()加快了约 80%。

![之后-02](https://github.com/WhiteCloud0123/CDDA-Breeze/assets/112397151/893f8a46-3feb-4048-abfd-247990e089a7)

![之后-03](https://github.com/WhiteCloud0123/CDDA-Breeze/assets/112397151/35d154f5-b523-4062-a083-8474060ddf02)


![之后-04](https://github.com/WhiteCloud0123/CDDA-Breeze/assets/112397151/ea1d1fe0-90f8-443e-ac20-be8c2b84b159)



<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
