### PR TITLE
调整触及攻击的斜向距离判定

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9513,7 +9513,9 @@ std::vector<Creature *> Character::get_targetable_creatures( const int range, bo
                 }
             }
         }
-        bool in_range = std::round( rl_dist_exact( pos(), critter.pos() ) ) <= range;
+        const float exact_distance = rl_dist_exact( pos(), critter.pos() );
+        const bool in_range = ( melee ? static_cast<int>( exact_distance ) :
+                                static_cast<int>( std::round( exact_distance ) ) ) <= range;
         // TODO: get rid of fake npcs (pos() check)
         bool valid_target = this != &critter && pos() != critter.pos() && attitude_to( critter ) != Creature::Attitude::FRIENDLY;
         return valid_target && in_range && can_see;

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -223,7 +223,8 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
         return;
     }
     if( !source.is_adjacent( critter, true ) ) {
-        if( rl_dist_exact( source.pos(), location ) <= weapon.reach_range( source ) ) {
+        if( static_cast<int>( rl_dist_exact( source.pos(), location ) ) <=
+            weapon.reach_range( source ) ) {
             add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is attempting a reach attack",
                            source.disp_name() );
             // check for friendlies in the line of fire

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3050,7 +3050,11 @@ void target_ui::update_status()
 
 int target_ui::dist_fn( const tripoint &p )
 {
-    return static_cast<int>( std::round( rl_dist_exact( src, p ) ) );
+    const float distance = rl_dist_exact( src, p );
+    if( mode == TargetMode::Reach ) {
+        return static_cast<int>( distance );
+    }
+    return static_cast<int>( std::round( distance ) );
 }
 
 void target_ui::set_last_target()


### PR DESCRIPTION
## 变更目的

对齐实验板远距武器更新。触及攻击使用 `std::round( rl_dist_exact(...) )` 判定距离时，横纵各偏移 2 格的目标实际距离约为 2.83，会被四舍五入为 3，导致射程 2 的触及武器无法攻击该斜向位置。

## 修改内容

- 仅在触及攻击目标模式中将精确距离向下取整。
- 同步调整角色自动触及攻击与 NPC 触及攻击的范围判断。
- 不改变枪械射程、视野、移动距离及其他普通距离规则。

## 预期行为

- 射程 2 的触及武器可以攻击横纵各偏移 2 格的目标。
- 射程 3 的触及武器可以覆盖上述位置，但不能攻击横纵各偏移 3 格的目标。
- 直线方向的原有射程保持不变。

## 验证情况

- Windows Tiles x64 MSVC 编译通过。
- 已在 Andy 分支游戏内确认射程 2 的斜向触及攻击恢复正常。