### PR TITLE
DDA端-来自RenechCDDA：修复安装CBM时的崩溃问题

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2784,6 +2784,7 @@ bionic_uid Character::add_bionic( const bionic_id &b, bionic_uid parent_uid )
         }
     }
 
+    invalidate_pseudo_items();
     update_bionic_power_capacity();
 
     calc_encumbrance();
@@ -2797,7 +2798,6 @@ bionic_uid Character::add_bionic( const bionic_id &b, bionic_uid parent_uid )
     }
     effect_on_conditions::process_reactivate( *this );
 
-    invalidate_pseudo_items();
 
     return bio_uid;
 }


### PR DESCRIPTION
修复 #737 