### PR TITLE
添加可拆卸三档分体式空调

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7206,5 +7206,51 @@
     "pre_special": "check_empty",
     "post_special": "done_appliance",
     "activity_level": "NO_EXERCISE"
+  },
+  {
+    "type": "construction",
+    "id": "app_split_air_conditioner",
+    "group": "place_split_air_conditioner",
+    "category": "APPLIANCE",
+    "required_skills": [
+      [
+        "electronics",
+        3
+      ],
+      [
+        "mechanics",
+        3
+      ]
+    ],
+    "time": "60 m",
+    "components": [
+      [
+        [
+          "split_air_conditioner",
+          1
+        ]
+      ]
+    ],
+    "pre_flags": {
+      "flag": "WALL",
+      "force_terrain": true
+    },
+    "post_special": "done_appliance",
+    "activity_level": "BRISK_EXERCISE",
+    "qualities": [
+      [
+        {
+          "id": "SCREW",
+          "level": 1
+        }
+      ],
+      [
+        {
+          "id": "WRENCH",
+          "level": 1
+        }
+      ]
+    ],
+    "pre_special": "check_air_conditioner_wall"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1708,5 +1708,10 @@
     "type": "construction_group",
     "id": "安装分拣器_组",
     "name": "安装运分拣器"
+  },
+  {
+    "type": "construction_group",
+    "id": "place_split_air_conditioner",
+    "name": "安装分体式空调"
   }
 ]

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -1648,5 +1648,109 @@
     "display_items": true,
     "phase": "solid",
     "looks_like": "t_dirtmound"
+  },
+  {
+    "id": "fd_aircon_cold_comfort",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "舒适冷风",
+        "sym": "&",
+        "convection_temperature_mod": -4
+      },
+      {
+        "color": "blue",
+        "convection_temperature_mod": -8
+      },
+      {
+        "color": "cyan",
+        "convection_temperature_mod": -12
+      }
+    ],
+    "priority": -1,
+    "display_field": false,
+    "decay_amount_factor": 5,
+    "percent_spread": 10,
+    "outdoor_age_speedup": "100 minutes",
+    "half_life": "50 minutes",
+    "phase": "gas"
+  },
+  {
+    "id": "fd_aircon_cold_refrigeration",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "冷藏冷风",
+        "sym": "&",
+        "convection_temperature_mod": -12
+      },
+      {
+        "color": "blue",
+        "convection_temperature_mod": -24
+      },
+      {
+        "color": "cyan",
+        "convection_temperature_mod": -36
+      }
+    ],
+    "priority": -1,
+    "display_field": false,
+    "decay_amount_factor": 5,
+    "percent_spread": 12,
+    "outdoor_age_speedup": "100 minutes",
+    "half_life": "55 minutes",
+    "phase": "gas"
+  },
+  {
+    "id": "fd_aircon_cold_freezing",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "冷冻冷风",
+        "sym": "&",
+        "convection_temperature_mod": -30
+      },
+      {
+        "color": "blue",
+        "convection_temperature_mod": -50
+      },
+      {
+        "color": "cyan",
+        "convection_temperature_mod": -70
+      }
+    ],
+    "priority": -1,
+    "display_field": false,
+    "decay_amount_factor": 5,
+    "percent_spread": 15,
+    "outdoor_age_speedup": "100 minutes",
+    "half_life": "60 minutes",
+    "phase": "gas"
+  },
+  {
+    "id": "fd_aircon_waste_heat",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "空调废热",
+        "sym": "&",
+        "convection_temperature_mod": 12
+      },
+      {
+        "color": "yellow",
+        "convection_temperature_mod": 30
+      },
+      {
+        "color": "light_red",
+        "convection_temperature_mod": 55
+      }
+    ],
+    "priority": -1,
+    "display_field": false,
+    "decay_amount_factor": 5,
+    "percent_spread": 10,
+    "outdoor_age_speedup": "100 minutes",
+    "half_life": "50 minutes",
+    "phase": "gas"
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -2,29 +2,19 @@
   {
     "type": "furniture",
     "id": "f_air_conditioner",
-    "name": "cooling unit",
+    "name": "制冷机",
     "looks_like": "f_machinery_light",
-    "description": "A large, blocky appliance encased in sheet metal.  This commonplace fixture is used for cooling large indoor areas.",
+    "description": "一台大型分体式制冷设备。检查它可重新接线并转换成可通电的分体式空调家电，也可拆解成整机带走。",
     "symbol": "{",
     "bgcolor": "white",
     "move_cost_mod": -1,
     "coverage": 55,
     "required_str": -1,
-    "deconstruct": {
-      "items": [
-        { "item": "pipe", "count": 1 },
-        { "item": "scrap", "count": [ 2, 6 ] },
-        { "item": "steel_chunk", "count": [ 1, 3 ] },
-        { "item": "sheet_metal", "count": [ 2, 6 ] },
-        { "item": "cable", "charges": [ 1, 15 ] },
-        { "item": "cu_pipe", "count": [ 2, 5 ] },
-        { "item": "hose", "count": [ 0, 2 ] },
-        { "item": "thermostat", "count": 1 },
-        { "item": "refrigerant_tank", "count": 1 },
-        { "item": "motor_small", "count": 1 },
-        { "item": "pipe_fittings", "count": [ 2, 6 ] }
-      ]
-    },
+    "mass": "55 kg",
+    "max_volume": "220 L",
+    "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "split_air_conditioner" },
+    "flags": [ "MINEABLE", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "items": [ { "item": "split_air_conditioner", "count": 1 } ] },
     "bash": {
       "str_min": 18,
       "str_max": 50,

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -1758,7 +1758,8 @@
       [ "dehydrator", 30 ],
       [ "vac_sealer", 45 ],
       [ "forge", 5 ],
-      [ "atomic_coffeepot", 2 ]
+      [ "atomic_coffeepot", 2 ],
+      [ "split_air_conditioner", 4 ]
     ]
   },
   {

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -355,5 +355,23 @@
     "price_postapoc": 10000,
     "symbol": "T",
     "color": "white"
+  },
+  {
+    "type": "GENERIC",
+    "id": "split_air_conditioner",
+    "looks_like": "f_air_conditioner",
+    "symbol": "A",
+    "color": "light_cyan",
+    "name": {
+      "str": "分体式空调"
+    },
+    "description": "一套完整的分体式空调，室内外换热器被整合成可安装在墙上的整机。将其安装到墙面并接入电网后，可选择舒适、冷藏或冷冻模式。",
+    "longest_side": "110 cm",
+    "material": [
+      "steel",
+      "plastic"
+    ],
+    "volume": "220 L",
+    "weight": "55 kg"
   }
 ]

