### PR TITLE
让物品能通过区域管理跨层搬运

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2329,6 +2329,12 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
         bool unload_molle = false;
         bool unload_always = false;
 
+        // A legacy loot-sort turn may inspect the same destination for many
+        // items.  Cache cross-z reachability for this turn so enabling
+        // multi-level zones does not run A* once per item.
+        std::set<tripoint_abs_ms> reachable_cross_z_destinations;
+        std::set<tripoint_abs_ms> unreachable_cross_z_destinations;
+
         std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_zone_unload_all,
                 _fac_id( you ) );
 
@@ -2471,6 +2477,33 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                 const tripoint_bub_ms dest_loc = here.bub_from_abs( dest );
                 vehicle *dest_veh;
                 int dest_part;
+
+                // The legacy sorter transfers items directly after charging a
+                // movement cost.  Before allowing that transfer between
+                // z-levels, verify that the character could actually reach the
+                // destination through stairs or ramps.  This prevents items
+                // from passing through sealed floors merely because two zones
+                // share nearby x/y coordinates.
+                if( dest.z() != src.z() ) {
+                    if( unreachable_cross_z_destinations.count( dest ) > 0 ) {
+                        continue;
+                    }
+                    if( reachable_cross_z_destinations.count( dest ) == 0 ) {
+                        std::vector<tripoint_bub_ms> route;
+                        if( here.passable( dest_loc ) ) {
+                            route = here.route( you.pos_bub(), dest_loc,
+                                                you.get_pathfinding_settings(),
+                                                you.get_path_avoid() );
+                        } else {
+                            route = route_adjacent( you, dest_loc );
+                        }
+                        if( route.empty() ) {
+                            unreachable_cross_z_destinations.insert( dest );
+                            continue;
+                        }
+                        reachable_cross_z_destinations.insert( dest );
+                    }
+                }
 
                 //Check destination for cargo part
                 if( const std::optional<vpart_reference> vp =

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -828,10 +828,11 @@ bool zone_manager::has_near( const zone_type_id &type, const tripoint_abs_ms &wh
 {
     const auto &point_set = get_point_set( type, fac );
     for( const tripoint_abs_ms &point : point_set ) {
-        if( point.z() == where.z() ) {
-            if( square_dist( point, where ) <= range ) {
-                return true;
-            }
+        // Static zones can be reached through stairs and ramps, so include
+        // nearby zones on other z-levels.  Vehicle zones remain restricted to
+        // the current z-level because their cached positions are level-local.
+        if( square_dist( point, where ) <= range ) {
+            return true;
         }
     }
 
@@ -931,12 +932,10 @@ std::unordered_set<tripoint_abs_ms> zone_manager::get_near( const zone_type_id &
     std::unordered_set<tripoint_abs_ms> near_point_set;
 
     for( const tripoint_abs_ms &point : point_set ) {
-        if( point.z() == where.z() ) {
-            if( square_dist( point, where ) <= range ) {
-                if( ( type != zone_type_LOOT_CUSTOM && type != zone_type_LOOT_ITEM_GROUP ) ||
-                    ( it != nullptr && custom_loot_has( point, it, type, fac ) ) ) {
-                    near_point_set.insert( point );
-                }
+        if( square_dist( point, where ) <= range ) {
+            if( ( type != zone_type_LOOT_CUSTOM && type != zone_type_LOOT_ITEM_GROUP ) ||
+                ( it != nullptr && custom_loot_has( point, it, type, fac ) ) ) {
+                near_point_set.insert( point );
             }
         }
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6871,8 +6871,9 @@ void game::zones_manager()
         mgr.cache_avatar_location();
     }
 
-    // get zones on the same z-level, with distance between player and
-    // zone center point <= 50 or all zones, if show_all_zones is true
+    // Show nearby zones on every z-level.  This keeps the manager UI in
+    // sync with cross-z loot sorting; distant zones are still hidden unless
+    // SHOW_ALL_ZONES is enabled.
     auto get_zones = [&]() {
         std::vector<zone_manager::ref_zone_data> zones;
         if( show_all_zones ) {
@@ -6881,8 +6882,7 @@ void game::zones_manager()
             const tripoint_abs_ms u_abs_pos = u.get_location();
             for( zone_manager::ref_zone_data &ref : mgr.get_zones( zones_faction ) ) {
                 const tripoint_abs_ms &zone_abs_pos = ref.get().get_center_point();
-                if( u_abs_pos.z() == zone_abs_pos.z() &&
-                    rl_dist( u_abs_pos, zone_abs_pos ) <= 50 ) {
+                if( rl_dist( u_abs_pos, zone_abs_pos ) <= MAX_VIEW_DISTANCE ) {
                     zones.emplace_back( ref );
                 }
             }


### PR DESCRIPTION
原版玩家搬运物品跨层只能YO搬运到楼梯，然后再用搬运键跨层，增加了游戏负担。修改后，静态区域可以跨楼层参与自动整理，区域管理界面也能同时列出附近不同楼层的区域，并正确显示方向和楼层信息。载具绑定区域仍限制在载具所在楼层，避免跨层错误引用。搬运继续采用抽象处理，只验证路径是否可达并扣除合理时间，不会让角色逐件往返搬运。
<img width="1280" height="747" alt="{A6F35CB0-2DF4-4E19-9EAE-5776D5550CAD}" src="https://github.com/user-attachments/assets/bedbcbe4-988a-441c-8860-010266068946" />
<img width="483" height="368" alt="{FA05D4D4-63BF-4BB1-A169-C548A7DEBE2B}" src="https://github.com/user-attachments/assets/adfb6b7f-20d4-4984-88ca-a12b9d17af19" />
