### PR TITLE
从CDDA端迁移一些小bug的修复

### DIFF
--- a/data/json/monster_special_attacks/monster_attacks.json
+++ b/data/json/monster_special_attacks/monster_attacks.json
@@ -23,7 +23,7 @@
     "move_cost": 100,
     "damage_max_instance": [ { "damage_type": "cut", "amount": 15 }, { "damage_type": "acid", "amount": 16 } ],
     "effects": [ { "id": "corroding", "duration": [ 10, 30 ], "affect_hit_bp": true } ],
-    "effects_require_dmg": false,
+    "effects_require_dmg": true,
     "self_effects_always": [ { "id": "maimed_acid_gland", "duration": 5 } ],
     "required_effects_any": [ "acid_charged" ],
     "forbidden_effects_any": [ "maimed_acid_gland", "maimed_claws" ],

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -947,7 +947,6 @@
     "result": "tin",
     "type": "recipe",
     "activity_level": "fake",
-    "byproducts": [ [ "steel_chunk" ] ],
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
     "skill_used": "chemistry",


### PR DESCRIPTION
#### Summary

从CDDA端迁移一些小bug的修复

#### Purpose of change

从CDDA端迁移一些小bug的修复

#### Describe the solution

1.删去锡粉配方中不应存在的钢块副产品
2.攻击必须对玩家造成伤害才能施加扣除玩家生命值的腐蚀效果

#### Describe alternatives you've considered

无

#### Testing

无

#### Additional context

是之前在CDDA那边修的两个小bug，顺手就丢过来了
