### PR TITLE
在大地图显示派系营地与主要派系据点名称

### DIFF
--- a/data/json/overmap/faction_camp_labels.json
+++ b/data/json/overmap/faction_camp_labels.json
@@ -1,0 +1,18 @@
+[
+  { "type": "faction_camp_label", "overmap_terrain": "evac_center_13", "name": "难民中心" },
+  { "type": "faction_camp_label", "overmap_terrain": "exodii_base_x1y2z0", "name": "流亡族" },
+  { "type": "faction_camp_label", "overmap_terrain": "hive", "name": "？？？" },
+  { "type": "faction_camp_label", "overmap_terrain": "cabin_lapin", "name": "拉宾" },
+  { "type": "faction_camp_label", "overmap_terrain": "prison_island_1_6", "name": "越狱囚犯" },
+  { "type": "faction_camp_label", "overmap_terrain": "godco_5", "name": "新英格兰教会社区" },
+  { "type": "faction_camp_label", "overmap_terrain": "ranch_camp_67", "name": "塔科马公社" },
+  { "type": "faction_camp_label", "overmap_terrain": "robofachq_surface_entrance", "name": "Hub 01" },
+  { "type": "faction_camp_label", "overmap_terrain": "isolated_house_farm_gunsmith", "name": "科迪与杰伊" },
+  { "type": "faction_camp_label", "overmap_terrain": "horse_farm_isherwood_6", "name": "伊舍伍德马场" },
+  { "type": "faction_camp_label", "overmap_terrain": "farm_isherwood_2", "name": "伊舍伍德山庄" },
+  { "type": "faction_camp_label", "overmap_terrain": "dairy_farm_isherwood_SW", "name": "伊舍伍德农场" },
+  { "type": "faction_camp_label", "overmap_terrain": "campus_media_0_0_0", "name": "大图书馆" },
+  { "type": "faction_camp_label", "overmap_terrain": "chemical_lab_ocu", "name": "化学家" },
+  { "type": "faction_camp_label", "overmap_terrain": "smallscrapyard_ocu", "name": "废品商" },
+  { "type": "faction_camp_label", "overmap_terrain": "lumbermill_1_1_ocu", "name": "幸存者伐木场" }
+]

--- a/data/json/overmap/faction_camp_labels.json
+++ b/data/json/overmap/faction_camp_labels.json
@@ -8,7 +8,7 @@
   { "type": "faction_camp_label", "overmap_terrain": "robofachq_surface_entrance", "name": "Hub 01" },
   { "type": "faction_camp_label", "overmap_terrain": "isolated_house_farm_gunsmith", "name": "科迪与杰伊" },
   { "type": "faction_camp_label", "overmap_terrain": "horse_farm_isherwood_6", "name": "伊舍伍德马场" },
-  { "type": "faction_camp_label", "overmap_terrain": "farm_isherwood_2", "name": "伊舍伍德山庄" },
+  { "type": "faction_camp_label", "overmap_terrain": "farm_isherwood_2", "name": "伊舍伍德家族" },
   { "type": "faction_camp_label", "overmap_terrain": "dairy_farm_isherwood_SW", "name": "伊舍伍德农场" },
   { "type": "faction_camp_label", "overmap_terrain": "campus_media_0_0_0", "name": "大图书馆" },
   { "type": "faction_camp_label", "overmap_terrain": "chemical_lab_ocu", "name": "化学家" },