--- a/data/json/recipes/recipe_appliance.json
+++ b/data/json/recipes/recipe_appliance.json
@@ -107,5 +107,116 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "components": [ [ [ "frame_wood", 1 ] ], [ [ "battery_charger", 1 ] ] ]
+  },
+  {
+    "result": "split_air_conditioner",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "skill_used": "electronics",
+    "difficulty": 4,
+    "time": "4 h",
+    "autolearn": [
+      [
+        "electronics",
+        4
+      ],
+      [
+        "mechanics",
+        3
+      ],
+      [
+        "fabrication",
+        3
+      ]
+    ],
+    "category": "CC_APPLIANCE",
+    "subcategory": "CSC_APPLIANCE_UTILITY",
+    "skills_required": [
+      [
+        "mechanics",
+        3
+      ],
+      [
+        "fabrication",
+        3
+      ]
+    ],
+    "using": [
+      [
+        "soldering_standard",
+        12
+      ]
+    ],
+    "qualities": [
+      {
+        "id": "SCREW",
+        "level": 1
+      },
+      {
+        "id": "WRENCH",
+        "level": 1
+      }
+    ],
+    "proficiencies": [
+      {
+        "proficiency": "prof_elec_soldering"
+      }
+    ],
+    "components": [
+      [
+        [
+          "sheet_metal",
+          6
+        ]
+      ],
+      [
+        [
+          "cu_pipe",
+          6
+        ]
+      ],
+      [
+        [
+          "cable",
+          30
+        ]
+      ],
+      [
+        [
+          "hose",
+          2
+        ]
+      ],
+      [
+        [
+          "thermostat",
+          1
+        ]
+      ],
+      [
+        [
+          "refrigerant_tank",
+          1
+        ]
+      ],
+      [
+        [
+          "motor_small",
+          1
+        ]
+      ],
+      [
+        [
+          "pipe_fittings",
+          6
+        ]
+      ],
+      [
+        [
+          "plastic_chunk",
+          8
+        ]
+      ]
+    ]
   }
 ]

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -3302,5 +3302,193 @@
       "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "vehicle_weld_removal", 1 ] ] }
     },
     "flags": [ "OBSTACLE", "HALF_BOARD","AUTONOMOUS_CONTROL"]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ap_split_air_conditioner",
