### PR TITLE
添加NPC武术切换与自动流派选择

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
@@ -334,6 +334,7 @@
     "responses": [
       { "text": "Change your engagement rules…", "topic": "TALK_COMBAT_ENGAGEMENT" },
       { "text": "Change your aiming rules…", "topic": "TALK_AIM_RULES" },
+      { "text": "选择你应该使用的武术……", "topic": "TALK_COMBAT_COMMANDS", "effect": "pick_style" },
       {
         "text": "Change your bionic power reserve rules…",
         "topic": "TALK_CBM_RESERVE_RULES",

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1762,7 +1762,12 @@ void avatar::add_pain_msg( int val, const bodypart_id &bp ) const
     }
 }
 
-bool character_martial_arts::pick_style( const avatar &you ) // Style selection menu
+bool character_martial_arts::pick_style( const avatar &you )
+{
+    return pick_style( static_cast<Character &>( const_cast<avatar &>( you ) ) );
+}
+
+bool character_martial_arts::pick_style( Character &you ) // Style selection menu
 {
     enum style_selection {
         KEEP_HANDS_FREE = 0,
@@ -1804,9 +1809,11 @@ bool character_martial_arts::pick_style( const avatar &you ) // Style selection 
     kmenu.input_category = "MELEE_STYLE_PICKER";
     kmenu.additional_actions.emplace_back( "SHOW_DESCRIPTION", translation() );
     kmenu.desc_enabled = true;
-    kmenu.addentry_desc( KEEP_HANDS_FREE, true, 'h',
-                         keep_hands_free ? _( "Keep hands free (on)" ) : _( "Keep hands free (off)" ),
-                         _( "When this is enabled, player won't wield things unless explicitly told to." ) );
+    if( you.is_avatar() ) {
+        kmenu.addentry_desc( KEEP_HANDS_FREE, true, 'h',
+                             keep_hands_free ? _( "Keep hands free (on)" ) : _( "Keep hands free (off)" ),
+                             _( "When this is enabled, player won't wield things unless explicitly told to." ) );
+    }
 
     kmenu.selected = STYLE_OFFSET;
 
@@ -1834,12 +1841,11 @@ bool character_martial_arts::pick_style( const avatar &you ) // Style selection 
     if( selection >= STYLE_OFFSET ) {
         // If the currect style is selected, do not change styles
 
-        avatar &u = const_cast<avatar &>( you );
-        style_selected->remove_all_buffs( u );
-        style_selected = selectable_styles[selection - STYLE_OFFSET];
-        ma_static_effects( u );
+        clear_all_effects( you );
+        set_style( selectable_styles[selection - STYLE_OFFSET], true );
+        ma_static_effects( you );
         martialart_use_message( you );
-    } else if( selection == KEEP_HANDS_FREE ) {
+    } else if( selection == KEEP_HANDS_FREE && you.is_avatar() ) {
         keep_hands_free = !keep_hands_free;
     } else {
         return false;

--- a/src/character_martial_arts.h
+++ b/src/character_martial_arts.h
@@ -9,9 +9,9 @@
 #include "type_id.h"
 
 class Character;
+class avatar;
 class JsonObject;
 class JsonOut;
-class avatar;
 class item;
 
 class character_martial_arts
@@ -34,6 +34,7 @@ class character_martial_arts
         void selected_style_check();
         /** Creates the UI and handles player input for picking martial arts styles */
         bool pick_style( const avatar &you );
+        bool pick_style( Character &you );
 
         bool knows_selected_style() const;
         bool selected_strictly_melee() const;
@@ -106,6 +107,12 @@ class character_martial_arts
 
         std::string enumerate_known_styles( const itype_id &weap ) const;
         std::string selected_style_name( const Character &owner ) const;
+        const std::vector<matype_id> &known_styles() const {
+            return ma_styles;
+        }
+        const matype_id &selected_style() const {
+            return style_selected;
+        }
 };
 
 #endif // CATA_SRC_CHARACTER_MARTIAL_ARTS_H

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -305,6 +305,18 @@ void npc_template::load( const JsonObject &jsobj )
     guy.name.clear();
     jsobj.read( "name_unique", tem.name_unique );
     jsobj.read( "name_suffix", tem.name_suffix );
+    if( jsobj.has_array( "martial_arts" ) ) {
+        for( const std::string style : jsobj.get_array( "martial_arts" ) ) {
+            tem.martial_arts.emplace_back( style );
+        }
+    }
+    if( jsobj.has_string( "martial_art" ) ) {
+        tem.selected_martial_art = matype_id( jsobj.get_string( "martial_art" ) );
+        if( std::find( tem.martial_arts.begin(), tem.martial_arts.end(),
+                       *tem.selected_martial_art ) == tem.martial_arts.end() ) {
+            tem.martial_arts.push_back( *tem.selected_martial_art );
+        }
+    }
     if( jsobj.has_string( "gender" ) ) {
         if( jsobj.get_string( "gender" ) == "male" ) {
             tem.gender_override = gender::male;
@@ -614,6 +626,15 @@ void npc_template::check_consistency()
         if( !guy.myclass.is_valid() ) {
             debugmsg( "Invalid NPC class %s", guy.myclass.c_str() );
         }
+        for( const matype_id &style : e.second.martial_arts ) {
+            if( !style.is_valid() ) {
+                debugmsg( "NPC模板%s包含无效的武术%s", e.first.c_str(), style.c_str() );
+            }
+        }
+        if( e.second.selected_martial_art && !e.second.selected_martial_art->is_valid() ) {
+            debugmsg( "NPC模板%s指定了无效的默认武术%s", e.first.c_str(),
+                      e.second.selected_martial_art->c_str() );
+        }
         std::string first_topic = guy.chatbin.first_topic;
         if( const json_talk_topic *topic = get_talk_topic( first_topic ) ) {
             cata::flat_set<std::string> reachable_topics =
@@ -766,6 +787,19 @@ void npc::load_npc_template( const string_id<npc_template> &ident )
         add_new_mission( mission::reserve_new( miss_id, getID() ) );
     }
     death_eocs = tguy.death_eocs;
+
+    for( const matype_id &style : tem.martial_arts ) {
+        if( style.is_valid() ) {
+            martial_arts_data->add_martialart( style );
+        }
+    }
+    if( tem.selected_martial_art && tem.selected_martial_art->is_valid() ) {
+        martial_arts_data->clear_all_effects( *this );
+        martial_arts_data->set_style( *tem.selected_martial_art );
+        martial_arts_data->ma_static_effects( *this );
+    } else {
+        select_best_martial_art( false );
+    }
     
     // 从模板复制 ai_prompt_from_npc_json
     ai_prompt_from_npc_json = tguy.ai_prompt_from_npc_json;
@@ -921,6 +955,7 @@ void npc::randomize( const npc_class_id &type )
     }
     // Add martial arts
     learn_ma_styles_from_traits();
+    select_best_martial_art( false );
     // Add spells for magiclysm mod
     for( std::pair<spell_id, int> spell_pair : type->_starting_spells ) {
         this->magic->learn_spell( spell_pair.first, *this, true );
@@ -948,6 +983,44 @@ void npc::learn_ma_styles_from_traits()
                 }
             }
         }
+    }
+}
+
+void npc::select_best_martial_art( bool announce )
+{
+    item_location wielded = get_wielded_item();
+    item &weapon = wielded ? *wielded : null_item_reference();
+    const bool can_use_gun = !is_player_ally() || rules.has_flag( ally_rule::use_guns );
+    const bool use_silent = is_player_ally() && rules.has_flag( ally_rule::use_silent );
+
+    const matype_id starting_style = martial_arts_data->selected_style();
+    matype_id best_style = starting_style;
+    martial_arts_data->clear_all_effects( *this );
+    martial_arts_data->set_style( starting_style );
+    martial_arts_data->ma_static_effects( *this );
+    cached_info.erase( "weapon_value" );
+    double best_value = evaluate_weapon( weapon, can_use_gun, use_silent );
+
+    for( const matype_id &style : martial_arts_data->known_styles() ) {
+        martial_arts_data->clear_all_effects( *this );
+        martial_arts_data->set_style( style );
+        martial_arts_data->ma_static_effects( *this );
+        cached_info.erase( "weapon_value" );
+        const double style_value = evaluate_weapon( weapon, can_use_gun, use_silent );
+        if( style_value > best_value ) {
+            best_value = style_value;
+            best_style = style;
+        }
+    }
+
+    martial_arts_data->clear_all_effects( *this );
+    martial_arts_data->set_style( best_style );
+    martial_arts_data->ma_static_effects( *this );
+    cached_info.erase( "weapon_value" );
+
+    if( announce && starting_style != best_style ) {
+        add_msg_if_player_sees( *this, m_info, _( "%1$s改用%2$s！" ),
+                                disp_name(), martial_arts_data->selected_style_name( *this ) );
     }
 }
 