--- a/data/json/overmap/faction_camp_labels.json
+++ b/data/json/overmap/faction_camp_labels.json
@@ -1,7 +1,6 @@
 [
   { "type": "faction_camp_label", "overmap_terrain": "evac_center_13", "name": "难民中心" },
   { "type": "faction_camp_label", "overmap_terrain": "exodii_base_x1y2z0", "name": "流亡族" },
-  { "type": "faction_camp_label", "overmap_terrain": "hive", "name": "？？？" },
   { "type": "faction_camp_label", "overmap_terrain": "cabin_lapin", "name": "拉宾" },
   { "type": "faction_camp_label", "overmap_terrain": "prison_island_1_6", "name": "越狱囚犯" },
   { "type": "faction_camp_label", "overmap_terrain": "godco_5", "name": "新英格兰教会社区" },

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -398,6 +398,7 @@ void DynamicDataLoader::initialize()
     add( "martial_art", &load_martial_art );
     add( "effect_type", &load_effect_type );
     add( "obsolete_terrain", &overmap::load_obsolete_terrains );
+    add( "faction_camp_label", &overmap::load_faction_camp_label );
     add( "overmap_terrain", &overmap_terrains::load );
     add( "construction_category", &construction_categories::load );
     add( "construction_group", &construction_groups::load );
@@ -590,6 +591,7 @@ void DynamicDataLoader::unload_data()
     city::reset();
     overmap_specials::reset();
     overmap_special_migration::reset();
+    overmap::reset_faction_camp_labels();
     overmap_terrains::reset();
     profession::reset();
     proficiency::reset();

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <exception>
 #include <istream>
+#include <map>
 #include <memory>
 #include <numeric>
 #include <ostream>
@@ -92,6 +93,8 @@ static const oter_str_id oter_lab_escape_cells( "lab_escape_cells" );
 static const oter_str_id oter_lab_escape_entrance( "lab_escape_entrance" );
 static const oter_str_id oter_lab_train_depot( "lab_train_depot" );
 static const oter_str_id oter_open_air( "open_air" );
+
+static std::map<oter_type_str_id, translation> faction_camp_labels;
 static const oter_str_id oter_river_c_not_ne( "river_c_not_ne" );
 static const oter_str_id oter_river_c_not_nw( "river_c_not_nw" );
 static const oter_str_id oter_river_c_not_se( "river_c_not_se" );
@@ -1061,6 +1064,26 @@ bool oter_t::is_hardcoded() const
     };
 
     return hardcoded_mapgen.find( get_mapgen_id() ) != hardcoded_mapgen.end();
+}
+
+void overmap::load_faction_camp_label( const JsonObject &jo )
+{
+    oter_type_str_id terrain;
+    translation name;
+    jo.read( "overmap_terrain", terrain );
+    jo.read( "name", name );
+    faction_camp_labels.insert_or_assign( terrain, name );
+}
+
+void overmap::reset_faction_camp_labels()
+{
+    faction_camp_labels.clear();
+}
+
+const translation *overmap::faction_camp_name( const oter_type_str_id &terrain )
+{
+    const auto iter = faction_camp_labels.find( terrain );
+    return iter == faction_camp_labels.end() ? nullptr : &iter->second;
 }
 
 void overmap_terrains::load( const JsonObject &jo, const std::string &src )

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -595,6 +595,9 @@ class overmap
         void save_monster_groups( JsonOut &jo ) const;
     public:
         static void load_obsolete_terrains( const JsonObject &jo );
+        static void load_faction_camp_label( const JsonObject &jo );
+        static void reset_faction_camp_labels();
+        static const translation *faction_camp_name( const oter_type_str_id &terrain );
 };
 
 bool is_river( const oter_id &ter );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -357,6 +357,37 @@ static void draw_camp_labels( const catacurses::window &w, const tripoint_abs_om
     }
 }
 
