### PR TITLE
DDA端-来自akrieger：避免一个没必要的对item的复制行为，在get_uncraft_components()

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15500,7 +15500,7 @@ std::vector<item_comp> item::get_uncraft_components() const
     } else {
         //Make a new vector of components from the registered components
         for( const item &component : components ) {
-            auto iter = std::find_if( ret.begin(), ret.end(), [component]( item_comp & obj ) {
+            auto iter = std::find_if( ret.begin(), ret.end(), [&component]( item_comp & obj ) {
                 return obj.type == component.typeId();
             } );
 


### PR DESCRIPTION
#833 