### PR TITLE
提前缓存对于loose_parts有没有POWER_TRANSFER flag的检查结果

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5203,20 +5203,20 @@ int vehicle::traverse_vehicle_graph( Vehicle *start_veh, int amount, Func action
     phmap::flat_hash_set<Vehicle *> visited_vehs;
     phmap::flat_hash_set<tripoint> visited_targets;
     while( amount > 0 && !connected_vehs.empty() ) {
-        auto current_node = connected_vehs.back();
+        const auto &current_node = connected_vehs.back();
         Vehicle *current_veh = current_node.first;
         int current_loss = current_node.second;
         
         visited_vehs.insert( current_veh );
         connected_vehs.pop_back();
 
-        add_msg_debug( debugmode::DF_VEHICLE, "Traversing graph with %d power", amount );
+        //add_msg_debug( debugmode::DF_VEHICLE, "Traversing graph with %d power", amount );
 
         for( int p : current_veh->loose_parts ) {
             // If we've already looked at the target location, don't bother the expensive vehicle lookup.
             // ignore loose parts that aren't power transfer cables
-            if (visited_targets.find(current_veh->parts[p].target.second) != visited_targets.end() 
-                   || !current_veh->part_info(p).has_flag("POWER_TRANSFER")) {
+            if (visited_targets.find(current_veh->parts[p].target.second) != visited_targets.end()
+                || !current_veh->parts[p].has_POWER_TRANSFER) {
                 continue;
             }
 
@@ -5237,13 +5237,13 @@ int vehicle::traverse_vehicle_graph( Vehicle *start_veh, int amount, Func action
             // current_veh could be invalid after this point
 
             float loss_amount = ( static_cast<float>( amount ) * static_cast<float>( target_loss ) ) / 100.0f;
-            add_msg_debug( debugmode::DF_VEHICLE,
+            /*add_msg_debug( debugmode::DF_VEHICLE,
                            "Visiting remote %p with %d power (loss %f, which is %d percent)",
-                           static_cast<void *>( target_veh ), amount, loss_amount, target_loss );
+                           static_cast<void *>( target_veh ), amount, loss_amount, target_loss );*/
 
             amount = action( target_veh, amount, static_cast<int>( loss_amount ) );
-            add_msg_debug( debugmode::DF_VEHICLE, "After remote %p, %d power",
-                           static_cast<void *>( target_veh ), amount );
+            /*add_msg_debug( debugmode::DF_VEHICLE, "After remote %p, %d power",
+                           static_cast<void *>( target_veh ), amount );*/
 
             if( amount < 1 ) {
                 break; // No more charge to donate away.
@@ -6103,6 +6103,14 @@ void vehicle::refresh( const bool remove_fakes )
         }
 
     }
+
+    for (const int& num : loose_parts) {
+        vehicle_part& vp = parts[num];
+        if (vp.info().has_flag("POWER_TRANSFER")) {
+            vp.has_POWER_TRANSFER = true;
+        }
+    }
+
 
     rail_wheel_bounding_box.p1 = point( railwheel_xmin, railwheel_ymin );
     rail_wheel_bounding_box.p2 = point( railwheel_xmax, railwheel_ymax );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -274,6 +274,8 @@ struct vehicle_part {
 
         // each time this vehicle part is racked this will push the data required to unrack to stack
         std::stack<carried_part_data> carried_stack;
+        
+        bool has_POWER_TRANSFER = false;
 
         /** Specific type of fuel, charges or ammunition currently contained by a part */
         itype_id ammo_current() const;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
跟进 #454  #473 #491 提前缓存对于loose_part有没有POWER_TRANSFER flag的检查结果，以继续加快traverse_vehicle_graph()
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
提前缓存对于loose_part有没有`POWER_TRANSFER` flag的检查结果，以继续加快`traverse_vehicle_graph()`。
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
当进入游戏的时候，会进行一次载具的`refresh()`,在这里提前缓存loose_parts有没有`POWER_TRANSFER` flag的检查结果，以便于减少在`current_veh->part_info(p).has_flag("POWER_TRANSFER")`层层调用中的性能损耗，单独维护一个bool值总体上要快的多。

另外将一个没有必要的复制行为改为引用，以及注释掉一些`add_msg_debug`。
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
测试条件与之前一致
![01](https://github.com/WhiteCloud0123/CDDA-Breeze/assets/112397151/8169dadb-f19c-481a-8e64-119b2efbc4ba)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