+static void draw_faction_camp_labels( const catacurses::window &w,
+        const tripoint_abs_omt &center )
+{
+    const int win_x_max = getmaxx( w );
+    const int win_y_max = getmaxy( w );
+    const point screen_center_pos( win_x_max / 2, win_y_max / 2 );
+
+    for( const faction_camp_reference &element : overmap_buffer.get_faction_camps_near(
+             center, win_x_max / 2 + 1, win_y_max / 2 + 1 ) ) {
+        const point screen_pos( ( element.abs_omt_pos.xy() - center.xy() ).raw() +
+                                screen_center_pos );
+        const int text_width = utf8_width( element.name, true );
+        const int text_x_min = screen_pos.x - text_width / 2;
+        const int text_x_max = text_x_min + text_width;
+        const int text_y = screen_pos.y;
+
+        if( text_x_min < 0 || text_x_max > win_x_max || text_y < 0 || text_y > win_y_max ) {
+            continue;
+        }
+        if( screen_center_pos.x >= text_x_min - 1 && screen_center_pos.x <= text_x_max &&
+            screen_center_pos.y >= text_y - 1 && screen_center_pos.y <= text_y + 1 ) {
+            continue;
+        }
+        if( !overmap_buffer.seen( element.abs_omt_pos ) ) {
+            continue;
+        }
+
+        mvwprintz( w, point( text_x_min, text_y ), i_yellow, element.name );
+    }
+}
+
 class map_notes_callback : public uilist_callback
 {
     private:
@@ -884,6 +915,7 @@ static void draw_ascii(
     if( center.z() == 0 && uistate.overmap_show_city_labels ) {
         draw_city_labels( w, center );
         draw_camp_labels( w, center );
+        draw_faction_camp_labels( w, center );
     }
 
     half_open_rectangle<point_abs_omt> screen_bounds(

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -329,11 +329,12 @@ static void draw_camp_labels( const catacurses::window &w, const tripoint_abs_om
              project_to<coords::sm>( center ), sm_radius ) ) {
         const point_abs_omt camp_pos( element.camp->camp_omt_pos().xy() );
         const point screen_pos( ( camp_pos - center.xy() ).raw() + screen_center_pos );
-        const int text_width = utf8_width( element.camp->name, true );
+        const std::string camp_name = element.camp->camp_name().empty() ?
+                                      _( "Faction Camp" ) : element.camp->camp_name();
+        const int text_width = utf8_width( camp_name, true );
         const int text_x_min = screen_pos.x - text_width / 2;
         const int text_x_max = text_x_min + text_width;
         const int text_y = screen_pos.y;
-        const std::string camp_name = element.camp->name;
         if( text_x_min < 0 ||
             text_x_max > win_x_max ||
             text_y < 0 ||
@@ -352,7 +353,7 @@ static void draw_camp_labels( const catacurses::window &w, const tripoint_abs_om
             continue;   // haven't seen it.
         }
 
-        mvwprintz( w, point( text_x_min, text_y ), i_white, camp_name );
+        mvwprintz( w, point( text_x_min, text_y ), i_yellow, camp_name );
     }
 }
 

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1454,14 +1454,13 @@ std::vector<camp_reference> overmapbuffer::get_camps_near( const tripoint_abs_sm
     std::vector<camp_reference> result;
     for( overmap *om : get_overmaps_near( location, radius ) ) {
         result.reserve( result.size() + om->camps.size() );
-        std::transform( om->camps.begin(), om->camps.end(), std::back_inserter( result ),
-        [&]( basecamp & element ) {
-            const tripoint_abs_omt camp_pt = element.camp_omt_pos();
-            const tripoint_abs_sm camp_sm = project_to<coords::sm>( camp_pt );
+        for( basecamp &camp : om->camps ) {
+            const tripoint_abs_sm camp_sm = project_to<coords::sm>( camp.camp_omt_pos() );
             const int distance = rl_dist( camp_sm, location );
-
-            return camp_reference{ &element, camp_sm, distance };
-        } );
+            if( distance <= radius ) {
+                result.push_back( camp_reference{ &camp, camp_sm, distance } );
+            }
+        }
     }
     std::sort( result.begin(), result.end(), []( const camp_reference & lhs,
     const camp_reference & rhs ) {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1448,6 +1448,31 @@ std::vector<radio_tower_reference> overmapbuffer::find_all_radio_stations()
     return result;
 }
 
+std::vector<faction_camp_reference> overmapbuffer::get_faction_camps_near(
+    const tripoint_abs_omt &location, int x_radius, int y_radius )
+{
+    std::vector<faction_camp_reference> result;
+    if( location.z() != 0 ) {
+        return result;
+    }
+
+    result.reserve( 16 );
+    for( int y = -y_radius; y <= y_radius; ++y ) {
+        for( int x = -x_radius; x <= x_radius; ++x ) {
+            const tripoint_abs_omt pos( location.xy() + point( x, y ), location.z() );
+            const oter_id &terrain = ter_existing( pos );
+            if( !terrain ) {
+                continue;
+            }
+            const translation *name = overmap::faction_camp_name( terrain->get_type_id() );
+            if( name != nullptr ) {
+                result.push_back( faction_camp_reference{ pos, name->translated() } );
+            }
+        }
+    }
+    return result;
+}
+
 std::vector<camp_reference> overmapbuffer::get_camps_near( const tripoint_abs_sm &location,
         int radius )
 {

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <new>
 #include <set>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -102,6 +103,11 @@ struct camp_reference {
     }
 
     int get_distance_from_bounds() const;
+};
+
+struct faction_camp_reference {
+    tripoint_abs_omt abs_omt_pos;
+    std::string name;
 };
 
 struct overmap_with_local_coords {
@@ -479,6 +485,8 @@ class overmapbuffer
          */
         std::vector<radio_tower_reference> find_all_radio_stations();
         std::vector<camp_reference> get_camps_near( const tripoint_abs_sm &location, int radius );
+        std::vector<faction_camp_reference> get_faction_camps_near(
+            const tripoint_abs_omt &location, int x_radius, int y_radius );
         /**
          * Find all cities within the specified @ref radius.
          * Result is sorted by proximity to @ref location in ascending order.

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include "avatar.h"
+#include "basecamp.h"
 #include "cached_options.h"
 #include "cata_assert.h"
 #include "cata_scope_helpers.h"
@@ -1171,7 +1172,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
         // the tiles on the overmap are overmap tiles, so we need to use
         // coordinate conversions to make sure we're in the right place.
-        const int radius = project_to<coords::sm>( tripoint_abs_omt( std::min( max_col, max_row ),
+        const int radius = project_to<coords::sm>( tripoint_abs_omt( std::max( max_col, max_row ),
                            0, 0 ) ).x() / 2;
 
         for( const city_reference &city : overmap_buffer.get_cities_near(
@@ -1186,7 +1187,9 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                  project_to<coords::sm>( center_abs_omt ), radius ) ) {
             const tripoint_abs_omt camp_center = project_to<coords::omt>( camp.abs_sm_pos );
             if( overmap_buffer.seen( camp_center ) && overmap_area.contains( camp_center.raw() ) ) {
-                label_bg( camp.abs_sm_pos, camp.camp->name );
+                const std::string camp_name = camp.camp->camp_name().empty() ?
+                                              _( "Faction Camp" ) : camp.camp->camp_name();
+                label_bg( camp.abs_sm_pos, camp_name );
             }
         }
     }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1192,6 +1192,14 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                 label_bg( camp.abs_sm_pos, camp_name );
             }
         }
+
+        for( const faction_camp_reference &camp : overmap_buffer.get_faction_camps_near(
+                 center_abs_omt, max_col / 2 + 1, max_row / 2 + 1 ) ) {
+            if( overmap_buffer.seen( camp.abs_omt_pos ) &&
+                overmap_area.contains( camp.abs_omt_pos.raw() ) ) {
+                label_bg( project_to<coords::sm>( camp.abs_omt_pos ), camp.name );
+            }
+        }
     }
 
     std::vector<std::pair<nc_color, std::string>> notes_window_text;


### PR DESCRIPTION
为 CDDA-Breeze 微风本体增加派系据点名称显示功能，使难民中心、Hub 01、流亡族据点、伊舍伍德农场群等固定派系据点能够像城市名称一样，在大地图上以醒目的黄色文字直接显示名称。内容包括难民中心、流亡族、拉宾、Hub 01、越狱囚犯、新英格兰教会社区、塔科马公社、科迪与杰伊、伊舍伍德马场、伊舍伍德家族、伊舍伍德农场、化学家、废品商和幸存者伐木场。MSVC编译成功，测试无误。
<img width="363" height="333" alt="{7F3B8F6E-045D-4DA3-B9A7-2C6AB81853D1}" src="https://github.com/user-attachments/assets/183ee946-4430-49ae-98ce-a9e2c85fcb35" />
<img width="393" height="289" alt="{92A70301-130F-485B-955E-0E7F2FF0048F}" src="https://github.com/user-attachments/assets/dedfa899-c4ec-464b-9a51-89b8f6d89254" />