+    "name": {
+      "str": "分体式空调"
+    },
+    "symbol": "A",
+    "looks_like": "f_air_conditioner",
+    "categories": [
+      "utility"
+    ],
+    "color": "light_cyan",
+    "broken_symbol": "#",
+    "broken_color": "dark_gray",
+    "damage_modifier": 80,
+    "durability": 180,
+    "description": "固定在墙上的分体式空调。正面排出的冷气会向密闭房间逐步扩散，背面排出废热。开启后持续运行，舒适、冷藏、冷冻模式分别固定消耗250瓦、375瓦、500瓦电力；切换模式前需要先关闭空调。",
+    "epower": -250,
+    "item": "split_air_conditioner",
+    "location": "structure",
+    "requirements": {
+      "install": {
+        "skills": [
+          [
+            "mechanics",
+            3
+          ],
+          [
+            "electronics",
+            3
+          ]
+        ],
+        "time": "60 m",
+        "using": [
+          [
+            "vehicle_wrench_2",
+            1
+          ],
+          [
+            "soldering_standard",
+            5
+          ]
+        ]
+      },
+      "removal": {
+        "skills": [
+          [
+            "mechanics",
+            2
+          ],
+          [
+            "electronics",
+            2
+          ]
+        ],
+        "time": "30 m",
+        "using": [
+          [
+            "vehicle_wrench_2",
+            1
+          ]
+        ]
+      },
+      "repair": {
+        "skills": [
+          [
+            "mechanics",
+            4
+          ],
+          [
+            "electronics",
+            4
+          ]
+        ],
+        "time": "60 m",
+        "using": [
+          [
+            "repair_welding_standard",
+            1
+          ],
+          [
+            "soldering_standard",
+            8
+          ]
+        ]
+      }
+    },
+    "flags": [
+      "APPLIANCE",
+      "WALL_MOUNTED",
+      "ENABLED_DRAINS_EPOWER",
+      "CTRL_ELECTRONIC",
+      "COOLER"
+    ],
+    "appliance_modes": [
+      {
+        "id": "comfort",
+        "name": "舒适",
+        "lower_temperature_c": 21,
+        "upper_temperature_c": 24,
+        "active_power_w": 600,
+        "idle_power_w": 2,
+        "cold_field": "fd_aircon_cold_comfort",
+        "hot_field": "fd_aircon_waste_heat",
+        "epower": -250,
+        "cold_field_qty": 3,
+        "hot_field_qty": 3
+      },
+      {
+        "id": "refrigeration",
+        "name": "冷藏",
+        "lower_temperature_c": 2,
+        "upper_temperature_c": 5,
+        "active_power_w": 600,
+        "idle_power_w": 2,
+        "cold_field": "fd_aircon_cold_refrigeration",
+        "hot_field": "fd_aircon_waste_heat",
+        "epower": -375,
+        "cold_field_qty": 7,
+        "hot_field_qty": 5
+      },
+      {
+        "id": "freezing",
+        "name": "冷冻",
+        "lower_temperature_c": -18,
+        "upper_temperature_c": -12,
+        "active_power_w": 600,
+        "idle_power_w": 2,
+        "cold_field": "fd_aircon_cold_freezing",
+        "hot_field": "fd_aircon_waste_heat",
+        "epower": -500,
+        "cold_field_qty": 12,
+        "hot_field_qty": 7
+      }
+    ],
+    "breaks_into": [
+      {
+        "item": "sheet_metal",
+        "count": [
+          2,
+          5
+        ]
+      },
+      {
+        "item": "scrap",
+        "count": [
+          4,
+          8
+        ]
+      },
+      {
+        "item": "cu_pipe",
+        "count": [
+          2,
+          5
+        ]
+      },
+      {
+        "item": "cable",
+        "charges": [
+          4,
+          12
+        ]
+      },
+      {
+        "item": "hose",
+        "count": [
+          1,
+          2
+        ]
+      },
+      {
+        "item": "thermostat",
+        "count": 1
+      },
+      {
+        "item": "refrigerant_tank",
+        "count": 1
+      },
+      {
+        "item": "motor_small",
+        "count": 1
+      }
+    ],
+    "damage_reduction": {
+      "all": 20
+    }
   }
 ]

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -696,5 +696,10 @@
     "id": "LADDER",
     "type": "json_flag",
     "info": "该部件为梯子，可让您从载具上爬下。"
+  },
+  {
+    "id": "WALL_MOUNTED",
+    "type": "json_flag",
+    "info": "该部件固定在墙上，不能直接拖动。"
   }
 ]

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1553,9 +1553,15 @@ void construct::done_appliance( const tripoint_bub_ms &p, Character &player_char
     const item base = components.front();
     const vpart_id &vpart = vpart_appliance_from_item( base.typeId() );
 
-    const units::angle direction = appliance_install_direction( p.raw(), player_character, vpart );
+    const std::optional<units::angle> direction = appliance_install_direction( p.raw(),
+            player_character, vpart );
+    if( !direction ) {
+        here.add_item_or_charges( p, base );
+        add_msg( m_info, _( "你取消了%s的安装，并将其放回地面。" ), base.tname() );
+        return;
+    }
     // TODO: fix point types
-    place_appliance( p.raw(), vpart, base, direction );
+    place_appliance( p.raw(), vpart, base, *direction );
 }
 
 void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_character )

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -153,6 +153,7 @@ static bool check_no_trap( const tripoint_bub_ms & );
 static bool check_ramp_low( const tripoint_bub_ms & );
 static bool check_ramp_high( const tripoint_bub_ms & );
 static bool check_no_wiring( const tripoint_bub_ms & );
+static bool check_air_conditioner_wall( const tripoint_bub_ms & );
 
 // Special actions to be run post-terrain-mod
 static void done_nothing( const tripoint_bub_ms &, Character & ) {}
