### PR TITLE
允许交易玩家载具储存空间中的物品

### DIFF
--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -19,6 +19,9 @@
 #include "point.h"
 #include "string_formatter.h"
 #include "type_id.h"
+#include "vehicle.h"
+
+static const faction_id faction_your_followers( "your_followers" );
 
 static const flag_id json_flag_NO_UNWIELD( "NO_UNWIELD" );
 static const item_category_id item_category_ITEMS_WORN( "ITEMS_WORN" );
@@ -138,6 +141,15 @@ trade_ui::trade_ui( party_t &you, npc &trader, currency_t cost, std::string titl
         }
     } else if( !trader.is_player_ally() ) {
         _panes[_trader]->add_nearby_items( 1 );
+    }
+
+    map &here = get_map();
+    for( const wrapped_vehicle &wrapped_veh : here.get_vehicles() ) {
+        if( wrapped_veh.v->owner == faction_your_followers ) {
+            for( const tripoint &veh_point : wrapped_veh.v->get_points() ) {
+                _panes[_you]->add_vehicle_items( veh_point );
+            }
+        }
     }
 
     if( trader.will_exchange_items_freely() ) {


### PR DESCRIPTION
## 变更目的

现有交易界面主要读取玩家随身物品与附近地面物品。大型载具携带大量物资时，储存空间无法直接参与交易，需要反复取出和放回。

## 修改内容

- 打开交易界面时，遍历当前已加载地图内属于 `your_followers` 阵营的载具。
- 使用现有 `add_vehicle_items` 流程，将载具货舱物品加入玩家一侧的交易列表。
- 成交、按数量扣除与取消交易继续沿用原有 `item_location` 和交易转移流程，不先复制到玩家背包。

## 行为范围

- 只读取玩家阵营载具中具有货舱功能的部件。
- 不改变 NPC 的价格、购买规则、所有权判断与拒收规则。
- 从 NPC 购买的物品仍按原规则交给玩家，不会自动送入载具。

## 验证情况

- Windows Tiles x64 MSVC 编译通过。
- 已确认代码能够编译，与避难所NPC交易测试可以交换停在外面的车内物品，建议上游合并前继续复测整件物品、按数量出售、多个同类物品与取消交易。