### PR TITLE
Revert "修复区域清空活动不能连续移除枪械模组的问题"

### DIFF
--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -263,11 +263,10 @@ bool Character::gunmod_remove( item &gun, item &mod )
 
     // Removing gunmod takes only half as much time as installing it
     const int moves = has_trait( trait_DEBUG_HS ) ? 0 : mod.type->gunmod->install_time / 2;
-   
-    gunmod_remove_activity_actor::gunmod_remove(*this,gun,mod);
-
-    mod_moves(-moves);
-
+    item_location gun_loc = item_location( *this, &gun );
+    assign_activity(
+        player_activity(
+            gunmod_remove_activity_actor( moves, gun_loc, static_cast<int>( gunmod_idx ) ) ) );
     return true;
 }
 


### PR DESCRIPTION
This reverts commit 6f2dbb2158ede7f37ad067b0fd12a1fdd85dccbb.