@@ -1337,6 +1338,15 @@ bool construct::check_no_wiring( const tripoint_bub_ms &p )
     return !veh_target.has_tag( flag_WIRING );
 }
 
+bool construct::check_air_conditioner_wall( const tripoint_bub_ms &p )
+{
+    if( get_map().veh_at( p ) ) {
+        return false;
+    }
+
+    return air_conditioner_has_clear_direction( p.raw() );
+}
+
 void construct::done_trunk_plank( const tripoint_bub_ms &/*p*/, Character &/*who*/ )
 {
     int num_logs = rng( 2, 3 );
@@ -1523,7 +1533,7 @@ void construct::done_wiring( const tripoint_bub_ms &p, Character &/*who*/ )
     }
 }
 
-void construct::done_appliance( const tripoint_bub_ms &p, Character & )
+void construct::done_appliance( const tripoint_bub_ms &p, Character &player_character )
 {
     map &here = get_map();
     partial_con *pc = here.partial_con_at( p );
@@ -1543,8 +1553,9 @@ void construct::done_appliance( const tripoint_bub_ms &p, Character & )
     const item base = components.front();
     const vpart_id &vpart = vpart_appliance_from_item( base.typeId() );
 
+    const units::angle direction = appliance_install_direction( p.raw(), player_character, vpart );
     // TODO: fix point types
-    place_appliance( p.raw(), vpart, base );
+    place_appliance( p.raw(), vpart, base, direction );
 }
 
 void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_character )
@@ -2014,7 +2025,8 @@ void load_construction( const JsonObject &jo )
             { "check_no_trap", construct::check_no_trap },
             { "check_ramp_low", construct::check_ramp_low },
             { "check_ramp_high", construct::check_ramp_high },
-            { "check_no_wiring", construct::check_no_wiring }
+            { "check_no_wiring", construct::check_no_wiring },
+            { "check_air_conditioner_wall", construct::check_air_conditioner_wall }
         }
     };
     static const std::map<std::string, void( * )( const tripoint_bub_ms &, Character & )>

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -926,6 +926,10 @@ static void grab()
         if (!vp->vehicle().handle_potential_theft(you)) {
             return;
         }
+        if( vp.part_with_feature( VPFLAG_WALL_MOUNTED, false ) ) {
+            add_msg( m_info, _( "它固定在墙上，无法移动。" ) );
+            return;
+        }
         if (vp->vehicle().has_tag(flag_CANT_DRAG)) {
             add_msg(m_info, _("There's nothing to grab there!"));
             return;

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -1,7 +1,5 @@
 #include "iexamine_actors.h"
 
-#include <optional>
-
 #include "avatar.h"
 #include "effect_on_condition.h"
 #include "game.h"
@@ -25,13 +23,11 @@ void appliance_convert_examine_actor::load( const JsonObject &jo )
     mandatory( jo, false, "item", appliance_item );
 }
 
-void appliance_convert_examine_actor::call( Character &who, const tripoint &examp ) const
+void appliance_convert_examine_actor::call( Character &, const tripoint &examp ) const
 {
     if( !query_yn( _( "Connect %s to grid?" ), item::nname( appliance_item ) ) ) {
         return;
     }
-    const vpart_id vpart = vpart_appliance_from_item( appliance_item );
-    const units::angle direction = appliance_install_direction( examp, who, vpart );
     map &here = get_map();
     if( furn_set ) {
         here.furn_set( examp, *furn_set );
@@ -40,7 +36,7 @@ void appliance_convert_examine_actor::call( Character &who, const tripoint &exam
         here.ter_set( examp, *ter_set );
     }
 
-    place_appliance( examp, vpart, std::nullopt, direction );
+    place_appliance( examp, vpart_appliance_from_item( appliance_item ) );
 }
 
 void appliance_convert_examine_actor::finalize() const

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -1,5 +1,7 @@
 #include "iexamine_actors.h"
 
+#include <optional>
+
 #include "avatar.h"
 #include "effect_on_condition.h"
 #include "game.h"
@@ -23,11 +25,13 @@ void appliance_convert_examine_actor::load( const JsonObject &jo )
     mandatory( jo, false, "item", appliance_item );
 }
 
-void appliance_convert_examine_actor::call( Character &, const tripoint &examp ) const
+void appliance_convert_examine_actor::call( Character &who, const tripoint &examp ) const
 {
     if( !query_yn( _( "Connect %s to grid?" ), item::nname( appliance_item ) ) ) {
         return;
     }
+    const vpart_id vpart = vpart_appliance_from_item( appliance_item );
+    const units::angle direction = appliance_install_direction( examp, who, vpart );
     map &here = get_map();
     if( furn_set ) {
         here.furn_set( examp, *furn_set );
@@ -36,7 +40,7 @@ void appliance_convert_examine_actor::call( Character &, const tripoint &examp )
         here.ter_set( examp, *ter_set );
     }
 
-    place_appliance( examp, vpart_appliance_from_item( appliance_item ) );
+    place_appliance( examp, vpart, std::nullopt, direction );
 }
 
 void appliance_convert_examine_actor::finalize() const

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -85,7 +85,8 @@ bool air_conditioner_has_clear_direction( const tripoint &p )
     return false;
 }
 