@@ -1562,6 +1635,8 @@ bool npc::wield( item &it )
     if( to_wield.is_null() ) {
         set_wielded_item( item() );
         get_event_bus().send<event_type::character_wields_item>( getID(), item().typeId() );
+        select_best_martial_art();
+        invalidate_range_cache();
         return true;
     }
 
@@ -1578,6 +1653,7 @@ bool npc::wield( item &it )
     if( get_player_view().sees( pos() ) ) {
         add_msg_if_npc( m_info, _( "<npcname> wields a %s." ),  weapon->tname() );
     }
+    select_best_martial_art();
     invalidate_range_cache();
     return true;
 }

--- a/src/npc.h
+++ b/src/npc.h
@@ -774,6 +774,7 @@ class npc : public Character
         void randomize_from_faction( faction *fac );
         void apply_ownership_to_inv();
         void learn_ma_styles_from_traits();
+        void select_best_martial_art( bool announce = true );
         // Faction version number
         int get_faction_ver() const;
         void set_faction_ver( int new_version );
@@ -1440,6 +1441,8 @@ class npc_template
         npc guy;
         translation name_unique;
         translation name_suffix;
+        std::vector<matype_id> martial_arts;
+        std::optional<matype_id> selected_martial_art;
         enum class gender : int {
             random,
             male,

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5381,6 +5381,7 @@ void talk_effect_t<T>::parse_string_effect( const std::string &effect_id, const 
             WRAP( npc_die ),
             WRAP( npc_thankful ),
             WRAP( clear_overrides ),
+            WRAP( pick_style ),
             WRAP( do_disassembly ),
             WRAP( nothing ),
             WRAP( edit_ai_prompt ),

--- a/src/npctalk.h
+++ b/src/npctalk.h
@@ -112,6 +112,7 @@ void set_npc_pickup( npc &p );
 void npc_die( npc &p );
 void npc_thankful( npc &p );
 void clear_overrides( npc &p );
+void pick_style( npc &p );
 void do_craft(npc&);
 void do_disassembly( npc &p );
 void edit_ai_prompt( npc &p );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -1973,3 +1973,8 @@ void talk_function::clear_overrides( npc &p )
 {
     p.rules.clear_overrides();
 }
+
+void talk_function::pick_style( npc &p )
+{
+    p.martial_arts_data->pick_style( p );
+}


### PR DESCRIPTION
## 改动内容

- 在友好NPC战斗命令中添加已知武术切换入口。
- NPC更换武器或切换为空手时，自动选择适合当前武器的已知流派。
- NPC模板支持指定已知武术和初始武术。
- 游戏内新增界面与提示保持中文显示。

## 测试

- 已在 `test/next-release` 完成 Windows MSVC 编译及游戏内基本测试。
- 8个正式文件与已测试分支逐文件一致。

SUMMARY: Features "添加NPC武术切换与自动流派选择"