### PR TITLE
添加飞艇随机刷新并修复生成边界

### DIFF
--- a/data/json/mapgen/airport/s_airport_runway_private.json
+++ b/data/json/mapgen/airport/s_airport_runway_private.json
@@ -33,7 +33,8 @@
         ".cccccccccccccccccccccccccccccccccccccccccccccccc_d____________________...........................____________________..ccccccccccccccccccccccc.",
         "................................................c_d____________________..........................._b________________b_.........................."
       ],
-      "terrain": { ".": "t_region_groundcover_urban", "_": "t_pavement", "b": "t_pavement_y", "c": "t_chainfence", "d": "t_conveyor" }
+      "terrain": { ".": "t_region_groundcover_urban", "_": "t_pavement", "b": "t_pavement_y", "c": "t_chainfence", "d": "t_conveyor" },
+      "place_vehicles": [ { "vehicle": "personal_aircraft_airport", "x": 85, "y": 12, "chance": 25, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {

--- a/data/json/mapgen/cabin.json
+++ b/data/json/mapgen/cabin.json
@@ -70,7 +70,8 @@
         "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { ".": "t_tar_flat_roof" }
+      "terrain": { ".": "t_tar_flat_roof" },
+      "place_vehicles": [ { "vehicle": "aircanoe", "x": 12, "y": 14, "chance": 15, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {
@@ -159,7 +160,8 @@
         "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { ".": "t_tar_flat_roof" }
+      "terrain": { ".": "t_tar_flat_roof" },
+      "place_vehicles": [ { "vehicle": "aircanoe", "x": 12, "y": 9, "chance": 15, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {
@@ -235,7 +237,8 @@
         "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { ".": "t_tar_flat_roof" }
+      "terrain": { ".": "t_tar_flat_roof" },
+      "place_vehicles": [ { "vehicle": "airboat", "x": 12, "y": 14, "chance": 15, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {
@@ -308,7 +311,8 @@
         "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { ".": "t_tar_flat_roof" }
+      "terrain": { ".": "t_tar_flat_roof" },
+      "place_vehicles": [ { "vehicle": "aircanoe", "x": 15, "y": 9, "chance": 15, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {
@@ -381,7 +385,8 @@
         "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { ".": "t_tar_flat_roof" }
+      "terrain": { ".": "t_tar_flat_roof" },
+      "place_vehicles": [ { "vehicle": "aircanoe", "x": 8, "y": 10, "chance": 15, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {
@@ -525,7 +530,8 @@
         "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { ".": "t_tar_flat_roof" }
+      "terrain": { ".": "t_tar_flat_roof" },
+      "place_vehicles": [ { "vehicle": "aircanoe", "x": 13, "y": 11, "chance": 15, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {
@@ -774,7 +780,8 @@
         "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { ".": "t_tar_flat_roof" }
+      "terrain": { ".": "t_tar_flat_roof" },
+      "place_vehicles": [ { "vehicle": "airboat", "x": 13, "y": 13, "chance": 15, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {

--- a/data/json/mapgen/farm.json
+++ b/data/json/mapgen/farm.json
@@ -242,7 +242,8 @@
         "                                                "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { ".": "t_shingle_flat_roof", ",": "t_metal_flat_roof" }
+      "terrain": { ".": "t_shingle_flat_roof", ",": "t_metal_flat_roof" },
+      "place_vehicles": [ { "vehicle": "personal_aircraft_large", "x": 14, "y": 10, "chance": 15, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {

--- a/data/json/mapgen/junkyard.json
+++ b/data/json/mapgen/junkyard.json
@@ -92,7 +92,8 @@
         "                                                ",
         "                                                "
       ],
-      "palettes": [ "roof_palette" ]
+      "palettes": [ "roof_palette" ],
+      "place_vehicles": [ { "vehicle": "personal_aircraft_large", "x": 34, "y": 8, "chance": 15, "rotation": 180, "fuel": 0, "status": -1 } ]
     }
   },
   {

--- a/data/json/mapgen/lake_buildings/cabin_lake.json
+++ b/data/json/mapgen/lake_buildings/cabin_lake.json
@@ -132,7 +132,8 @@
       ],
       "palettes": [ "roof_palette" ],
       "terrain": { ".": "t_shingle_flat_roof" },
-      "furniture": { "W": "f_chimney" }
+      "furniture": { "W": "f_chimney" },
+      "place_vehicles": [ { "vehicle": "airboat", "x": 12, "y": 14, "chance": 15, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {

--- a/data/json/mapgen/marina.json
+++ b/data/json/mapgen/marina.json
@@ -227,7 +227,9 @@
         { "chance": 20, "fuel": 15, "vehicle": "boat_motor_single", "x": 113, "y": 52, "rotation": 270 },
         { "chance": 20, "fuel": 15, "vehicle": "boat_motor_single", "x": 61, "y": 9, "rotation": 90 },
         { "chance": 20, "fuel": 15, "vehicle": "boat_motor_single", "x": 69, "y": 9, "rotation": 90 },
-        { "chance": 20, "fuel": 15, "vehicle": "boat_motor_single", "x": 75, "y": 9, "rotation": 90 }
+        { "chance": 20, "fuel": 15, "vehicle": "boat_motor_single", "x": 75, "y": 9, "rotation": 90 },
+        { "vehicle": "personal_aircraft_large", "x": 80, "y": 78, "chance": 15, "rotation": 180, "fuel": 0, "status": -1 },
+        { "vehicle": "airboat", "x": 60, "y": 89, "chance": 15, "rotation": 270, "fuel": 0, "status": -1 }
       ],
       "place_monsters": [
         { "monster": "GROUP_HOUSE", "x": [ 0, 23 ], "y": [ 53, 71 ], "density": 0.037 },

--- a/data/json/mapgen/regional_airport.json
+++ b/data/json/mapgen/regional_airport.json
@@ -553,7 +553,8 @@
         "/%fss_,___________,_ssf/",
         "/%fss_,___________,_ssf/"
       ],
-      "palettes": [ "airport_palette" ]
+      "palettes": [ "airport_palette" ],
+      "place_vehicles": [ { "vehicle": "personal_aircraft_airport", "x": 12, "y": 14, "chance": 25, "rotation": 90, "fuel": 0, "status": -1 } ]
     }
   },
   {

--- a/data/json/mapgen/shelter.json
+++ b/data/json/mapgen/shelter.json
@@ -111,7 +111,8 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 9, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ]
+      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 9, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_vehicles": [ { "vehicle": "aircanoe", "x": 12, "y": 15, "chance": 15, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {
@@ -194,7 +195,8 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 11, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ]
+      "place_items": [ { "item": "roof_trash", "x": [ 5, 17 ], "y": [ 11, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_vehicles": [ { "vehicle": "aircanoe", "x": 12, "y": 14, "chance": 15, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {
@@ -277,7 +279,8 @@
         "5": "t_gutter_drop"
       },
       "furniture": { ":": "f_standing_tank", "#": "f_solar_unit", "&": "f_roof_turbine_vent" },
-      "place_items": [ { "item": "roof_trash", "x": [ 8, 15 ], "y": [ 7, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ]
+      "place_items": [ { "item": "roof_trash", "x": [ 8, 15 ], "y": [ 7, 22 ], "chance": 50, "repeat": [ 1, 3 ] } ],
+      "place_vehicles": [ { "vehicle": "aircanoe", "x": 12, "y": 15, "chance": 15, "rotation": 0, "fuel": 0, "status": -1 } ]
     }
   },
   {

--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -932,6 +932,21 @@
   },
   {
     "type": "vehicle_group",
+    "id": "personal_aircraft_small",
+    "vehicles": [ [ "aircanoe", 60 ], [ "airboat", 40 ] ]
+  },
+  {
+    "type": "vehicle_group",
+    "id": "personal_aircraft_large",
+    "vehicles": [ [ "airship", 100 ] ]
+  },
+  {
+    "type": "vehicle_group",
+    "id": "personal_aircraft_airport",
+    "vehicles": [ [ "aircanoe", 45 ], [ "airboat", 35 ], [ "airship", 20 ] ]
+  },
+  {
+    "type": "vehicle_group",
     "id": "cars_only",
     "vehicles": [
       [ "4x4_car", 200 ],


### PR DESCRIPTION
## 改动内容

- 飞艇在目前版本不会在大地图生成，玩家自制会耗费很多时间，因此考虑引入轻度损坏
飞艇刷新。
- 在私人机场、区域机场及部分建筑屋顶随机刷新空中独木舟、飞艇和飞船。
- 使用载具组直接放置，不复制原有地图生成。
- 修复飞艇覆盖围栏、屋顶设施及跨越24×24地图区块边界的问题。

## 测试

- 已在 `test/next-release` 完成 Windows MSVC 编译及游戏内基本测试。
- 9个JSON文件全部解析通过。
- 21个实际载具变体全部通过单OMT边界检查。

SUMMARY: Content "在机场与部分建筑屋顶随机刷新飞艇"