-static units::angle choose_air_conditioner_direction( const tripoint &p, Character &who )
+static std::optional<units::angle> choose_air_conditioner_direction( const tripoint &p,
+        Character &who )
 {
     if( !who.is_avatar() ) {
         for( const units::angle &direction : { 0_degrees, 90_degrees, 180_degrees, 270_degrees } ) {
@@ -101,10 +102,11 @@ static units::angle choose_air_conditioner_direction( const tripoint &p, Charact
 
     units::angle direction = 0_degrees;
     while( true ) {
-        popup( _( "按空格键关闭提示，然后选择新空调的制冷侧并按回车键确认。" ) );
+        popup( _( "按空格键关闭提示，然后选择新空调的制冷侧并按回车键确认；按Esc取消安装。" ) );
         const std::optional<tripoint> chosen = g->look_around();
         if( !chosen ) {
-            continue;
+            who.view_offset = old_view_offset;
+            return std::nullopt;
         }
 
         const point delta = ( *chosen - p ).xy();
@@ -122,7 +124,7 @@ static units::angle choose_air_conditioner_direction( const tripoint &p, Charact
     return direction;
 }
 
-units::angle appliance_install_direction( const tripoint &p, Character &who,
+std::optional<units::angle> appliance_install_direction( const tripoint &p, Character &who,
         const vpart_id &vpart )
 {
     if( vpart->has_flag( VPFLAG_WALL_MOUNTED ) && !vpart->appliance_modes.empty() ) {

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -1,7 +1,12 @@
+#include <cstdlib>
+
+#include "character.h"
 #include "game.h"
 #include "handle_liquid.h"
 #include "inventory.h"
 #include "itype.h"
+#include "line.h"
+#include "map.h"
 #include "map_iterator.h"
 #include "messages.h"
 #include "output.h"
@@ -51,7 +56,83 @@ vpart_id vpart_appliance_from_item( const itype_id &item_id )
     return vpart_ap_standing_lamp;
 }
 
-void place_appliance( const tripoint &p, const vpart_id &vpart, const std::optional<item> &base )
+static units::angle cardinal_direction_from_delta( const point &delta )
+{
+    if( std::abs( delta.x ) >= std::abs( delta.y ) ) {
+        return delta.x >= 0 ? 0_degrees : 180_degrees;
+    }
+    return delta.y >= 0 ? 90_degrees : 270_degrees;
+}
+
+static bool air_conditioner_direction_is_clear( const tripoint &p,
+        const units::angle &direction )
+{
+    tileray facing( direction );
+    facing.advance();
+    map &here = get_map();
+    const tripoint cold_pos = p + tripoint( facing.dx(), facing.dy(), 0 );
+    const tripoint hot_pos = p - tripoint( facing.dx(), facing.dy(), 0 );
+    return !here.impassable( cold_pos ) && !here.impassable( hot_pos );
+}
+
+bool air_conditioner_has_clear_direction( const tripoint &p )
+{
+    for( const units::angle &direction : { 0_degrees, 90_degrees, 180_degrees, 270_degrees } ) {
+        if( air_conditioner_direction_is_clear( p, direction ) ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static units::angle choose_air_conditioner_direction( const tripoint &p, Character &who )
+{
+    if( !who.is_avatar() ) {
+        for( const units::angle &direction : { 0_degrees, 90_degrees, 180_degrees, 270_degrees } ) {
+            if( air_conditioner_direction_is_clear( p, direction ) ) {
+                return direction;
+            }
+        }
+        return 0_degrees;
+    }
+
+    const tripoint old_view_offset = who.view_offset;
+    who.view_offset = p - who.pos();
+
+    units::angle direction = 0_degrees;
+    while( true ) {
+        popup( _( "按空格键关闭提示，然后选择新空调的制冷侧并按回车键确认。" ) );
+        const std::optional<tripoint> chosen = g->look_around();
+        if( !chosen ) {
+            continue;
+        }
+
+        const point delta = ( *chosen - p ).xy();
+        if( delta == point_zero ) {
+            continue;
+        }
+        direction = cardinal_direction_from_delta( delta );
+        if( air_conditioner_direction_is_clear( p, direction ) ) {
+            break;
+        }
+        popup( _( "所选方向的制冷侧和废热侧都必须留有一格可通行空间。" ) );
+    }
+
+    who.view_offset = old_view_offset;
+    return direction;
+}
+
+units::angle appliance_install_direction( const tripoint &p, Character &who,
+        const vpart_id &vpart )
+{
+    if( vpart->has_flag( VPFLAG_WALL_MOUNTED ) && !vpart->appliance_modes.empty() ) {
+        return choose_air_conditioner_direction( p, who );
+    }
+    return 0_degrees;
+}
+
+void place_appliance( const tripoint &p, const vpart_id &vpart, const std::optional<item> &base,
+                      units::angle direction )
 {
     map &here = get_map();
     vehicle *veh = here.add_vehicle( vehicle_prototype_none, p, 0_degrees, 0, 0 );
@@ -70,6 +151,9 @@ void place_appliance( const tripoint &p, const vpart_id &vpart, const std::optio
         veh->install_part( point_zero, vpart );
     }
     veh->name = vpart->name();
+    veh->face.init( direction );
+    veh->turn_dir = direction;
+    veh->precalc_mounts( 0, direction, point_zero );
 
     // Update the vehicle cache immediately,
     // or the appliance will be invisible for the first couple of turns.
@@ -693,6 +777,37 @@ void veh_app_interact::unplug()
     act.values.push_back( veh->index_of_part( &vp ) );
 }
 
+void veh_app_interact::set_appliance_mode()
+{
+    const int part_index = veh->part_at( a_point );
+    vehicle_part &pt = veh->part( part_index >= 0 ? part_index : 0 );
+    const std::vector<appliance_mode_data> &modes = pt.info().appliance_modes;
+    if( modes.empty() ) {
+        return;
+    }
+    if( pt.enabled ) {
+        popup( _( "切换运行模式前，请先关闭这台家电。" ) );
+        return;
+    }
+
+    uilist menu;
+    menu.text = _( "选择运行模式" );
+    const int current = std::clamp( static_cast<int>( pt.get_base().get_var( "appliance_mode", 0.0 ) ),
+                                    0, static_cast<int>( modes.size() ) - 1 );
+    for( size_t i = 0; i < modes.size(); ++i ) {
+        const appliance_mode_data &mode = modes[i];
+        menu.addentry( static_cast<int>( i ), true, MENU_AUTOASSIGN,
+                       string_format( "%s%s", mode.name.translated(),
+                                      static_cast<int>( i ) == current ? _( " （当前）" ) : "" ) );
+    }
+    menu.query();
+    if( menu.ret >= 0 && static_cast<size_t>( menu.ret ) < modes.size() ) {
+        pt.get_base().set_var( "appliance_mode", menu.ret );
+
+        add_msg( _( "你将%s设为%s模式。" ), veh->name, modes[menu.ret].name.translated() );
+    }
+}
+
 void veh_app_interact::populate_app_actions()
 {
     const std::string ctxt_letters = ctxt.get_available_single_char_hotkeys();
@@ -738,6 +853,19 @@ void veh_app_interact::populate_app_actions()
     imenu.addentry( -1, can_unplug(), ctxt.keys_bound_to( "UNPLUG" ).front(),
                     ctxt.get_action_name( "UNPLUG" ) );
 
+    const int mode_part_index = veh->part_at( a_point );
+    vehicle_part &mode_part = veh->part( mode_part_index >= 0 ? mode_part_index : 0 );
+    if( !mode_part.info().appliance_modes.empty() ) {
+        const int selected = std::clamp(
+                                 static_cast<int>( mode_part.get_base().get_var( "appliance_mode", 0.0 ) ), 0,
+                                 static_cast<int>( mode_part.info().appliance_modes.size() ) - 1 );
+        app_actions.emplace_back( [this]() {
+            set_appliance_mode();
+        } );
+        imenu.addentry( -1, !mode_part.enabled, 'M',
+                        string_format( _( "切换运行模式：%s" ),
+                                       mode_part.info().appliance_modes[selected].name.translated() ) );
+    }
 
 
     if (veh->is_appliance() && veh->part(0).info().has_flag("CLASSIFIED_DEVICE")) {

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -13,7 +13,7 @@ struct point;
 
 vpart_id vpart_appliance_from_item( const itype_id &item_id );
 bool air_conditioner_has_clear_direction( const tripoint &p );
-units::angle appliance_install_direction( const tripoint &p, Character &who,
+std::optional<units::angle> appliance_install_direction( const tripoint &p, Character &who,
         const vpart_id &vpart );
 void place_appliance( const tripoint &p, const vpart_id &vpart,
                       const std::optional<item> &base = std::nullopt,

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -4,14 +4,20 @@
 
 #include "input.h"
 #include "player_activity.h"
+#include "units.h"
 
+class Character;
 class vehicle;
 class ui_adaptor;
 struct point;
 
 vpart_id vpart_appliance_from_item( const itype_id &item_id );
+bool air_conditioner_has_clear_direction( const tripoint &p );
+units::angle appliance_install_direction( const tripoint &p, Character &who,
+        const vpart_id &vpart );
 void place_appliance( const tripoint &p, const vpart_id &vpart,
-                      const std::optional<item> &base = std::nullopt );
+                      const std::optional<item> &base = std::nullopt,
+                      units::angle direction = 0_degrees );
 
 /**
  * Appliance interaction UI. Works similarly to veh_interact, but has
@@ -140,6 +146,7 @@ class veh_app_interact
          * any used cable items on the ground.
         */
         void unplug();
+        void set_appliance_mode();
 
         void set_conveyor_belt_direction();
 

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -96,6 +96,7 @@ static const std::unordered_map<std::string, vpart_bitflags> vpart_bitflag_map =
     { "BALLOON", VPFLAG_BALLOON },
     { "PROPELLER", VPFLAG_PROPELLER },
     { "LADDER", VPFLAG_LADDER },
+    { "WALL_MOUNTED", VPFLAG_WALL_MOUNTED },
     { "FLOATS", VPFLAG_FLOATS },
     { "DOME_LIGHT", VPFLAG_DOME_LIGHT },
     { "AISLE_LIGHT", VPFLAG_AISLE_LIGHT },
@@ -474,6 +475,26 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
     assign( jo, "comfort", def.comfort );
     assign( jo, "floor_bedding_warmth", def.floor_bedding_warmth );
     assign( jo, "bonus_fire_warmth_feet", def.bonus_fire_warmth_feet );
+
+    if( jo.has_array( "appliance_modes" ) ) {
+        def.appliance_modes.clear();
+        for( JsonObject mode_jo : jo.get_array( "appliance_modes" ) ) {
+            appliance_mode_data mode;
+            mode.id = mode_jo.get_string( "id" );
+            assign( mode_jo, "name", mode.name );
+            // CDDA-Breeze：墙挂空调固定模式功耗
+            assign( mode_jo, "epower", mode.epower );
+            mode.cold_field_qty = mode_jo.get_int( "cold_field_qty", 3 );
+            mode.hot_field_qty = mode_jo.get_int( "hot_field_qty", 3 );
+            mode.lower_temperature_c = mode_jo.get_int( "lower_temperature_c" );
+            mode.upper_temperature_c = mode_jo.get_int( "upper_temperature_c" );
+            mode.active_power_w = mode_jo.get_int( "active_power_w", 600 );
+            mode.idle_power_w = mode_jo.get_int( "idle_power_w", 2 );
+            mode.cold_field = field_type_str_id( mode_jo.get_string( "cold_field" ) );
+            mode.hot_field = field_type_str_id( mode_jo.get_string( "hot_field" ) );
+            def.appliance_modes.emplace_back( std::move( mode ) );
+        }
+    }
 
     if( jo.has_member( "transform_terrain" ) ) {
         JsonObject jttd = jo.get_object( "transform_terrain" );
@@ -920,6 +941,19 @@ void vpart_info::check()
             if( !( e.first.is_null() || e.first.is_valid() ) || e.second < 0 ) {
                 debugmsg( "vehicle part %s has unknown or incorrectly specified repair requirements %s",
                           part.id.c_str(), e.first.c_str() );
+            }
+        }
+
+        for( const appliance_mode_data &mode : part.appliance_modes ) {
+            if( mode.id.empty() || mode.epower >= 0 || mode.cold_field_qty <= 0 ||
+                mode.hot_field_qty <= 0 || mode.lower_temperature_c >= mode.upper_temperature_c ||
+                mode.active_power_w < 0 || mode.idle_power_w < 0 ||
+                mode.idle_power_w > mode.active_power_w ) {
+                debugmsg( "载具部件%s包含无效的家电运行模式", part.id.c_str() );
+            }
+            if( !mode.cold_field.is_valid() || !mode.hot_field.is_valid() ) {
+                debugmsg( "载具部件%s的家电运行模式%s使用了无效的温度场",
+                          part.id.c_str(), mode.id );
             }
         }
 

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -90,6 +90,7 @@ enum vpart_bitflags : int {
     VPFLAG_BALLOON,
     VPFLAG_PROPELLER,
     VPFLAG_LADDER,
+    VPFLAG_WALL_MOUNTED,
     NUM_VPFLAGS
 };
 /* Flag info:
@@ -144,6 +145,21 @@ struct vpslot_balloon {
 
 struct vpslot_ladder {
     int length = 0;
+};
+
+struct appliance_mode_data {
+    std::string id;
+    translation name;
+    /** CDDA-Breeze：墙挂空调固定模式功耗 */
+    int epower = 0;
+    int cold_field_qty = 3;
+    int hot_field_qty = 3;
+    int lower_temperature_c = 21;
+    int upper_temperature_c = 24;
+    int active_power_w = 600;
+    int idle_power_w = 2;
+    field_type_str_id cold_field;
+    field_type_str_id hot_field;
 };
 
 struct vpslot_workbench {
@@ -406,6 +422,7 @@ class vpart_info
         std::optional<vpslot_propeller> propeller_info;
         std::optional<vpslot_balloon> balloon_info;
         std::optional<vpslot_ladder> ladder_info;
+        std::vector<appliance_mode_data> appliance_modes;
         
         /* map of standard variant names to symbols */
         std::map<std::string, int> symbols;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -87,6 +87,7 @@
 static const std::string part_location_structure( "structure" );
 static const std::string part_location_center( "center" );
 static const std::string part_location_onroof( "on_roof" );
+static const std::string var_appliance_mode( "appliance_mode" );
 
 static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 
@@ -1114,7 +1115,16 @@ int vehicle::part_vpower_w( const int index, const bool at_full_hp ) const
 // for motor consumption see @ref vpart_info::energy_consumption instead
 int vehicle::part_epower_w( const int index ) const
 {
-    int e = part_info( index ).epower;
+    const vehicle_part &pt = parts[index];
+    const vpart_info &info = part_info( index );
+    int e = info.epower;
+    if( !info.appliance_modes.empty() ) {
+        const size_t mode_index = static_cast<size_t>( std::clamp(
+                                      static_cast<int>( pt.base.get_var( var_appliance_mode, 0.0 ) ),
+                                      0, static_cast<int>( info.appliance_modes.size() ) - 1 ) );
+        // CDDA-Breeze：墙挂空调固定模式功耗
+        e = info.appliance_modes[mode_index].epower;
+    }
     if( e < 0 ) {
         return e; // Consumers always draw full power, even if broken
     }
@@ -4814,7 +4824,7 @@ int vehicle::total_accessory_epower_w() const
     for( int part : accessories ) {
         const vehicle_part &vp = parts[part];
         if( vp.enabled ) {
-            epower += vp.info().epower;
+            epower += part_epower_w( part );
         }
     }
     return epower;
@@ -5177,7 +5187,7 @@ void vehicle::power_parts()
 
         for( const vpart_reference &vp : get_enabled_parts( VPFLAG_ENABLED_DRAINS_EPOWER ) ) {
             vehicle_part &pt = vp.part();
-            if( pt.info().epower < 0 ) {
+            if( part_epower_w( static_cast<int>( vp.part_index() ) ) < 0 ) {
                 pt.enabled = false;
             }
         }
@@ -5195,6 +5205,28 @@ void vehicle::power_parts()
             }
         }
         noise_and_smoke( 0, 1_turns ); // refreshes this->vehicle_noise
+    }
+
+    if( calendar::once_every( 5_turns ) ) {
+        map &here = get_map();
+        for( const int part_index : accessories ) {
+            vehicle_part &pt = parts[part_index];
+            const vpart_info &info = pt.info();
+            if( !pt.enabled || info.appliance_modes.empty() || pt.is_unavailable() ) {
+                continue;
+            }
+
+            const int selected = std::clamp( static_cast<int>( pt.base.get_var( var_appliance_mode, 0.0 ) ),
+                                             0, static_cast<int>( info.appliance_modes.size() ) - 1 );
+            const appliance_mode_data &mode = info.appliance_modes[selected];
+            tileray facing( face.dir() + pt.direction );
+            facing.advance();
+            const tripoint unit_pos = global_part_pos3( part_index );
+            const tripoint cold_pos = unit_pos + tripoint( facing.dx(), facing.dy(), 0 );
+            const tripoint hot_pos = unit_pos - tripoint( facing.dx(), facing.dy(), 0 );
+            here.propagate_field( cold_pos, mode.cold_field.id(), mode.cold_field_qty, 3 );
+            here.propagate_field( hot_pos, mode.hot_field.id(), mode.hot_field_qty, 3 );
+        }
     }
 }
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -527,6 +527,7 @@ struct vehicle_part {
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &data );
 
+        item &get_base();
         const item &get_base() const;
         void set_base( const item &new_base );
         /**

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -62,6 +62,11 @@ vehicle_part::operator bool() const
     return id != vpart_id::NULL_ID();
 }
 
+item &vehicle_part::get_base()
+{
+    return base;
+}
+
 const item &vehicle_part::get_base() const
 {
     return base;


### PR DESCRIPTION
## 改动内容

- 夏天必须要有空调！添加可拆卸、可制作的分体式空调。
- 地图中已有的制冷机可以接入电网成为家电，并能通过原版家电菜单取下带走。
- 分体式空调整机也有较低概率出现在电器店等商业地点。
- 支持舒适、冷藏、冷冻三档模式，固定耗电分别为250瓦、375瓦和500瓦。
- 空调需要安装在墙面，正面向室内扩散冷气并覆盖较大空间，背面集中排出废热。
- 玩家安装空调时可以选择制冷侧方向，按Esc可以取消安装并取回整机。
- 模式名称、物品名称和操作提示保持中文显示。

## 测试

- Windows MSVC编译测试通过。
- 已完成制冷机接电、取下电器、空调安装及三档模式的基本游戏内验证。
- 改动JSON文件全部解析通过。
<img width="1280" height="738" alt="{22C8E997-C1D1-4D6B-A39B-794D077E2B69}" src="https://github.com/user-attachments/assets/152c20ea-a929-4e75-b07a-c2f326c159c0" />
