### PR TITLE
修复启用粒子系统时降水不显示

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1828,8 +1828,9 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             draw_line();
             void_line();
         }
-        if( do_draw_weather && !use_particle_system ) {
-            
+       if( do_draw_weather ) {
+            // The particle system does not currently render precipitation.
+　　　　     // Keep the tile-based weather overlay visible as a fallback.
             draw_weather_frame();
             
             void_weather();


### PR DESCRIPTION
启用粒子系统后，传统天气覆盖层会被跳过，但当前天气粒子并未进入实际绘制流程，导致降雨和降雪不可见。
本修改在保留其他粒子效果的同时，恢复原有天气覆盖层作为降水显示回退。
测试情况：Windows Tiles x64 MSVC 编译通过；开启粒子系统后，降水显示恢复正常。