### PR TITLE
将“移动方向存在中立怪物“添加到干扰管理。

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -343,6 +343,10 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
                 you.clear_destination();
                 return false;
             }
+            if (critter.attitude(&you) != MATT_ATTACK && uistate.distraction_neutral_monsters_in_the_direction_of_movement 
+                && !query_yn("移动方向存在中立怪物，这将变成对怪物的攻击行为，确定要继续吗？")) {
+                return false;
+            }
             if( you.has_effect( effect_relax_gas ) ) {
                 if( one_in( 8 ) ) {
                     add_msg( m_good, _( "Your willpower asserts itself, and so do you!" ) );

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -18,9 +18,10 @@ namespace distraction_manager
 static const std::vector<std::pair<std::string, std::string>> configurable_distractions = {
     {translate_marker( "Noise" ),                        translate_marker( "This distraction will interrupt your activity when you hear a noise." )},
     {translate_marker( "Pain" ),                         translate_marker( "This distraction will interrupt your activity when you feel pain." )},
-    {translate_marker( "Attack" ),                       translate_marker( "This distraction will interrupt your activity when you're attacked." )},
+    {"受到攻击",                       translate_marker("This distraction will interrupt your activity when you're attacked.")},
     {translate_marker( "Hostile is dangerously close" ), translate_marker( "This distraction will interrupt your activity when a hostile comes within 5 tiles from you." )},
     {translate_marker( "Hostile spotted" ),              translate_marker( "This distraction will interrupt your activity when you spot a hostile." )},
+    {"移动方向存在中立怪物",                       "这项干扰会在你的移动方向存在中立怪物时中断你当前的行动。"},
     {translate_marker( "Conversation" ),                 translate_marker( "This distraction will interrupt your activity when someone starts a conversation with you." )},
     {translate_marker( "Asthma" ),                       translate_marker( "This distraction will interrupt your activity when you suffer an asthma attack." )},
     {translate_marker( "Dangerous field" ),              translate_marker( "This distraction will interrupt your activity when you're standing in a dangerous field." )},
@@ -69,6 +70,7 @@ void distraction_manager_gui::show()
         uistate.distraction_attack,
         uistate.distraction_hostile_close,
         uistate.distraction_hostile_spotted,
+        uistate.distraction_neutral_monsters_in_the_direction_of_movement,
         uistate.distraction_conversation,
         uistate.distraction_asthma,
         uistate.distraction_dangerous_field,
@@ -187,27 +189,30 @@ void distraction_manager_gui::show()
                     uistate.distraction_hostile_spotted = !uistate.distraction_hostile_spotted;
                     break;
                 case 5:
-                    uistate.distraction_conversation = !uistate.distraction_conversation;
+                    uistate.distraction_neutral_monsters_in_the_direction_of_movement = !uistate.distraction_neutral_monsters_in_the_direction_of_movement;
                     break;
                 case 6:
-                    uistate.distraction_asthma = !uistate.distraction_asthma;
+                    uistate.distraction_conversation = !uistate.distraction_conversation;
                     break;
                 case 7:
-                    uistate.distraction_dangerous_field = !uistate.distraction_dangerous_field;
+                    uistate.distraction_asthma = !uistate.distraction_asthma;
                     break;
                 case 8:
-                    uistate.distraction_weather_change = !uistate.distraction_weather_change;
+                    uistate.distraction_dangerous_field = !uistate.distraction_dangerous_field;
                     break;
                 case 9:
-                    uistate.distraction_hunger = !uistate.distraction_hunger;
+                    uistate.distraction_weather_change = !uistate.distraction_weather_change;
                     break;
                 case 10:
-                    uistate.distraction_thirst = !uistate.distraction_thirst;
+                    uistate.distraction_hunger = !uistate.distraction_hunger;
                     break;
                 case 11:
-                    uistate.distraction_temperature = !uistate.distraction_temperature;
+                    uistate.distraction_thirst = !uistate.distraction_thirst;
                     break;
                 case 12:
+                    uistate.distraction_temperature = !uistate.distraction_temperature;
+                    break;
+                case 13:
                     uistate.distraction_mutation = !uistate.distraction_mutation;
                     break;
                 default:

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -375,6 +375,7 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "distraction_attack", distraction_attack );
     json.member( "distraction_hostile_close", distraction_hostile_close );
     json.member( "distraction_hostile_spotted", distraction_hostile_spotted );
+    json.member("distraction_neutral_monsters_in_the_direction_of_movement", distraction_neutral_monsters_in_the_direction_of_movement);
     json.member( "distraction_conversation", distraction_conversation );
     json.member( "distraction_asthma", distraction_asthma );
     json.member( "distraction_dangerous_field", distraction_dangerous_field );
@@ -442,6 +443,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "distraction_attack", distraction_attack );
     jo.read( "distraction_hostile_close", distraction_hostile_close );
     jo.read( "distraction_hostile_spotted", distraction_hostile_spotted );
+    jo.read("distraction_neutral_monsters_in_the_direction_of_movement",distraction_neutral_monsters_in_the_direction_of_movement);
     jo.read( "distraction_conversation", distraction_conversation );
     jo.read( "distraction_asthma", distraction_asthma );
     jo.read( "distraction_dangerous_field", distraction_dangerous_field );

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -139,6 +139,7 @@ class uistatedata
         bool distraction_attack = true;
         bool distraction_hostile_close = true;
         bool distraction_hostile_spotted = true;
+        bool distraction_neutral_monsters_in_the_direction_of_movement = true;
         bool distraction_conversation = true;
         bool distraction_asthma = true;
         bool distraction_dangerous_field = true;


### PR DESCRIPTION
#756 