### PR TITLE
修复天气绘制代码中的全角空格

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1829,8 +1829,6 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             void_line();
         }
        if( do_draw_weather ) {
-            // The particle system does not currently render precipitation.
-　　　　     // Keep the tile-based weather overlay visible as a fallback.
             draw_weather_frame();
             
             void_weather();


### PR DESCRIPTION
降水显示修复中的一行注释前混入了 U+3000 全角空格，导致Windows MSVC 编译失败。
本次删除两行非必要注释，保留原有天气绘制逻辑不变。修复后的代码已通过 Windows Tiles x64 MSVC 编译。
验证测试天气气泡正常生成。
<img width="1280" height="760" alt="{74F2E0BB-F4D5-44B0-A832-66A97070AA7E}" src="https://github.com/user-attachments/assets/10af6974-cf13-4d61-89e6-64834da12a0c" />
