### PR TITLE
加入制作菜单的NPC制造和NPC工作清单

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -31,11 +31,11 @@
     "category": "OTHER",
     "required_skills": [  ],
     "time": "0 m",
-    "pre_note": "Mark a spot for crafting.  Crafting tasks next to this tile will automatically use this location instead of attempting to craft in your hands, with the usual crafting speed penalty for working on the ground.  Does not prevent using a proper workbench, if available.  Deconstruct or smash to remove.",
-    "pre_special": "check_empty",
+    "pre_note": "标记一个制造地点。可以标记空地或固定家具工作台，标记后的工作台会在自动选择时优先采用。空地制造仍按地面工作速度计算，调查制造点可以立即移除标记。",
+    "pre_special": "check_crafting_spot",
     "post_flags": [ "keep_items" ],
-    "dark_craftable": true,
-    "post_terrain": "f_ground_crafting_spot"
+    "post_special": "done_crafting_spot",
+    "dark_craftable": true
   },
   {
     "type": "construction",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1042,7 +1042,7 @@
   {
     "type": "construction_group",
     "id": "make_crafting_spot",
-    "name": "Make crafting spot"
+    "name": "标记制造点"
   },
   {
     "type": "construction_group",

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -1752,5 +1752,14 @@
     "outdoor_age_speedup": "100 minutes",
     "half_life": "50 minutes",
     "phase": "gas"
+  },
+  {
+    "id": "fd_crafting_spot",
+    "type": "field_type",
+    "intensity_levels": [ { "name": "制造点标记", "sym": "*", "color": "light_cyan", "dangerous": false } ],
+    "priority": 10,
+    "phase": "solid",
+    "display_field": true,
+    "display_items": true
   }
 ]

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -742,6 +742,20 @@
   },
   {
     "type": "keybinding",
+    "id": "CHOOSE_CRAFTER",
+    "category": "CRAFTING",
+    "name": "制造设置",
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "QUEUE_CRAFT",
+    "category": "CRAFTING",
+    "name": "加入NPC制造清单",
+    "bindings": [ { "input_method": "keyboard_any", "key": "q" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "CYCLE_BATCH",
     "category": "CRAFTING",
     "name": "Batch crafting",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3163,7 +3163,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     }
 
     if( five_percent_steps > 0 ) {
-        if( !crafter.craft_consume_tools( craft, five_percent_steps, false ) ) {
+        if( !crafter.craft_consume_tools( craft, five_percent_steps, false, location ) ) {
             // So we don't skip over any tool comsuption
             craft.item_counter -= craft.item_counter % 500'000 + 1;
             craft.erase_var("crafter");

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <iosfwd>
 #include <list>
+#include <limits>
 #include <memory>
 #include <set>
 #include <string>
@@ -138,6 +139,84 @@ static const zone_type_id zone_type_LOOT_WOOD( "LOOT_WOOD" );
 static const zone_type_id zone_type_MINING( "MINING" );
 static const zone_type_id zone_type_MOPPING( "MOPPING" );
 static const zone_type_id zone_type_SOURCE_FIREWOOD( "SOURCE_FIREWOOD" );
+static const std::string var_craft_queue_paused( "craft_queue_paused" );
+
+static bool craft_is_assigned_to( const item &craft, const npc &who )
+{
+    if( !craft.is_craft() ) {
+        return false;
+    }
+    const std::string crafter_id = craft.get_var( "crafter_id", "" );
+    return ( !crafter_id.empty() && crafter_id == std::to_string( who.getID().get_value() ) ) ||
+           craft.get_var( "crafter", "" ) == who.name;
+}
+
+static item_location item_to_craft_at( npc &who, const tripoint_bub_ms &where )
+{
+    static const std::string queue_order_var( "craft_queue_order" );
+    map &here = get_map();
+
+    // NPCs use a wielded in-progress craft when automatic selection falls
+    // back to hand crafting instead of choosing a map or vehicle workbench.
+    if( where == who.pos_bub() ) {
+        item_location wielded = who.get_wielded_item();
+        if( wielded && craft_is_assigned_to( *wielded, who ) ) {
+            return wielded;
+        }
+    }
+
+    item_location best;
+    int best_order = std::numeric_limits<int>::max();
+
+    const auto consider = [&]( item & candidate, const item_location & location ) {
+        if( !craft_is_assigned_to( candidate, who ) ) {
+            return;
+        }
+        const int order = candidate.get_var( queue_order_var, 0 );
+        if( order > 0 && order < best_order ) {
+            best_order = order;
+            best = location;
+        }
+    };
+
+    // Queue entries normally share one workbench tile.  A radius of two also catches the map
+    // overflow behavior without turning each activity tick into a large inventory search.
+    for( const tripoint_bub_ms &pt : here.points_in_radius( where, 2 ) ) {
+        for( item &candidate : here.i_at( pt ) ) {
+            consider( candidate, item_location( map_cursor( pt.raw() ), &candidate ) );
+        }
+        if( const optional_vpart_position vp = here.veh_at( pt ) ) {
+            const int cargo_part = vp->vehicle().part_with_feature( vp->part_index(), "CARGO", false );
+            if( cargo_part >= 0 ) {
+                for( item &candidate : vp->vehicle().get_items( cargo_part ) ) {
+                    consider( candidate, item_location( vehicle_cursor( vp->vehicle(), cargo_part ),
+                                                        &candidate ) );
+                }
+            }
+        }
+    }
+    if( best ) {
+        return best;
+    }
+
+    // Compatibility with semi-finished crafts assigned by the older dialogue workflow.
+    for( item &candidate : here.i_at( where ) ) {
+        if( craft_is_assigned_to( candidate, who ) ) {
+            return item_location( map_cursor( where.raw() ), &candidate );
+        }
+    }
+    if( const optional_vpart_position vp = here.veh_at( where ) ) {
+        const int cargo_part = vp->vehicle().part_with_feature( vp->part_index(), "CARGO", false );
+        if( cargo_part >= 0 ) {
+            for( item &candidate : vp->vehicle().get_items( cargo_part ) ) {
+                if( craft_is_assigned_to( candidate, who ) ) {
+                    return item_location( vehicle_cursor( vp->vehicle(), cargo_part ), &candidate );
+                }
+            }
+        }
+    }
+    return item_location();
+}
 static const zone_type_id zone_type_VEHICLE_DECONSTRUCT( "VEHICLE_DECONSTRUCT" );
 static const zone_type_id zone_type_VEHICLE_REPAIR( "VEHICLE_REPAIR" );
 static const zone_type_id zone_type_zone_disassemble( "zone_disassemble" );
@@ -1467,13 +1546,13 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
         // 2. when we form the src_set to loop through at the beginning of the fetch activity.
         return activity_reason_info::ok( do_activity_reason::CAN_DO_FETCH );
     }
-    else if (act == ACT_MULTIPLE_CRAFT) {
-        // only npc is supported
-        npc* p = you.as_npc();
-        if (p) {
-            item_location to_craft = p->get_item_to_craft();
-            if (to_craft && to_craft->is_craft()) {
-                const inventory& inv = you.crafting_inventory(src_loc.raw(), PICKUP_RANGE - 1, false);
+    else if( act == ACT_MULTIPLE_CRAFT ) {
+        // Only NPCs are supported.  The placement points at the selected workplace.
+        npc *p = you.as_npc();
+        if( p ) {
+            item_location to_craft = item_to_craft_at( *p, src_loc );
+            if( to_craft && to_craft->is_craft() ) {
+                const inventory &inv = you.crafting_inventory( src_loc.raw(), PICKUP_RANGE, false );
                 const recipe& r = to_craft->get_making();
                 std::vector<std::vector<item_comp>> item_comp_vector =
                     to_craft->get_continue_reqs().get_components();
@@ -1481,12 +1560,19 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                     r.simple_requirements().get_qualities();
                 std::vector<std::vector<tool_comp>> tool_comp_vector = r.simple_requirements().get_tools();
                 requirement_data req = requirement_data(tool_comp_vector, quality_comp_vector, item_comp_vector);
-                if (req.can_make_with_inventory(inv, is_crafting_component)) {
-                    return activity_reason_info::ok(do_activity_reason::NEEDS_CRAFT);
+                const std::function<bool( const item & )> no_rotten_filter =
+                    r.get_component_filter( recipe_filter_flags::no_rotten );
+                const std::function<bool( const item & )> no_favorite_filter =
+                    r.get_component_filter( recipe_filter_flags::no_favorite );
+                const auto safe_component_filter = [&]( const item & it ) {
+                    return is_crafting_component( it ) && no_rotten_filter( it ) &&
+                           no_favorite_filter( it ) &&
+                           ( it.is_container_empty() || !it.is_watertight_container() );
+                };
+                if( req.can_make_with_inventory( inv, safe_component_filter ) ) {
+                    return activity_reason_info::ok( do_activity_reason::NEEDS_CRAFT );
                 }
-                else {
-                    return activity_reason_info(do_activity_reason::NEEDS_CRAFT, false, req);
-                }
+                return activity_reason_info( do_activity_reason::NEEDS_CRAFT, false, req );
             }
         }
         return activity_reason_info::fail(do_activity_reason::ALREADY_DONE);
@@ -2681,7 +2767,7 @@ static zone_type_id get_zone_for_act( const tripoint_bub_ms &src_loc, const zone
 /** Determine all locations for this generic activity */
 /** Returns locations */
 static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
-    Character &you, const activity_id &act_id )
+    Character &you, const activity_id &act_id, const tripoint_abs_ms &activity_placement )
 {
     bool dark_capable = false;
     std::unordered_set<tripoint_abs_ms> src_set;
@@ -2744,9 +2830,11 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
         }
     }
     else if (act_id == ACT_MULTIPLE_CRAFT) {
-        // Craft only with what is on the spot
-        // TODO: add zone type like zone_type_CRAFT?
-        src_set.insert(here.getglobal(localpos));
+        if( activity_placement != player_activity::invalid_place ) {
+            src_set.insert( activity_placement );
+        } else {
+            src_set.insert( here.getglobal( localpos ) );
+        }
 
     } else if( act_id != ACT_FETCH_REQUIRED ) {
         zone_type_id zone_type = get_zone_for_act( tripoint_bub_ms{}, mgr, act_id, _fac_id( you ) );
@@ -2835,7 +2923,21 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
     }
     const bool post_dark_check = src_set.empty();
     if( !pre_dark_check && post_dark_check && !MOP_ACTIVITY ) {
-        you.add_msg_if_player( m_info, _( "It is too dark to do this activity." ) );
+        if( act_id == ACT_MULTIPLE_CRAFT &&
+            activity_placement != player_activity::invalid_place ) {
+            const tripoint_bub_ms workplace = here.bub_from_abs( activity_placement );
+            if( here.dangerous_field_at( workplace ) ) {
+                you.add_msg_player_or_npc( m_bad,
+                                           _( "指定工作地点出现了危险，制作已停止。" ),
+                                           _( "指定工作地点出现了危险，<npcname>停止了制作。" ) );
+            } else {
+                you.add_msg_player_or_npc( m_bad,
+                                           _( "指定工作地点光照不足，无法继续制作。" ),
+                                           _( "指定工作地点光照不足，<npcname>无法继续制作。" ) );
+            }
+        } else {
+            you.add_msg_if_player( m_info, _( "It is too dark to do this activity." ) );
+        }
     }
     return src_set;
 }
@@ -2877,6 +2979,26 @@ static requirement_check_result generic_multi_activity_check_requirement(
     }
     if( can_do_it ) {
         return requirement_check_result::CAN_DO_LOCATION;
+    }
+    if( act_id == ACT_MULTIPLE_CRAFT && reason == do_activity_reason::NEEDS_CRAFT ) {
+        if( !check_only ) {
+            if( npc *p = you.as_npc() ) {
+                item_location queued_craft = item_to_craft_at( *p, src_loc );
+                if( queued_craft &&
+                    queued_craft->get_var( var_craft_queue_paused, 0 ) == 0 ) {
+                    queued_craft->set_var( var_craft_queue_paused, 1 );
+                    you.add_msg_player_or_npc(
+                        m_bad,
+                        _( "制造清单缺少继续制作所需的材料或工具，已暂停等待补充。" ),
+                        _( "制造清单缺少继续制作所需的材料或工具，<npcname>暂停等待补充。" ) );
+                    const std::string missing = act_info.req.list_missing();
+                    if( !missing.empty() ) {
+                        add_msg( m_bad, missing );
+                    }
+                }
+            }
+        }
+        return requirement_check_result::SKIP_LOCATION;
     }
     if( reason == do_activity_reason::DONT_HAVE_SKILL ||
         reason == do_activity_reason::NO_ZONE ||
@@ -2932,7 +3054,8 @@ static requirement_check_result generic_multi_activity_check_requirement(
             loot_zone_spots.emplace_back( elem );
             combined_spots.emplace_back( elem );
         }
-        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
+        const int nearby_radius = act_id == ACT_MULTIPLE_CRAFT ? PICKUP_RANGE : PICKUP_RANGE - 1;
+        for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc, nearby_radius ) ) {
             combined_spots.push_back( elem );
         }
         add_basecamp_storage_to_loot_zone_list( mgr, src_loc, you, loot_zone_spots, combined_spots );
@@ -3026,9 +3149,17 @@ static requirement_check_result generic_multi_activity_check_requirement(
         // is it even worth fetching anything if there isn't enough nearby?
         if( !are_requirements_nearby( tool_pickup ? loot_zone_spots : combined_spots, what_we_need, you,
                                       act_id, tool_pickup, src_loc ) ) {
-            you.add_msg_player_or_npc( m_info,
-                                       _( "The required items are not available to complete this task." ),
-                                       _( "The required items are not available to complete this task." ) );
+            if( act_id == ACT_MULTIPLE_CRAFT ) {
+                you.add_msg_player_or_npc( m_bad,
+                                           _( "工作地点附近缺少继续制造所需的物品或工具，制作已停止。" ),
+                                           _( "工作地点附近缺少继续制造所需的物品或工具，<npcname>停止了制作。" ) );
+            } else {
+                you.add_msg_player_or_npc( m_info,
+                                           _( "The required items are not available to "
+                                              "complete this task." ),
+                                           _( "The required items are not available to "
+                                              "complete this task." ) );
+            }
 
             add_msg(m_bad,what_we_need.obj().list_missing());
 
@@ -3052,7 +3183,8 @@ static requirement_check_result generic_multi_activity_check_requirement(
                         local_src_set.push_back( here.bub_from_abs( elem ) );
                     }
                     std::vector<tripoint_bub_ms> candidates;
-                    for( const tripoint_bub_ms &point_elem : here.points_in_radius( src_loc, PICKUP_RANGE - 1 ) ) {
+                    for( const tripoint_bub_ms &point_elem : here.points_in_radius( src_loc,
+                            nearby_radius ) ) {
                         // we don't want to place the components where they could interfere with our ( or someone else's ) construction spots
                         if( !you.sees( point_elem ) || ( std::find( local_src_set.begin(), local_src_set.end(),
                                                          point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {
@@ -3061,6 +3193,11 @@ static requirement_check_result generic_multi_activity_check_requirement(
                         candidates.push_back( point_elem );
                     }
                     if( candidates.empty() ) {
+                        if( act_id == ACT_MULTIPLE_CRAFT ) {
+                            you.add_msg_player_or_npc( m_bad,
+                                                       _( "工作地点附近没有可供放置材料的位置，制作已停止。" ),
+                                                       _( "工作地点附近没有可供放置材料的位置，<npcname>停止了制作。" ) );
+                        }
                         you.activity = player_activity();
                         you.backlog.clear();
                         check_npc_revert( you );
@@ -3201,19 +3338,37 @@ static bool generic_multi_activity_do(
 
         you.activity_vehicle_part_index = -1;
     }
-    else if (reason == do_activity_reason::NEEDS_CRAFT) {
-        // only npc is supported
-        npc* p = you.as_npc();
-        if (p) {
-            item_location to_craft = p->get_item_to_craft();
-            if (to_craft && to_craft->is_craft() &&
-                you.lighting_craft_speed_multiplier(to_craft->get_making()) > 0) {
-                player_activity act = player_activity(craft_activity_actor(to_craft, false));
-                you.assign_activity(act);
-                you.backlog.emplace_front(ACT_MULTIPLE_CRAFT);
-                you.backlog.front().auto_resume = true;
-                return false;
+    else if( reason == do_activity_reason::NEEDS_CRAFT ) {
+        // Only NPCs are supported.
+        npc *p = you.as_npc();
+        if( p ) {
+            item_location to_craft = item_to_craft_at( *p, src_loc );
+            if( !to_craft || !to_craft->is_craft() ) {
+                you.add_msg_player_or_npc( m_bad,
+                                           _( "你找不到指定的制造中物品。" ),
+                                           _( "<npcname>找不到指定的制造中物品。" ) );
+                return true;
             }
+            if( you.lighting_craft_speed_multiplier( to_craft->get_making() ) <= 0 ) {
+                you.add_msg_player_or_npc( m_bad,
+                                           _( "这里太暗，无法继续制作。" ),
+                                           _( "这里太暗，<npcname>无法继续制作。" ) );
+                return true;
+            }
+            const bool was_paused = to_craft->get_var( var_craft_queue_paused, 0 ) != 0;
+            player_activity craft_act = player_activity( craft_activity_actor( to_craft, false ) );
+            you.assign_activity( craft_act );
+            you.backlog.emplace_front( ACT_MULTIPLE_CRAFT );
+            if( was_paused && you.activity ) {
+                to_craft->erase_var( var_craft_queue_paused );
+                you.add_msg_player_or_npc(
+                    m_info,
+                    _( "制造清单所需材料和工具已经补齐，继续制作。" ),
+                    _( "制造清单所需材料和工具已经补齐，<npcname>继续制作。" ) );
+            }
+            you.backlog.front().placement = here.getglobal( src_loc );
+            you.backlog.front().auto_resume = true;
+            return false;
         }
     } else if( reason == do_activity_reason::NEEDS_DISASSEMBLE ) {
         
@@ -3287,6 +3442,12 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
     const tripoint_abs_ms abspos = here.getglobal( you.pos() );
     // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     activity_id activity_to_restore = act.id();
+    const tripoint_abs_ms activity_placement = act.placement;
+    const auto restored_activity = [&]() {
+        player_activity restored( activity_to_restore );
+        restored.placement = activity_placement;
+        return restored;
+    };
     // Nuke the current activity, leaving the backlog alone
     if( !check_only ) {
         you.activity = player_activity();
@@ -3294,7 +3455,7 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
     // now we setup the target spots based on which activity is occurring
     // the set of target work spots - potentially after we have fetched required tools.
     std::unordered_set<tripoint_abs_ms> src_set =
-        generic_multi_activity_locations( you, activity_to_restore );
+        generic_multi_activity_locations( you, activity_to_restore, activity_placement );
     // now we have our final set of points
     std::vector<tripoint_abs_ms> src_sorted = get_sorted_tiles_by_distance( abspos, src_set );
     // now loop through the work-spot tiles and judge whether its worth traveling to it yet
@@ -3312,18 +3473,23 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
             if( !here.inbounds( you.pos() ) ) {
                 // p is implicitly an NPC that has been moved off the map, so reset the activity
                 // and unload them
-                you.assign_activity( activity_to_restore );
+                you.assign_activity( restored_activity() );
                 you.set_moves( 0 );
                 g->reload_npcs();
                 return false;
             }
             const std::vector<tripoint_bub_ms> route = route_adjacent( you, src_loc );
             if( route.empty() ) {
-                // can't get there, can't do anything, skip it
+                // Can't get there, can't do anything, skip it.
+                if( activity_to_restore == ACT_MULTIPLE_CRAFT ) {
+                    you.add_msg_player_or_npc( m_bad,
+                                               _( "你无法到达指定工作地点。" ),
+                                               _( "<npcname>无法到达指定工作地点。" ) );
+                }
                 continue;
             }
             you.set_moves( 0 );
-            you.set_destination( route, player_activity( activity_to_restore ) );
+            you.set_destination( route, restored_activity() );
             return false;
         }
         activity_reason_info act_info = can_do_activity_there( activity_to_restore, you,
@@ -3332,6 +3498,15 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
         const requirement_check_result req_res = generic_multi_activity_check_requirement(
                     you, activity_to_restore, act_info, src, src_loc, src_set, check_only );
         if( req_res == requirement_check_result::SKIP_LOCATION ) {
+            if( activity_to_restore == ACT_MULTIPLE_CRAFT &&
+                act_info.reason == do_activity_reason::NEEDS_CRAFT ) {
+                if( check_only ) {
+                    return true;
+                }
+                you.assign_activity( restored_activity() );
+                you.set_moves( 0 );
+                return false;
+            }
             continue;
         } else if( req_res == requirement_check_result::RETURN_EARLY ) {
             return true;
@@ -3353,20 +3528,25 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
             }
             // check if we found path to source / adjacent tile
             if( route.empty() ) {
+                if( activity_to_restore == ACT_MULTIPLE_CRAFT ) {
+                    you.add_msg_player_or_npc( m_bad,
+                                               _( "你无法到达指定工作地点。" ),
+                                               _( "<npcname>无法到达指定工作地点。" ) );
+                }
                 check_npc_revert( you );
                 continue;
             }
             if( !check_only ) {
                 if( you.moves <= 0 ) {
                     // Restart activity and break from cycle.
-                    you.assign_activity( activity_to_restore );
+                    you.assign_activity( restored_activity() );
                     return true;
                 }
                 // set the destination and restart activity after player arrives there
                 // we don't need to check for safe mode,
                 // activity will be restarted only if
                 // player arrives on destination tile
-                you.set_destination( route, player_activity( activity_to_restore ) );
+                you.set_destination( route, restored_activity() );
                 return true;
             }
         }
@@ -3381,7 +3561,13 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
             activity_to_restore != ACT_MOVE_LOOT &&
             activity_to_restore != ACT_FETCH_REQUIRED &&
             you.fine_detail_vision_mod( you.pos() ) > 4.0 ) {
-            you.add_msg_if_player( m_info, _( "It is too dark to work here." ) );
+            if( activity_to_restore == ACT_MULTIPLE_CRAFT ) {
+                you.add_msg_player_or_npc( m_bad,
+                                           _( "这里太暗，无法继续制作。" ),
+                                           _( "这里太暗，<npcname>无法继续制作。" ) );
+            } else {
+                you.add_msg_if_player( m_info, _( "It is too dark to work here." ) );
+            }
             return false;
         }
         if( !check_only ) {
@@ -3398,7 +3584,7 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
     if( !check_only ) {
         if( you.moves <= 0 ) {
             // Restart activity and break from cycle.
-            you.assign_activity( activity_to_restore );
+            you.assign_activity( restored_activity() );
             you.activity_vehicle_part_index = -1;
             return false;
         }

--- a/src/character.h
+++ b/src/character.h
@@ -3070,7 +3070,7 @@ class Character : public Creature, public visitable
 
         // ---- CRAFTING ----
         void make_craft_with_command( const recipe_id &id_to_make, int batch_size, bool is_long,
-                                      const std::optional<tripoint> &loc );
+                                      const std::optional<tripoint> &loc, bool queued = false );
         pimpl<craft_command> last_craft;
 
         recipe_id lastrecipe;
@@ -3166,8 +3166,12 @@ class Character : public Creature, public visitable
                          const std::optional<tripoint> &loc = std::nullopt );
         void make_all_craft( const recipe_id &id, int batch_size,
                              const std::optional<tripoint> &loc );
+        /** Add a recipe to an NPC manufacturing queue without closing the crafting menu. */
+        bool queue_craft( const recipe_id &id, int batch_size,
+                          const std::optional<tripoint> &loc );
         /** consume components and create an active, in progress craft containing them */
-        void start_craft( craft_command &command, const std::optional<tripoint> &loc );
+        void start_craft( craft_command &command, const std::optional<tripoint> &loc,
+                          bool queued = false );
         /**
          * Calculate a value representing the success of the player at crafting the given recipe,
          * taking player skill, recipe difficulty, npc helpers, and player mutations into account.
@@ -3188,6 +3192,11 @@ class Character : public Creature, public visitable
         bool can_continue_craft( item &craft, const requirement_data &continue_reqs );
         /** Returns nearby NPCs ready and willing to help with crafting. */
         std::vector<npc *> get_crafting_helpers() const;
+        /**
+         * Returns this character and nearby allied NPCs whose recipe knowledge
+         * can be selected from the normal crafting menu.
+         */
+        std::vector<Character *> get_crafting_group() const;
         int get_num_crafting_helpers( int max ) const;
         /**
          * Handle skill gain for player and followers during crafting.
@@ -3248,7 +3257,8 @@ class Character : public Creature, public visitable
             return i;
         } );
         /** Consume tools for the next multiplier * 5% progress of the craft */
-        bool craft_consume_tools( item &craft, int multiplier, bool start_craft );
+        bool craft_consume_tools( item &craft, int multiplier, bool start_craft,
+                                  const std::optional<tripoint> &workplace = std::nullopt );
         void consume_tools( const comp_selection<tool_comp> &tool, int batch );
         void consume_tools( map &m, const comp_selection<tool_comp> &tool, int batch,
                             const tripoint &origin = tripoint_zero, int radius = PICKUP_RANGE,

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -20,6 +20,7 @@
 #include "construction_category.h"
 #include "construction_group.h"
 #include "coordinates.h"
+#include "creature_tracker.h"
 #include "cursesdef.h"
 #include "debug.h"
 #include "enums.h"
@@ -78,6 +79,9 @@ static const flag_id json_flag_PIT( "PIT" );
 static const furn_str_id furn_f_console( "f_console" );
 static const furn_str_id furn_f_console_broken( "f_console_broken" );
 static const furn_str_id furn_f_machinery_electronic( "f_machinery_electronic" );
+static const furn_str_id furn_f_ground_crafting_spot( "f_ground_crafting_spot" );
+
+static const field_type_str_id fd_crafting_spot( "fd_crafting_spot" );
 
 static const item_group_id Item_spawn_data_allclothes( "allclothes" );
 static const item_group_id Item_spawn_data_grave( "grave" );
@@ -137,6 +141,7 @@ static bool check_nothing( const tripoint_bub_ms & )
 static bool check_channel( const tripoint_bub_ms & ); // tile has adjacent flowing water
 static bool check_empty_lite( const tripoint_bub_ms & );
 static bool check_empty( const tripoint_bub_ms & ); // tile is empty
+static bool check_crafting_spot( const tripoint_bub_ms & );
 static bool check_support( const tripoint_bub_ms & ); // at least two orthogonal supports
 static bool check_support_below( const tripoint_bub_ms
                                  & ); // at least two orthogonal supports at the level below
@@ -163,6 +168,7 @@ static void done_vehicle( const tripoint_bub_ms &, Character & );
 static void done_appliance( const tripoint_bub_ms &, Character & );
 static void done_wiring( const tripoint_bub_ms &, Character & );
 static void done_deconstruct( const tripoint_bub_ms &, Character & );
+static void done_crafting_spot( const tripoint_bub_ms &, Character & );
 static void done_digormine_stair( const tripoint_bub_ms &, bool, Character & );
 static void done_dig_grave( const tripoint_bub_ms &p, Character & );
 static void done_dig_grave_nospawn( const tripoint_bub_ms &p, Character & );
@@ -1204,6 +1210,25 @@ bool construct::check_empty( const tripoint_bub_ms &p )
              here.i_at( p ).empty() && !here.veh_at( p ) );
 }
 
+bool construct::check_crafting_spot( const tripoint_bub_ms &p )
+{
+    map &here = get_map();
+    if( get_creature_tracker().creature_at( p ) != nullptr || !here.tr_at( p ).is_null() ||
+        here.get_field( p, fd_crafting_spot ) != nullptr ||
+        here.furn( p ) == furn_f_ground_crafting_spot ) {
+        return false;
+    }
+
+    // A field marker can coexist with a fixed furniture workbench.  Vehicle workbenches are
+    // deliberately excluded because map fields do not move with the vehicle.
+    if( here.has_furn( p ) && here.furn( p ).obj().workbench && !here.veh_at( p ) ) {
+        return true;
+    }
+
+    return here.has_flag( ter_furn_flag::TFLAG_FLAT, p ) && !here.has_furn( p ) &&
+           !here.veh_at( p );
+}
+
 static std::array<tripoint_bub_ms, 4> get_orthogonal_neighbors( const tripoint_bub_ms &p )
 {
     return {{
@@ -1562,6 +1587,18 @@ void construct::done_appliance( const tripoint_bub_ms &p, Character &player_char
     }
     // TODO: fix point types
     place_appliance( p.raw(), vpart, base, *direction );
+}
+
+void construct::done_crafting_spot( const tripoint_bub_ms &p, Character &who )
+{
+    map &here = get_map();
+    if( here.has_furn( p ) && here.furn( p ).obj().workbench ) {
+        here.add_field( p, fd_crafting_spot, 1 );
+        who.add_msg_if_player( m_info, _( "你在%s上标记了制造点。" ), here.furnname( p ) );
+    } else {
+        here.furn_set( p, furn_f_ground_crafting_spot );
+        who.add_msg_if_player( m_info, _( "你标记了一个地面制造点。" ) );
+    }
 }
 
 void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_character )
@@ -2018,6 +2055,7 @@ void load_construction( const JsonObject &jo )
             { "", construct::check_nothing },
             { "check_channel", construct::check_channel },
             { "check_empty", construct::check_empty },
+            { "check_crafting_spot", construct::check_crafting_spot },
             { "check_empty_lite", construct::check_empty_lite },
             { "check_support", construct::check_support },
             { "check_support_below", construct::check_support_below },
@@ -2044,6 +2082,7 @@ void load_construction( const JsonObject &jo )
             { "done_appliance", construct::done_appliance },
             { "done_wiring", construct::done_wiring },
             { "done_deconstruct", construct::done_deconstruct },
+            { "done_crafting_spot", construct::done_crafting_spot },
             { "done_dig_grave", construct::done_dig_grave },
             { "done_dig_grave_nospawn", construct::done_dig_grave_nospawn },
             { "done_dig_stair", construct::done_dig_stair },

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -114,8 +114,21 @@ void craft_command::execute( bool only_cache_comps )
     }
 
     bool need_selections = true;
+    const tripoint origin = loc ? *loc : crafter->pos();
     inventory map_inv;
-    map_inv.form_from_map( crafter->pos(), PICKUP_RANGE, crafter );
+    map_inv.form_from_map( origin, PICKUP_RANGE, crafter );
+    const inventory &crafting_inv = crafter->crafting_inventory( origin, PICKUP_RANGE, true );
+
+    const auto can_make_at_workplace = [&]( recipe_filter_flags filter_flags,
+                                            craft_flags craft_flag ) {
+        if( !crafter->has_recipe( rec, crafting_inv, crafter->get_crafting_helpers() ) ||
+            !rec->character_has_required_proficiencies( *crafter ) ) {
+            return false;
+        }
+        return rec->deduped_requirements().can_make_with_inventory(
+                   crafting_inv, rec->get_component_filter( filter_flags ), batch_size,
+                   craft_flag );
+    };
 
     if( has_cached_selections() ) {
         std::vector<comp_selection<item_comp>> missing_items = check_item_components_missing( map_inv );
@@ -130,8 +143,8 @@ void craft_command::execute( bool only_cache_comps )
     }
 
     if( need_selections ) {
-        if( !crafter->can_make( rec, batch_size ) ) {
-            if( crafter->can_start_craft( rec, recipe_filter_flags::none, batch_size ) ) {
+        if( !can_make_at_workplace( recipe_filter_flags::none, craft_flags::none ) ) {
+            if( can_make_at_workplace( recipe_filter_flags::none, craft_flags::start_only ) ) {
                 if( !query_yn( _( "You don't have enough charges to complete the %s.\n"
                                   "Start crafting anyway?" ), rec->result_name() ) ) {
                     return;
@@ -147,7 +160,7 @@ void craft_command::execute( bool only_cache_comps )
 
         flags = recipe_filter_flags::no_rotten;
 
-        if( !crafter->can_start_craft( rec, flags, batch_size ) ) {
+        if( !can_make_at_workplace( flags, craft_flags::start_only ) ) {
             if( !query_yn( _( "This craft will use rotten components.\n"
                               "Start crafting anyway?" ) ) ) {
                 return;
@@ -156,7 +169,7 @@ void craft_command::execute( bool only_cache_comps )
         }
 
         flags |= recipe_filter_flags::no_favorite;
-        if( !crafter->can_start_craft( rec, flags, batch_size ) ) {
+        if( !can_make_at_workplace( flags, craft_flags::start_only ) ) {
             if( !query_yn( _( "This craft will use favorited components.\n"
                               "Start crafting anyway?" ) ) ) {
                 return;
@@ -199,7 +212,7 @@ void craft_command::execute( bool only_cache_comps )
         return;
     }
 
-    crafter->start_craft( *this, loc );
+    crafter->start_craft( *this, loc, queued );
     crafter->last_batch = batch_size;
     crafter->lastrecipe = rec->ident();
 
@@ -250,6 +263,7 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
         bool no_prompt )
 {
     map &m = get_map();
+    const tripoint origin = loc ? *loc : crafter->pos();
     for( const auto &it : item_selections ) {
         const std::vector<pocket_data> it_pkt = it.comp.type->pockets;
         if( ( item::count_by_charges( it.comp.type ) && it.comp.count > 0 ) ||
@@ -284,10 +298,9 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
         int real_count = ( it.comp.count > 0 ) ? it.comp.count * batch_size : std::abs( it.comp.count );
         for( int i = 0; i < 2 && real_count > 0; i++ ) {
             if( it.use_from & usage_from::map ) {
-                const tripoint &loc = crafter->pos();
                 for( int radius = 0; radius <= PICKUP_RANGE && real_count > 0; radius++ ) {
-                    for( const tripoint &p : m.points_in_radius( loc, radius ) ) {
-                        if( rl_dist( loc, p ) >= radius ) {
+                    for( const tripoint &p : m.points_in_radius( origin, radius ) ) {
+                        if( rl_dist( origin, p ) >= radius ) {
                             // "Simulate" consuming items and put them back
                             // not very efficient but should be rare enough not to matter
                             std::list<item> tmp = m.use_amount_square( p, it.comp.type, real_count,
@@ -340,7 +353,7 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
 }
 
 static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, Character *crafter,
-        int batch, const std::function<bool( const item & )> &filter )
+        int batch, const std::function<bool( const item & )> &filter, const tripoint &origin )
 {
     map &m = get_map();
     const std::vector<pocket_data> it_pkt = it.comp.type->pockets;
@@ -348,7 +361,7 @@ static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, 
     !std::any_of( it_pkt.begin(), it_pkt.end(), []( const pocket_data & p ) {
     return p.type == item_pocket::pocket_type::CONTAINER && p.watertight;
 } ) ) {
-        return crafter->consume_items( it, batch, filter );
+        return crafter->consume_items( m, it, batch, filter, origin, PICKUP_RANGE );
     }
 
     // Everything below only occurs for item components that are liquid containers
@@ -360,10 +373,9 @@ static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, 
     std::list<item> ret;
     for( int i = 0; i < 2 && real_count > 0; i++ ) {
         if( it.use_from & usage_from::map ) {
-            const tripoint &loc = crafter->pos();
             for( int radius = 0; radius <= PICKUP_RANGE && real_count > 0; radius++ ) {
-                for( const tripoint &p : m.points_in_radius( loc, radius ) ) {
-                    if( rl_dist( loc, p ) >= radius ) {
+                for( const tripoint &p : m.points_in_radius( origin, radius ) ) {
+                    if( rl_dist( origin, p ) >= radius ) {
                         std::list<item> tmp = m.use_amount_square( p, it.comp.type, real_count,
                                               i == 0 ? empty_filter : filter );
                         ret.insert( ret.end(), tmp.begin(), tmp.end() );
@@ -425,8 +437,9 @@ item craft_command::create_in_progress_craft()
         return item();
     }
 
+    const tripoint origin = loc ? *loc : crafter->pos();
     inventory map_inv;
-    map_inv.form_from_map( crafter->pos(), PICKUP_RANGE, crafter );
+    map_inv.form_from_map( origin, PICKUP_RANGE, crafter );
 
     if( !check_item_components_missing( map_inv ).empty() ) {
         debugmsg( "Aborting crafting: couldn't find cached components" );
@@ -442,7 +455,7 @@ item craft_command::create_in_progress_craft()
     }
 
     for( const auto &it : item_selections ) {
-        std::list<item> tmp = sane_consume_items( it, crafter, batch_size, filter );
+        std::list<item> tmp = sane_consume_items( it, crafter, batch_size, filter, origin );
         for( item &tmp_it : tmp ) {
             if( safe_to_unload_comp( tmp_it ) ) {
                 item_location tmp_loc( *crafter, &tmp_it );
@@ -474,7 +487,7 @@ item craft_command::create_in_progress_craft()
     new_craft.set_cached_tool_selections( tool_selections );
     new_craft.set_tools_to_continue( true );
     // Pass true to indicate that we are starting the craft and the remainder should be consumed as well
-    crafter->craft_consume_tools( new_craft, 1, true );
+    crafter->craft_consume_tools( new_craft, 1, true, loc );
     new_craft.set_next_failure_point( *crafter );
 
     return new_craft;

--- a/src/craft_command.h
+++ b/src/craft_command.h
@@ -63,8 +63,9 @@ class craft_command
         /** Instantiates an empty craft_command, which can't be executed. */
         craft_command() = default;
         craft_command( const recipe *to_make, int batch_size, bool is_long, Character *crafter,
-                       const std::optional<tripoint> &loc ) :
-            rec( to_make ), batch_size( batch_size ), longcraft( is_long ), crafter( crafter ), loc( loc ) {}
+                       const std::optional<tripoint> &loc, bool queued = false ) :
+            rec( to_make ), batch_size( batch_size ), longcraft( is_long ), queued( queued ),
+            crafter( crafter ), loc( loc ) {}
 
         /**
          * Selects components to use for the craft, then assigns the crafting activity to 'crafter'.
@@ -105,6 +106,8 @@ class craft_command
         * long as possible.
         */
         bool longcraft = false;
+        // NPC queue entries are created immediately, but do not interrupt an existing queue.
+        bool queued = false;
         // This is mainly here for maintainability reasons.
         Character *crafter;
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -104,6 +104,8 @@ static const string_id<struct furn_t> furn_f_fake_bench_hands( "f_fake_bench_han
 
 static const string_id<struct furn_t> furn_f_ground_crafting_spot( "f_ground_crafting_spot" );
 
+static const field_type_str_id fd_crafting_spot( "fd_crafting_spot" );
+
 static const trait_id trait_BURROW( "BURROW" );
 static const trait_id trait_BURROWLARGE( "BURROWLARGE" );
 static const trait_id trait_DEBUG_CNF( "DEBUG_CNF" );
@@ -114,11 +116,250 @@ static const std::string flag_BLIND_HARD( "BLIND_HARD" );
 static const std::string flag_FULL_MAGAZINE( "FULL_MAGAZINE" );
 static const std::string flag_NO_RESIZE( "NO_RESIZE" );
 static const std::string flag_UNCRAFT_LIQUIDS_CONTAINED( "UNCRAFT_LIQUIDS_CONTAINED" );
+static const std::string var_craft_queue_order( "craft_queue_order" );
 
 class basecamp;
 
-static bool crafting_allowed( const Character &p, const recipe &rec )
+static float workbench_multiplier_at( map &here, const tripoint &loc )
 {
+    if( const std::optional<vpart_reference> vp = here.veh_at( loc ).part_with_feature(
+                "WORKBENCH", true ) ) {
+        if( const std::optional<vpslot_workbench> &wb = vp->part().info().get_workbench_info() ) {
+            return wb->multiplier;
+        }
+        return 0.0f;
+    }
+    if( here.has_furn( loc ) && here.furn( loc ).obj().workbench ) {
+        return here.furn( loc ).obj().workbench->multiplier;
+    }
+    return 0.0f;
+}
+
+std::optional<tripoint> resolve_crafting_workplace(
+    const Character &crafter, const std::optional<tripoint> &selected_workplace )
+{
+    if( selected_workplace ) {
+        return selected_workplace;
+    }
+
+    map &here = get_map();
+    std::optional<tripoint> best_marked;
+    std::optional<tripoint> best_regular;
+    float best_marked_multiplier = -1.0f;
+    float best_regular_multiplier = -1.0f;
+
+    // Automatic selection only examines the nine tiles around the crafter.  Callers resolve this
+    // once when the crafter or selected workplace changes and reuse the returned location.
+    for( const tripoint &loc : here.points_in_radius( crafter.pos(), 1 ) ) {
+        if( here.dangerous_field_at( loc ) ) {
+            continue;
+        }
+        const float multiplier = workbench_multiplier_at( here, loc );
+        if( multiplier <= 0.0f ) {
+            continue;
+        }
+        const bool marked = here.furn( loc ) == furn_f_ground_crafting_spot ||
+                            here.get_field( loc, fd_crafting_spot ) != nullptr;
+        if( marked ) {
+            if( multiplier > best_marked_multiplier ) {
+                best_marked_multiplier = multiplier;
+                best_marked = loc;
+            }
+        } else if( multiplier > best_regular_multiplier ) {
+            best_regular_multiplier = multiplier;
+            best_regular = loc;
+        }
+    }
+
+    return best_marked ? best_marked : best_regular;
+}
+
+static const inventory &crafting_inventory_at( Character &crafter,
+        const std::optional<tripoint> &workplace )
+{
+    const std::optional<tripoint> effective = resolve_crafting_workplace( crafter, workplace );
+    return effective ? crafter.crafting_inventory( *effective, PICKUP_RANGE, true ) :
+           crafter.crafting_inventory();
+}
+
+static bool has_safe_crafting_position( const tripoint &workplace )
+{
+    map &here = get_map();
+    for( const tripoint &adj : here.points_in_radius( workplace, 1 ) ) {
+        if( adj.z == workplace.z && here.passable( adj ) && !here.dangerous_field_at( adj ) ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool npc_can_reach_crafting_position( const Character &crafter, const tripoint &workplace )
+{
+    if( crafter.posz() != workplace.z ) {
+        return false;
+    }
+    if( square_dist( crafter.pos(), workplace ) <= 1 ) {
+        return true;
+    }
+
+    map &here = get_map();
+    for( const tripoint &adj : here.points_in_radius( workplace, 1 ) ) {
+        if( !here.passable( adj ) || here.dangerous_field_at( adj ) ) {
+            continue;
+        }
+        if( !here.route( crafter.pos(), adj, crafter.get_pathfinding_settings() ).empty() ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool craft_is_assigned_to( const item &craft, const npc &who )
+{
+    if( !craft.is_craft() ) {
+        return false;
+    }
+    const std::string crafter_id = craft.get_var( "crafter_id", "" );
+    return ( !crafter_id.empty() && crafter_id == std::to_string( who.getID().get_value() ) ) ||
+           craft.get_var( "crafter", "" ) == who.name;
+}
+
+static std::optional<tripoint> npc_crafting_queue_location( const npc &who )
+{
+    map &here = get_map();
+    const auto location_from = [&]( const player_activity & act ) -> std::optional<tripoint> {
+        if( act.id() == ACT_MULTIPLE_CRAFT && act.placement != player_activity::invalid_place ) {
+            return here.bub_from_abs( act.placement ).raw();
+        }
+        return std::nullopt;
+    };
+
+    if( const std::optional<tripoint> current = location_from( who.activity ) ) {
+        return current;
+    }
+    for( const player_activity &queued_activity : who.backlog ) {
+        if( const std::optional<tripoint> queued = location_from( queued_activity ) ) {
+            return queued;
+        }
+    }
+    return std::nullopt;
+}
+
+static int next_crafting_queue_order( const npc &who, const tripoint &anchor )
+{
+    map &here = get_map();
+    int result = 0;
+    const auto include = [&]( const item & candidate ) {
+        if( craft_is_assigned_to( candidate, who ) ) {
+            result = std::max( result, static_cast<int>( candidate.get_var( var_craft_queue_order, 0 ) ) );
+        }
+    };
+
+    // Workbench placement may overflow by one or two tiles.  Keep the scan tiny and only inspect
+    // items already assigned to this NPC, so adding an entry remains effectively constant cost.
+    for( const tripoint &pt : here.points_in_radius( anchor, 2 ) ) {
+        for( const item &candidate : here.i_at( pt ) ) {
+            include( candidate );
+        }
+        if( const optional_vpart_position vp = here.veh_at( pt ) ) {
+            const int cargo_part = vp->vehicle().part_with_feature( vp->part_index(), "CARGO", false );
+            if( cargo_part >= 0 ) {
+                for( const item &candidate : vp->vehicle().get_items( cargo_part ) ) {
+                    include( candidate );
+                }
+            }
+        }
+    }
+    return result + 1;
+}
+
+static std::string crafting_failure_reason( Character &crafter, const recipe &rec,
+        int batch_size, const std::optional<tripoint> &workplace, bool allow_queue_append = false )
+{
+    const std::optional<tripoint> effective_workplace = resolve_crafting_workplace(
+                crafter, workplace );
+
+    if( rec.category == "CC_BUILDING" ) {
+        return _( "大地图地形建造配方尚未实现。" );
+    }
+
+    if( crafter.in_sleep_state() ) {
+        return crafter.is_avatar() ? _( "你正在睡觉，无法制作。" ) :
+               string_format( _( "%s正在睡觉，无法制作。" ), crafter.get_name() );
+    }
+    if( const npc *guy = crafter.as_npc(); guy != nullptr &&
+        ( guy->has_activity() || !crafter.activity.is_null() ) ) {
+        const std::optional<tripoint> queue_location = npc_crafting_queue_location( *guy );
+        const tripoint desired_location = effective_workplace ? *effective_workplace : crafter.pos();
+        const bool appending_same_queue = allow_queue_append && queue_location &&
+                                          *queue_location == desired_location;
+        if( !appending_same_queue ) {
+            return string_format( _( "%s正在忙碌，无法开始新的制作。" ), crafter.get_name() );
+        }
+    }
+
+    if( effective_workplace ) {
+        map &here = get_map();
+        if( here.dangerous_field_at( *effective_workplace ) ) {
+            return _( "所选工作地点存在危险，无法开始制作。" );
+        }
+        if( !has_safe_crafting_position( *effective_workplace ) ) {
+            return _( "所选工作地点附近没有可以安全站立的位置。" );
+        }
+        if( crafter.is_avatar() && square_dist( crafter.pos(), *effective_workplace ) > 1 ) {
+            return _( "你必须先走到所选工作地点旁边才能开始制作。" );
+        }
+        if( crafter.is_npc() &&
+            !npc_can_reach_crafting_position( crafter, *effective_workplace ) ) {
+            return string_format( _( "%s无法到达所选工作地点。" ), crafter.get_name() );
+        }
+    }
+
+    const inventory &inv = crafting_inventory_at( crafter, effective_workplace );
+    if( !crafter.has_recipe( &rec, inv, crafter.get_crafting_helpers() ) ) {
+        return string_format( _( "%s不知道这个配方，也没有可用的配方资料。" ),
+                              crafter.is_avatar() ? _( "你" ) : crafter.get_name() );
+    }
+    if( rec.is_practice() && ( rec.skill_used.is_null() ||
+                               crafter.get_skill_level( rec.skill_used ) <
+                               rec.get_difficulty( crafter ) ) ) {
+        return _( "当前制作者的技能不足，无法进行这项练习。" );
+    }
+    if( !rec.character_has_required_proficiencies( crafter ) ) {
+        return _( "当前制作者缺少这项制作要求的熟练度。" );
+    }
+
+    std::string npc_reason;
+    if( crafter.is_npc() && !rec.npc_can_craft( npc_reason ) ) {
+        return npc_reason;
+    }
+    if( crafter.morale_crafting_speed_multiplier( rec ) <= 0.0f ) {
+        return crafter.is_avatar() ? _( "你的士气太低，无法制作这件物品。" ) :
+               string_format( _( "%s的士气太低，无法制作这件物品。" ), crafter.get_name() );
+    }
+    if( crafter.lighting_craft_speed_multiplier( rec,
+            effective_workplace ? *effective_workplace : tripoint_zero ) <= 0.0f ) {
+        return effective_workplace ? _( "所选工作地点光照不足，无法制作。" ) :
+               _( "当前制作者所在位置光照不足，无法制作。" );
+    }
+
+    const auto filter = rec.get_component_filter( recipe_filter_flags::none );
+    if( !rec.deduped_requirements().can_make_with_inventory( inv, filter, batch_size,
+            craft_flags::start_only ) ) {
+        const requirement_data &simple = rec.simple_requirements();
+        simple.can_make_with_inventory( inv, filter, batch_size, craft_flags::start_only );
+        const std::string missing = simple.list_missing();
+        return missing.empty() ? _( "所选制作者在工作地点附近缺少必要的工具或材料。" ) :
+               string_format( _( "所选制作者无法开始制作：\n%s" ), missing );
+    }
+    return std::string();
+}
+
+static bool crafting_allowed( const Character &p, const recipe &rec,
+                              const std::optional<tripoint> &workplace )
+{
+    const std::optional<tripoint> effective_workplace = resolve_crafting_workplace( p, workplace );
+
     if( p.morale_crafting_speed_multiplier( rec ) <= 0.0f ) {
         if (p.is_avatar()) {
             add_msg(m_info, _("Your morale is too low to craft such a difficult thing…"));
@@ -131,7 +372,8 @@ static bool crafting_allowed( const Character &p, const recipe &rec )
         return false;
     }
 
-    if( p.lighting_craft_speed_multiplier( rec ) <= 0.0f ) {
+    if( p.lighting_craft_speed_multiplier( rec,
+            effective_workplace ? *effective_workplace : tripoint_zero ) <= 0.0f ) {
         if (p.is_avatar()) {
             add_msg(m_info, _("You can't see to craft!"));
         }
@@ -146,14 +388,15 @@ static bool crafting_allowed( const Character &p, const recipe &rec )
         add_msg( m_info, _( "Overmap terrain building recipes are not implemented yet!" ) );
         return false;
     }
+
     return true;
 }
 
-float Character::lighting_craft_speed_multiplier(const recipe& rec, const tripoint& p) const
+float Character::lighting_craft_speed_multiplier( const recipe &rec, const tripoint &p ) const
 {
-    // negative is bright, 0 is just bright enough, positive is dark, +7.0f is pitch black
-    // 待定 此处有问题，如果完全按照原版移植 使用fine_detail_vision_mod( p )计算会出现光线太暗
-    float darkness = fine_detail_vision_mod() - 4.0f;
+    // Negative is bright, 0 is just bright enough, positive is dark, +7.0f is pitch black.
+    const tripoint light_position = p == tripoint_min ? tripoint_zero : p;
+    float darkness = fine_detail_vision_mod( light_position ) - 4.0f;
     
     if( darkness <= 0.0f ) {
         return 1.0f; // it's bright, go for it
@@ -317,22 +560,30 @@ float Character::crafting_speed_multiplier( const item &craft,
                               get_limb_score( limb_score_manip );
 
     if( light_multi <= 0.0f ) {
-        add_msg_if_player( m_bad, _( "You can no longer see well enough to keep crafting." ) );
+        add_msg_player_or_npc( m_bad,
+                               _( "你已经看不清，无法继续制造。" ),
+                               _( "<npcname>已经看不清，无法继续制造。" ) );
         return 0.0f;
     }
     if( bench_multi <= 0.1f || ( bench_multi <= 0.33f && total_multi <= 0.2f ) ) {
-        add_msg_if_player( m_bad, _( "The %s is too large and/or heavy to work on.  You may want to"
-                                     " use a workbench or a lifting tool" ), craft.tname() );
+        add_msg_player_or_npc( m_bad,
+                               _( "%s过于沉重或庞大，当前工作台无法继续加工。" ),
+                               _( "%s过于沉重或庞大，<npcname>无法在当前工作台继续加工。" ),
+                               craft.tname() );
         return 0.0f;
     }
     if( morale_multi <= 0.2f || ( morale_multi <= 0.33f && total_multi <= 0.2f ) ) {
-        add_msg_if_player( m_bad, _( "Your morale is too low to continue crafting." ) );
+        add_msg_player_or_npc( m_bad,
+                               _( "你的士气过低，无法继续制造。" ),
+                               _( "<npcname>的士气过低，停止了制造。" ) );
         return 0.0f;
     }
 
     // If we're working below 20% speed, just give up
     if( total_multi <= 0.2f ) {
-        add_msg_if_player( m_bad, _( "You are too frustrated to continue and just give up." ) );
+        add_msg_player_or_npc( m_bad,
+                               _( "你过于沮丧，只能停止制造。" ),
+                               _( "<npcname>过于沮丧，停止了制造。" ) );
         return 0.0f;
     }
 
@@ -361,15 +612,19 @@ bool Character::has_morale_to_craft() const
 void Character::craft( const std::optional<tripoint> &loc, const recipe_id &goto_recipe )
 {
     int batch_size = 0;
-    const recipe* rec = select_crafting_recipe(batch_size, goto_recipe, *this);
+    const crafting_selection selected = select_crafter_and_crafting_recipe( batch_size, goto_recipe,
+                                        *this, loc );
+    Character *crafter = selected.crafter;
+    const recipe *rec = selected.rec;
     if( rec ) {
-        std::string reason;
-        if (is_npc() && !rec->npc_can_craft(reason)) {
-            add_msg(m_info, reason);
+        const std::string reason = crafting_failure_reason( *crafter, *rec, batch_size,
+                                   selected.workplace );
+        if( !reason.empty() ) {
+            popup( reason, PF_NONE );
             return;
         }
-        if( crafting_allowed( *this, *rec ) ) {
-            make_craft( rec->ident(), batch_size, loc );
+        if( crafting_allowed( *crafter, *rec, selected.workplace ) ) {
+            crafter->make_craft( rec->ident(), batch_size, selected.workplace );
         }
     }
 }
@@ -386,10 +641,19 @@ void Character::recraft( const std::optional<tripoint> &loc )
 void Character::long_craft( const std::optional<tripoint> &loc, const recipe_id &goto_recipe )
 {
     int batch_size = 0;
-    const recipe* rec = select_crafting_recipe(batch_size, goto_recipe, *this);
+    const crafting_selection selected = select_crafter_and_crafting_recipe( batch_size, goto_recipe,
+                                        *this, loc );
+    Character *crafter = selected.crafter;
+    const recipe *rec = selected.rec;
     if( rec ) {
-        if( crafting_allowed( *this, *rec ) ) {
-            make_all_craft( rec->ident(), batch_size, loc );
+        const std::string reason = crafting_failure_reason( *crafter, *rec, batch_size,
+                                   selected.workplace );
+        if( !reason.empty() ) {
+            popup( reason, PF_NONE );
+            return;
+        }
+        if( crafting_allowed( *crafter, *rec, selected.workplace ) ) {
+            crafter->make_all_craft( rec->ident(), batch_size, selected.workplace );
         }
     }
 }
@@ -397,7 +661,7 @@ void Character::long_craft( const std::optional<tripoint> &loc, const recipe_id 
 bool Character::making_would_work( const recipe_id &id_to_make, int batch_size ) const
 {
     const recipe &making = *id_to_make;
-    if( !( making && crafting_allowed( *this, making ) ) ) {
+    if( !( making && crafting_allowed( *this, making, std::nullopt ) ) ) {
         return false;
     }
 
@@ -728,8 +992,44 @@ void Character::make_all_craft( const recipe_id &id_to_make, int batch_size,
     make_craft_with_command( id_to_make, batch_size, true, loc );
 }
 
+bool Character::queue_craft( const recipe_id &id_to_make, int batch_size,
+                             const std::optional<tripoint> &loc )
+{
+    npc *npc_crafter = as_npc();
+    if( npc_crafter == nullptr ) {
+        popup( _( "制造清单目前只用于附近的NPC盟友。" ), PF_NONE );
+        return false;
+    }
+
+    const recipe &recipe_to_make = *id_to_make;
+    if( !recipe_to_make ) {
+        return false;
+    }
+
+    // Once a queue has started, all new entries use its existing anchor.  This keeps automatic
+    // workplace selection from drifting if another bench later becomes preferable.
+    const std::optional<tripoint> queue_location = npc_crafting_queue_location( *npc_crafter );
+    const std::optional<tripoint> effective_workplace = queue_location ? queue_location :
+            resolve_crafting_workplace( *this, loc );
+    const tripoint anchor = effective_workplace ? *effective_workplace : pos();
+    const int order_before = next_crafting_queue_order( *npc_crafter, anchor );
+
+    const std::string reason = crafting_failure_reason( *this, recipe_to_make, batch_size,
+                               effective_workplace, true );
+    if( !reason.empty() ) {
+        popup( reason, PF_NONE );
+        return false;
+    }
+    if( !crafting_allowed( *this, recipe_to_make, effective_workplace ) ) {
+        return false;
+    }
+
+    make_craft_with_command( id_to_make, batch_size, false, effective_workplace, true );
+    return next_crafting_queue_order( *npc_crafter, anchor ) > order_before;
+}
+
 void Character::make_craft_with_command( const recipe_id &id_to_make, int batch_size, bool is_long,
-        const std::optional<tripoint> &loc )
+        const std::optional<tripoint> &loc, bool queued )
 {
     const recipe &recipe_to_make = *id_to_make;
 
@@ -737,7 +1037,8 @@ void Character::make_craft_with_command( const recipe_id &id_to_make, int batch_
         return;
     }
 
-    *last_craft = craft_command( &recipe_to_make, batch_size, is_long, this, loc );
+    const std::optional<tripoint> effective_workplace = resolve_crafting_workplace( *this, loc );
+    *last_craft = craft_command( &recipe_to_make, batch_size, is_long, this, effective_workplace, queued );
     last_craft->execute();
 }
 
@@ -873,30 +1174,8 @@ static item_location place_craft_or_disassembly(
 {
     item_location craft_in_world;
 
-    // Check if we are standing next to a workbench. If so, just use that.
-    float best_bench_multi = 0.0f;
     map &here = get_map();
-    for( const tripoint &adj : here.points_in_radius( ch.pos(), 1 ) ) {
-        if( here.dangerous_field_at( adj ) ) {
-            continue;
-        }
-        if( const cata::value_ptr<furn_workbench_info> &wb = here.furn( adj ).obj().workbench ) {
-            if( wb->multiplier > best_bench_multi ) {
-                best_bench_multi = wb->multiplier;
-                target = adj;
-            }
-        } else if( const std::optional<vpart_reference> vp = here.veh_at(
-                       adj ).part_with_feature( "WORKBENCH", true ) ) {
-            if( const std::optional<vpslot_workbench> &wb_info = vp->part().info().get_workbench_info() ) {
-                if( wb_info->multiplier > best_bench_multi ) {
-                    best_bench_multi = wb_info->multiplier;
-                    target = adj;
-                }
-            } else {
-                debugmsg( "part '%s' with WORKBENCH flag has no workbench info", vp->part().name() );
-            }
-        }
-    }
+    target = resolve_crafting_workplace( ch, target );
 
     // Crafting without a workbench
     if( !target ) {
@@ -969,7 +1248,7 @@ static item_location place_craft_or_disassembly(
     return craft_in_world;
 }
 
-void Character::start_craft( craft_command &command, const std::optional<tripoint> &loc )
+void Character::start_craft( craft_command &command, const std::optional<tripoint> &loc, bool queued )
 {
     if( command.empty() ) {
         debugmsg( "Attempted to start craft with empty command" );
@@ -990,26 +1269,52 @@ void Character::start_craft( craft_command &command, const std::optional<tripoin
         calc_encumbrance();
     }
 
-    item_location craft_in_world = place_craft_or_disassembly( *this, craft, loc );
+    npc *npc_crafter = as_npc();
+    const std::optional<tripoint> existing_queue_location = npc_crafter ?
+            npc_crafting_queue_location( *npc_crafter ) : std::nullopt;
+    const std::optional<tripoint> queue_location = npc_crafter ?
+            std::optional<tripoint>( existing_queue_location ? *existing_queue_location :
+                                     ( loc ? *loc : pos() ) ) : loc;
+
+    // NPC queue entries are physical in-progress crafts on the selected workplace.  Keeping them
+    // out of the NPC inventory prevents newly made clothing and containers from being worn while
+    // another queued recipe is started.
+    item_location craft_in_world = place_craft_or_disassembly( *this, craft, queue_location );
 
     if( !craft_in_world ) {
         return;
     }
-    
-    if (is_avatar()) {
-        assign_activity(player_activity(craft_activity_actor(craft_in_world, command.is_long())));
-    }
-    else {
-        // set flag to craft
-        craft_in_world.get_item()->set_var("crafter", name);
-        craft_in_world.get_item()->set_var("crafter_id", id.get_value());
-        assign_activity(ACT_MULTIPLE_CRAFT);
+
+    bool appended_to_queue = false;
+    if( is_avatar() ) {
+        assign_activity( player_activity( craft_activity_actor( craft_in_world, command.is_long() ) ) );
+    } else {
+        cata_assert( npc_crafter != nullptr );
+        item *queued_craft = craft_in_world.get_item();
+        queued_craft->set_var( "crafter", name );
+        queued_craft->set_var( "crafter_id", id.get_value() );
+        queued_craft->set_var( var_craft_queue_order,
+                               next_crafting_queue_order( *npc_crafter, *queue_location ) );
+
+        appended_to_queue = existing_queue_location.has_value();
+        if( !appended_to_queue ) {
+            player_activity npc_crafting( ACT_MULTIPLE_CRAFT );
+            npc_crafting.placement = get_map().getglobal( *queue_location );
+            assign_activity( npc_crafting );
+        }
     }
 
-    add_msg_player_or_npc(
-        pgettext( "in progress craft", "You start working on the %s." ),
-        pgettext( "in progress craft", "<npcname> starts working on the %s." ),
-        craft.tname() );
+    if( appended_to_queue || queued ) {
+        add_msg_player_or_npc(
+            _( "你把%s加入了制造清单。" ),
+            _( "<npcname>把%s加入了制造清单。" ),
+            craft.tname() );
+    } else {
+        add_msg_player_or_npc(
+            pgettext( "in progress craft", "You start working on the %s." ),
+            pgettext( "in progress craft", "<npcname> starts working on the %s." ),
+            craft.tname() );
+    }
 }
 
 bool Character::craft_skill_gain( const item &craft, const int &num_practice_ticks )
@@ -1593,19 +1898,28 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
                 popup(buffer, PF_NONE);
             }
             else {
-                add_msg_if_npc(_("<npcname> don't have the required components to continue crafting!"));
+                add_msg_if_npc( _( "<npcname>缺少继续制作所需的材料。" ) );
             }
             return false;
         }
 
-        std::string buffer = _( "Consume the missing components and continue crafting?" );
-        buffer += "\n";
-        buffer += continue_reqs.list_all();
-        if( !query_yn( buffer ) ) {
-            return false;
+        const bool automatic_npc_craft = is_npc();
+        if( !automatic_npc_craft ) {
+            std::string buffer = _( "Consume the missing components and continue crafting?" );
+            buffer += "\n";
+            buffer += continue_reqs.list_all();
+            if( !query_yn( buffer ) ) {
+                return false;
+            }
         }
 
         if( !continue_reqs.can_make_with_inventory( crafting_inventory(), no_rotten_filter, batch_size ) ) {
+            if( automatic_npc_craft ) {
+                add_msg_if_player_sees( pos(), m_bad,
+                                        _( "%s附近只有腐烂材料，自动制造不会使用这些材料。" ),
+                                        get_name() );
+                return false;
+            }
             if( !query_yn( _( "Some components required to continue are rotten.\n"
                               "Continue crafting anyway?" ) ) ) {
                 return false;
@@ -1615,6 +1929,12 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
 
         if( !continue_reqs.can_make_with_inventory( crafting_inventory(), no_favorite_filter,
                 batch_size ) ) {
+            if( automatic_npc_craft ) {
+                add_msg_if_player_sees( pos(), m_bad,
+                                        _( "%s附近只有收藏材料，自动制造不会使用这些材料。" ),
+                                        get_name() );
+                return false;
+            }
             if( !query_yn( _( "Some components required to continue are favorite.\n"
                               "Continue crafting anyway?" ) ) ) {
                 return false;
@@ -1650,6 +1970,10 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
         for( const auto &it : item_selections ) {
             craft.components.splice( craft.components.end(), consume_items( it, batch_size, filter ) );
         }
+        if( automatic_npc_craft ) {
+            add_msg_if_player_sees( pos(), m_info,
+                                    _( "%s补充了缺失材料并继续制作。" ), get_name() );
+        }
     }
 
     if( !craft.has_tools_to_continue() ) {
@@ -1684,7 +2008,7 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
                 popup(buffer, PF_NONE);
             }
             else {
-                add_msg_if_npc(_("<npcname> don't have the necessary tools to continue crafting!"));
+                add_msg_if_npc( _( "<npcname>缺少继续制作所需的工具。" ) );
             }
             return false;
         }
@@ -1862,6 +2186,9 @@ comp_selection<item_comp> Character::select_item_component( const std::vector<it
         } else if( !map_has.empty() ) {
             selected.use_from = usage_from::map;
             selected.comp = map_has[0].first;
+        } else if( !mixed.empty() ) {
+            selected.use_from = usage_from::both;
+            selected.comp = mixed[0].first;
         } else {
             debugmsg( "Attempted a recipe with no available components!" );
             selected.use_from = usage_from::cancel;
@@ -2241,7 +2568,8 @@ Character::select_tool_component( const std::vector<tool_comp> &tools, int batch
     return selected;
 }
 
-bool Character::craft_consume_tools( item &craft, int multiplier, bool start_craft )
+bool Character::craft_consume_tools( item &craft, int multiplier, bool start_craft,
+                                     const std::optional<tripoint> &workplace )
 {
     if( !craft.is_craft() ) {
         debugmsg( "craft_consume_tools() called on non-craft '%s.' Aborting.", craft.tname() );
@@ -2278,8 +2606,9 @@ bool Character::craft_consume_tools( item &craft, int multiplier, bool start_cra
     const std::vector<comp_selection<tool_comp>> &cached_tool_selections =
                 craft.get_cached_tool_selections();
 
+    const tripoint origin = workplace ? *workplace : pos();
     inventory map_inv;
-    map_inv.form_from_map( pos(), PICKUP_RANGE, this );
+    map_inv.form_from_map( origin, PICKUP_RANGE, this );
 
     for( const comp_selection<tool_comp> &tool_sel : cached_tool_selections ) {
         itype_id type = tool_sel.comp.type;
@@ -2307,7 +2636,8 @@ bool Character::craft_consume_tools( item &craft, int multiplier, bool start_cra
                     }
                     break;
                 case usage_from::both:
-                    if( !crafting_inventory().has_charges( type, count ) ) {
+                    if( !crafting_inventory( origin, PICKUP_RANGE, true ).has_charges(
+                            type, count ) ) {
                         add_msg_player_or_npc(
                             _( "You have insufficient %s charges and can't continue crafting." ),
                             _( "<npcname> has insufficient %s charges and can't continue crafting." ),
@@ -2335,7 +2665,7 @@ bool Character::craft_consume_tools( item &craft, int multiplier, bool start_cra
     for( const comp_selection<tool_comp> &tool : cached_tool_selections ) {
         comp_selection<tool_comp> to_consume = tool;
         to_consume.comp.count = calc_charges( to_consume.comp.count );
-        consume_tools( to_consume, 1 );
+        consume_tools( get_map(), to_consume, 1, origin, PICKUP_RANGE );
     }
     return true;
 }
@@ -2356,7 +2686,10 @@ void Character::consume_tools( map &m, const comp_selection<tool_comp> &tool, in
     const itype *tmp = item::find_type( tool.comp.type );
     int quantity = tool.comp.count * batch * tmp->charge_factor();
     if( tool.use_from == usage_from::both ) {
-        use_charges( tool.comp.type, quantity, radius );
+        m.use_charges( origin, radius, tool.comp.type, quantity, return_true<item>, bcp );
+        if( quantity > 0 ) {
+            use_charges( tool.comp.type, quantity );
+        }
     } else if( tool.use_from == usage_from::player ) {
         use_charges( tool.comp.type, quantity );
     } else if( tool.use_from == usage_from::map ) {
@@ -2973,6 +3306,26 @@ std::vector<npc *> Character::get_crafting_helpers() const
                rl_dist( guy.pos(), pos() ) < PICKUP_RANGE &&
                get_map().clear_path( pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
     } );
+}
+
+std::vector<Character *> Character::get_crafting_group() const
+{
+    std::vector<Character *> result;
+    result.push_back( const_cast<Character *>( this ) );
+
+    // NPC dialogue crafting deliberately remains a one-NPC command.  The
+    // group selector is intended for the normal menu opened by the avatar.
+    if( !is_avatar() ) {
+        return result;
+    }
+
+    std::vector<npc *> allies = g->get_npcs_if( [this]( const npc &guy ) {
+        return guy.is_ally( *this ) &&
+               rl_dist( guy.pos(), pos() ) < PICKUP_RANGE &&
+               get_map().clear_path( pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
+    } );
+    result.insert( result.end(), allies.begin(), allies.end() );
+    return result;
 }
 
 static bool is_anyone_crafting(const item_location& itm, const Character* you = nullptr)

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -3,6 +3,9 @@
 #define CATA_SRC_CRAFTING_H
 
 #include <list>
+#include <optional>
+
+#include "point.h"
 
 class Character;
 class item;
@@ -25,4 +28,9 @@ void remove_ammo( item &dis_item, Character &p );
 void remove_ammo( std::list<item> &dis_items, Character &p );
 
 void drop_or_handle( const item &newit, Character &p );
+
+// Resolve an explicitly selected workplace, or the best nearby workbench for automatic mode.
+// Marked crafting spots are preferred over ordinary workbenches.
+std::optional<tripoint> resolve_crafting_workplace(
+    const Character &crafter, const std::optional<tripoint> &selected_workplace );
 #endif // CATA_SRC_CRAFTING_H

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -8,12 +8,14 @@
 #include <iterator>
 #include <map>
 #include <new>
+#include <numeric>
 #include <set>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "calendar.h"
+#include "cata_assert.h"
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "character.h"
@@ -23,11 +25,16 @@
 #include "debug.h"
 #include "display.h"
 #include "flag.h"
+#include "game_constants.h"
 #include "input.h"
 #include "inventory.h"
 #include "item.h"
 #include "itype.h"
 #include "json.h"
+#include "line.h"
+#include "map.h"
+#include "mapdata.h"
+#include "messages.h"
 #include "localized_comparator.h"
 #include "npc.h"
 #include <optional>
@@ -35,6 +42,7 @@
 #include "output.h"
 #include "point.h"
 #include "popup.h"
+#include "player_activity.h"
 #include "recipe.h"
 #include "recipe_dictionary.h"
 #include "requirements.h"
@@ -46,9 +54,20 @@
 #include "ui.h"
 #include "ui_manager.h"
 #include "uistate.h"
+#include "veh_type.h"
+#include "vehicle.h"
+#include "vehicle_selector.h"
+#include "vpart_position.h"
 
 static const std::string flag_BLIND_EASY( "BLIND_EASY" );
 static const std::string flag_BLIND_HARD( "BLIND_HARD" );
+
+static const limb_score_id limb_score_manip( "manip" );
+static const string_id<struct furn_t> furn_f_ground_crafting_spot( "f_ground_crafting_spot" );
+static const field_type_str_id fd_crafting_spot( "fd_crafting_spot" );
+static const activity_id ACT_CRAFT( "ACT_CRAFT" );
+static const activity_id ACT_MULTIPLE_CRAFT( "ACT_MULTIPLE_CRAFT" );
+static const std::string var_craft_queue_order( "craft_queue_order" );
 
 class npc;
 
@@ -76,6 +95,594 @@ static const std::map<const CRAFTING_SPEED_STATE, translation> craft_speed_reaso
     {NORMAL_CRAFTING, to_translation( "craftable" )}
 };
 
+namespace
+{
+
+class crafting_uimenu
+{
+    public:
+        struct query_result {
+            int retval;
+            int selected;
+            std::string action;
+        };
+
+        explicit crafting_uimenu( int columns ) : column_count( columns ) {
+            cata_assert( columns >= 1 );
+            // Keep all manufacturing-setting pages the same size.  A slightly larger window is
+            // easier to use on Android and avoids visible jumping when switching pages.
+            menu.w_width_setup = []() {
+                return std::max( 40, std::min( TERMX - 4, 120 ) );
+            };
+            menu.w_height_setup = []() {
+                return std::max( 12, std::min( TERMY - 4, 26 ) );
+            };
+        }
+
+        void addentry( int retval, bool enabled, const std::vector<std::string> &columns ) {
+            cata_assert( static_cast<int>( columns.size() ) == column_count );
+            rows.push_back( { retval, enabled, columns } );
+        }
+
+        void set_header( const std::vector<std::string> &columns ) {
+            cata_assert( static_cast<int>( columns.size() ) == column_count );
+            header = columns;
+        }
+
+        void set_selected( int index ) {
+            menu.selected = index;
+        }
+
+        void set_title( const std::string &title ) {
+            menu.title = title;
+        }
+
+        void set_tabs( const std::vector<std::string> &labels, int current ) {
+            tabs = labels;
+            current_tab = current;
+        }
+
+        void set_column_weights( const std::vector<int> &weights ) {
+            cata_assert( static_cast<int>( weights.size() ) == column_count );
+            column_weights = weights;
+        }
+
+        void set_footer( const std::string &text ) {
+            menu.footer_text = text;
+        }
+
+        query_result query( bool allow_page_switch = false ) {
+            finalize();
+            if( allow_page_switch ) {
+                menu.additional_actions = {
+                    { "PREV_TAB", to_translation( "上一分页" ) },
+                    { "NEXT_TAB", to_translation( "下一分页" ) },
+                    { "UILIST.LEFT", to_translation( "上一分页" ) },
+                    { "UILIST.RIGHT", to_translation( "下一分页" ) }
+                };
+                menu.allow_additional = true;
+            }
+            menu.query();
+            return { menu.ret, menu.selected, menu.ret_act };
+        }
+
+    private:
+        struct row {
+            int retval;
+            bool enabled;
+            std::vector<std::string> columns;
+        };
+
+        static std::string pad_cell( const std::string &cell, int width ) {
+            const std::string trimmed = trim_by_length( cell, width );
+            return trimmed + std::string( std::max( 0, width - utf8_width( trimmed, true ) ), ' ' );
+        }
+
+        std::string format_columns( const std::vector<std::string> &columns,
+                                    const std::vector<int> &widths ) const {
+            std::string text;
+            for( int i = 0; i < column_count; ++i ) {
+                const std::string cell = trim_by_length( columns[i], widths[i] );
+                text += i + 1 == column_count ? cell : pad_cell( cell, widths[i] );
+            }
+            return text;
+        }
+
+        std::string format_tabs() const {
+            std::string result;
+            for( size_t i = 0; i < tabs.size(); ++i ) {
+                if( i > 0 ) {
+                    result += " ";
+                }
+                const std::string label = " " + tabs[i] + " ";
+                if( static_cast<int>( i ) == current_tab ) {
+                    result += colorize( "<" + label + ">", c_light_blue );
+                } else {
+                    // Keep the same visible width as the selected form so later tabs never move.
+                    result += " " + label + " ";
+                }
+            }
+            return result;
+        }
+
+        void finalize() {
+            menu.entries.clear();
+            std::vector<int> widths( column_count, 0 );
+            const auto include_widths = [&]( const std::vector<std::string> &columns ) {
+                for( int i = 0; i < column_count; ++i ) {
+                    widths[i] = std::max( widths[i], utf8_width( columns[i], true ) );
+                }
+            };
+            if( header ) {
+                include_widths( *header );
+            }
+            for( const row &entry : rows ) {
+                include_widths( entry.columns );
+            }
+
+            const int available_width = std::max( 40, std::min( TERMX - 8, 120 ) );
+            int spacing = 2;
+            if( column_count > 1 && available_width < column_count * 8 ) {
+                spacing = 1;
+            }
+            if( column_weights ) {
+                const int minimum_cell_width = 4;
+                const int usable_width = std::max( column_count * minimum_cell_width,
+                                                   available_width - spacing * ( column_count - 1 ) );
+                const int extra_width = usable_width - column_count * minimum_cell_width;
+                const int total_weight = std::accumulate( column_weights->begin(),
+                                         column_weights->end(), 0 );
+                int assigned = 0;
+                for( int i = 0; i < column_count; ++i ) {
+                    widths[i] = minimum_cell_width +
+                                ( i + 1 == column_count ? extra_width - assigned :
+                                  extra_width * ( *column_weights )[i] / total_weight );
+                    assigned += widths[i] - minimum_cell_width;
+                }
+            } else {
+                const int content_width = std::accumulate( widths.begin(), widths.end(), 0 );
+                const int free_width = available_width - content_width;
+                spacing = std::max( 1, std::min( 3,
+                                    column_count > 1 ? free_width / ( column_count - 1 ) : 0 ) );
+            }
+            for( int i = 0; i < column_count - 1; ++i ) {
+                widths[i] += spacing;
+            }
+
+            std::string menu_text;
+            if( !tabs.empty() ) {
+                menu_text = "  " + format_tabs();
+            }
+            if( header ) {
+                // uilist descriptions begin two cells left of entry text because entries reserve
+                // space for their numeric hotkey.  Prefixing two spaces keeps the columns aligned.
+                if( !menu_text.empty() ) {
+                    menu_text += "\n";
+                }
+                menu_text += "  " + format_columns( *header, widths );
+            }
+            menu.settext( menu_text );
+            for( const row &entry : rows ) {
+                menu.addentry( entry.retval, entry.enabled, -1,
+                               format_columns( entry.columns, widths ) );
+            }
+        }
+
+        int column_count;
+        std::optional<std::vector<std::string>> header;
+        std::optional<std::vector<int>> column_weights;
+        std::vector<std::string> tabs;
+        int current_tab = 0;
+        std::vector<row> rows;
+        uilist menu;
+};
+
+struct crafting_workplace {
+    std::optional<tripoint> location;
+    std::string name;
+    std::string type;
+    std::string detail;
+    bool selectable = true;
+    bool marked = false;
+};
+
+struct crafting_menu_defaults {
+    bool initialized = false;
+    character_id crafter;
+    std::optional<tripoint_abs_ms> workplace;
+};
+
+static crafting_menu_defaults last_crafting_settings;
+
+static const inventory &crafting_inventory_at( Character &crafter,
+        const std::optional<tripoint> &workplace )
+{
+    return workplace ? crafter.crafting_inventory( *workplace, PICKUP_RANGE, true ) :
+           crafter.crafting_inventory();
+}
+
+static float crafting_light_at( const Character &crafter, const recipe &rec,
+                                const std::optional<tripoint> &workplace )
+{
+    return crafter.lighting_craft_speed_multiplier( rec,
+            workplace ? *workplace : tripoint_zero );
+}
+
+static float crafting_speed_at( const Character &crafter, const recipe &rec,
+                                const std::optional<tripoint> &workplace )
+{
+    const float result = crafter.morale_crafting_speed_multiplier( rec ) *
+                         crafting_light_at( crafter, rec, workplace ) *
+                         crafter.get_limb_score( limb_score_manip );
+    return std::max( result, 0.0f );
+}
+
+static std::string workplace_distance_text( const Character &crafter, const tripoint &loc )
+{
+    const int level_delta = loc.z - crafter.posz();
+    if( level_delta > 0 ) {
+        return string_format( _( "上方 %d 层" ), level_delta );
+    }
+    if( level_delta < 0 ) {
+        return string_format( _( "下方 %d 层" ), -level_delta );
+    }
+    const int distance = rl_dist( crafter.pos(), loc );
+    if( distance == 0 ) {
+        return _( "脚下" );
+    }
+    return string_format( _( "%s %d 格" ),
+                          trim( direction_name( direction_from( crafter.pos(), loc ) ) ),
+                          distance );
+}
+
+static std::string workplace_name_at( const tripoint &location )
+{
+    map &here = get_map();
+    if( const std::optional<vpart_reference> vp = here.veh_at( location ).part_with_feature(
+                "WORKBENCH", true ) ) {
+        return vp->part().name();
+    }
+    if( here.furn( location ) == furn_f_ground_crafting_spot ) {
+        return _( "地面制造点" );
+    }
+    if( here.has_furn( location ) ) {
+        return here.furn( location ).obj().name();
+    }
+    return _( "指定地点" );
+}
+
+static bool is_marked_crafting_spot( const tripoint &location )
+{
+    map &here = get_map();
+    return here.furn( location ) == furn_f_ground_crafting_spot ||
+           here.get_field( location, fd_crafting_spot ) != nullptr;
+}
+
+static std::string workplace_description_at( const tripoint &location )
+{
+    map &here = get_map();
+    if( const std::optional<vpart_reference> vp = here.veh_at( location ).part_with_feature(
+                "WORKBENCH", true ) ) {
+        if( const std::optional<vpslot_workbench> &wb = vp->part().info().get_workbench_info() ) {
+            return string_format( _( "载具工作台，倍率 %.2f" ), wb->multiplier );
+        }
+        return _( "载具工作台" );
+    }
+    if( here.has_furn( location ) && here.furn( location ).obj().workbench ) {
+        const furn_t &furniture = here.furn( location ).obj();
+        const std::string type = here.furn( location ) == furn_f_ground_crafting_spot ?
+                                 _( "地面制造点" ) :
+                                 is_marked_crafting_spot( location ) ? _( "标记工作台" ) :
+                                 _( "家具工作台" );
+        return string_format( _( "%s，倍率 %.2f" ), type, furniture.workbench->multiplier );
+    }
+    return _( "指定地点" );
+}
+
+static bool has_adjacent_work_position( const tripoint &loc )
+{
+    map &here = get_map();
+    for( const tripoint &adj : here.points_in_radius( loc, 1 ) ) {
+        if( adj.z == loc.z && here.passable( adj ) && !here.dangerous_field_at( adj ) ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool can_reach_workplace( const Character &crafter, const tripoint &loc )
+{
+    if( crafter.posz() != loc.z ) {
+        return false;
+    }
+    if( square_dist( crafter.pos(), loc ) <= 1 ) {
+        return true;
+    }
+    if( crafter.is_avatar() ) {
+        return false;
+    }
+
+    map &here = get_map();
+    for( const tripoint &adj : here.points_in_radius( loc, 1 ) ) {
+        if( !here.passable( adj ) || here.dangerous_field_at( adj ) ) {
+            continue;
+        }
+        if( !here.route( crafter.pos(), adj, crafter.get_pathfinding_settings() ).empty() ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static std::vector<crafting_workplace> collect_crafting_workplaces(
+    Character &viewer, const std::vector<Character *> &crafting_group,
+    const std::optional<tripoint> &initial_workplace )
+{
+    map &here = get_map();
+    std::set<tripoint> locations;
+    if( initial_workplace ) {
+        locations.insert( *initial_workplace );
+    }
+
+    for( Character *member : crafting_group ) {
+        for( const tripoint &pt : here.points_in_radius( member->pos(), PICKUP_RANGE ) ) {
+            const bool furniture_workbench = here.has_furn( pt ) &&
+                                             static_cast<bool>( here.furn( pt ).obj().workbench );
+            const bool vehicle_workbench = static_cast<bool>( here.veh_at( pt ).part_with_feature(
+                                               "WORKBENCH", true ) );
+            if( furniture_workbench || vehicle_workbench ) {
+                locations.insert( pt );
+            }
+        }
+    }
+
+    for( const tripoint &pt : here.points_in_radius( viewer.pos(), ACTIVITY_SEARCH_DISTANCE ) ) {
+        if( is_marked_crafting_spot( pt ) ) {
+            locations.insert( pt );
+        }
+    }
+
+    std::vector<crafting_workplace> result;
+    result.push_back( { std::nullopt, _( "自动选择" ), _( "制作者身边" ),
+                        _( "最佳工作台或手持制作" ), true } );
+
+    for( const tripoint &loc : locations ) {
+        crafting_workplace entry;
+        entry.location = loc;
+        entry.marked = is_marked_crafting_spot( loc );
+        entry.selectable = !here.dangerous_field_at( loc ) && has_adjacent_work_position( loc );
+        if( const std::optional<vpart_reference> vp = here.veh_at( loc ).part_with_feature(
+                    "WORKBENCH", true ) ) {
+            entry.name = vp->part().name();
+            entry.type = _( "载具工作台" );
+            if( const std::optional<vpslot_workbench> &wb =
+                vp->part().info().get_workbench_info() ) {
+                entry.detail = string_format( _( "倍率 %.2f" ), wb->multiplier );
+            }
+        } else if( here.has_furn( loc ) ) {
+            const furn_t &furniture = here.furn( loc ).obj();
+            entry.name = here.furn( loc ) == furn_f_ground_crafting_spot ? _( "地面制造点" ) :
+                         furniture.name();
+            entry.type = here.furn( loc ) == furn_f_ground_crafting_spot ? _( "地面制造点" ) :
+                         entry.marked ? _( "标记工作台" ) : _( "家具工作台" );
+            if( furniture.workbench ) {
+                entry.detail = string_format( _( "倍率 %.2f" ), furniture.workbench->multiplier );
+            } else if( entry.marked ) {
+                entry.selectable = false;
+                entry.detail = _( "原家具已不再是工作台" );
+            }
+        } else {
+            entry.name = _( "地面" );
+            entry.type = entry.marked ? _( "失效制造点" ) : _( "指定地点" );
+            if( entry.marked ) {
+                entry.selectable = false;
+                entry.detail = _( "标记所在的工作台已不存在" );
+            }
+        }
+        result.push_back( std::move( entry ) );
+    }
+
+    std::stable_sort( result.begin() + 1, result.end(), [&]( const crafting_workplace &lhs,
+    const crafting_workplace & rhs ) {
+        if( lhs.marked != rhs.marked ) {
+            return lhs.marked;
+        }
+        const int lhs_distance = lhs.location ? rl_dist( viewer.pos(), *lhs.location ) : 0;
+        const int rhs_distance = rhs.location ? rl_dist( viewer.pos(), *rhs.location ) : 0;
+        if( lhs_distance != rhs_distance ) {
+            return lhs_distance < rhs_distance;
+        }
+        return localized_compare( lhs.name, rhs.name );
+    } );
+    return result;
+}
+
+static std::string workplace_detail_text( const crafting_workplace &workplace,
+        const Character &crafter )
+{
+    std::vector<std::string> parts;
+    if( !workplace.location ) {
+        const std::optional<tripoint> effective = resolve_crafting_workplace(
+                    crafter, std::nullopt );
+        if( effective ) {
+            parts.emplace_back( string_format( _( "自动采用：%s，%s" ),
+                                               workplace_name_at( *effective ),
+                                               workplace_description_at( *effective ) ) );
+        } else {
+            parts.emplace_back( _( "附近无工作台，将手持或在地面制造" ) );
+        }
+    } else {
+        parts.emplace_back( workplace.type );
+        if( !workplace.detail.empty() ) {
+            parts.emplace_back( workplace.detail );
+        }
+    }
+    if( !workplace.selectable ) {
+        parts.emplace_back( _( "附近没有安全站位" ) );
+    }
+    return enumerate_as_string( parts, enumeration_conjunction::none );
+}
+
+static std::string workplace_relative_text( const crafting_workplace &workplace,
+        const Character &crafter )
+{
+    if( workplace.location ) {
+        return workplace_distance_text( crafter, *workplace.location );
+    }
+    const std::optional<tripoint> effective = resolve_crafting_workplace( crafter, std::nullopt );
+    return effective ? workplace_distance_text( crafter, *effective ) : _( "脚下" );
+}
+
+static std::string selected_workplace_text( const Character &crafter,
+        const std::optional<tripoint> &selected_location,
+        const std::optional<tripoint> &effective_location )
+{
+    const std::string crafter_name = crafter.is_avatar() ? _( "你" ) : crafter.get_name();
+    if( selected_location ) {
+        return string_format( _( "%s，距%s%s" ), workplace_name_at( *selected_location ),
+                              crafter_name, workplace_distance_text( crafter, *selected_location ) );
+    }
+    if( effective_location ) {
+        return string_format( _( "自动选择（%s，距%s%s）" ),
+                              workplace_name_at( *effective_location ), crafter_name,
+                              workplace_distance_text( crafter, *effective_location ) );
+    }
+    return _( "自动选择（手持或地面制造）" );
+}
+
+static bool craft_is_assigned_to( const item &craft, const npc &who )
+{
+    if( !craft.is_craft() ) {
+        return false;
+    }
+    const std::string crafter_id = craft.get_var( "crafter_id", "" );
+    return ( !crafter_id.empty() && crafter_id == std::to_string( who.getID().get_value() ) ) ||
+           craft.get_var( "crafter", "" ) == who.name;
+}
+
+static std::optional<tripoint> npc_crafting_queue_location( const npc &who )
+{
+    map &here = get_map();
+    const auto location_from = [&]( const player_activity & act ) -> std::optional<tripoint> {
+        if( act.id() == ACT_MULTIPLE_CRAFT && act.placement != player_activity::invalid_place ) {
+            return here.bub_from_abs( act.placement ).raw();
+        }
+        return std::nullopt;
+    };
+
+    if( const std::optional<tripoint> current = location_from( who.activity ) ) {
+        return current;
+    }
+    for( const player_activity &queued_activity : who.backlog ) {
+        if( const std::optional<tripoint> queued = location_from( queued_activity ) ) {
+            return queued;
+        }
+    }
+    return std::nullopt;
+}
+
+static bool npc_has_crafting_queue_activity( const npc &who )
+{
+    return npc_crafting_queue_location( who ).has_value();
+}
+
+static std::vector<item_location> crafting_queue_items( npc &who,
+        const std::optional<tripoint> &selected_workplace )
+{
+    map &here = get_map();
+    const std::optional<tripoint> active_location = npc_crafting_queue_location( who );
+    const std::optional<tripoint> effective = active_location ? active_location :
+            resolve_crafting_workplace( who, selected_workplace );
+    const tripoint anchor = effective ? *effective : who.pos();
+    std::vector<item_location> result;
+
+    const auto include = [&]( item & candidate, const item_location & location ) {
+        if( craft_is_assigned_to( candidate, who ) &&
+            candidate.get_var( var_craft_queue_order, 0 ) > 0 ) {
+            result.push_back( location );
+        }
+    };
+
+    for( const tripoint &pt : here.points_in_radius( anchor, 2 ) ) {
+        for( item &candidate : here.i_at( pt ) ) {
+            include( candidate, item_location( map_cursor( pt ), &candidate ) );
+        }
+        if( const optional_vpart_position vp = here.veh_at( pt ) ) {
+            const int cargo_part = vp->vehicle().part_with_feature( vp->part_index(), "CARGO", false );
+            if( cargo_part >= 0 ) {
+                for( item &candidate : vp->vehicle().get_items( cargo_part ) ) {
+                    include( candidate, item_location( vehicle_cursor( vp->vehicle(), cargo_part ),
+                                                       &candidate ) );
+                }
+            }
+        }
+    }
+
+    std::stable_sort( result.begin(), result.end(), []( const item_location & lhs,
+    const item_location & rhs ) {
+        const int lhs_order = lhs->get_var( var_craft_queue_order, 0 );
+        const int rhs_order = rhs->get_var( var_craft_queue_order, 0 );
+        if( lhs_order != rhs_order ) {
+            return lhs_order < rhs_order;
+        }
+        return localized_compare( lhs->tname(), rhs->tname() );
+    } );
+    return result;
+}
+
+static bool npc_is_crafting_item( const npc &who, const item_location &candidate )
+{
+    if( who.activity.id() != ACT_CRAFT ) {
+        return false;
+    }
+    return std::any_of( who.activity.targets.begin(), who.activity.targets.end(),
+    [&]( const item_location & target ) {
+        return target == candidate;
+    } );
+}
+
+static bool edit_crafting_queue_item( npc &who, std::vector<item_location> &queue, size_t index )
+{
+    if( index >= queue.size() || !queue[index] ) {
+        return false;
+    }
+
+    const bool active = npc_is_crafting_item( who, queue[index] );
+    const bool previous_is_active = index > 0 && npc_is_crafting_item( who, queue[index - 1] );
+    uilist actions;
+    actions.title = queue[index]->get_making().result_name();
+    actions.addentry( 0, index > 0 && !active && !previous_is_active, 'u', _( "上移一项" ) );
+    actions.addentry( 1, index + 1 < queue.size() && !active, 'd', _( "下移一项" ) );
+    actions.addentry( 2, !active, 'r', _( "移出清单，保留制造中物品" ) );
+    actions.query();
+
+    if( actions.ret == 0 ) {
+        const int old_order = queue[index]->get_var( var_craft_queue_order, 0 );
+        const int previous_order = queue[index - 1]->get_var( var_craft_queue_order, 0 );
+        queue[index]->set_var( var_craft_queue_order, previous_order );
+        queue[index - 1]->set_var( var_craft_queue_order, old_order );
+        return true;
+    }
+    if( actions.ret == 1 ) {
+        const int old_order = queue[index]->get_var( var_craft_queue_order, 0 );
+        const int next_order = queue[index + 1]->get_var( var_craft_queue_order, 0 );
+        queue[index]->set_var( var_craft_queue_order, next_order );
+        queue[index + 1]->set_var( var_craft_queue_order, old_order );
+        return true;
+    }
+    if( actions.ret == 2 ) {
+        queue[index]->erase_var( "crafter" );
+        queue[index]->erase_var( "crafter_id" );
+        queue[index]->erase_var( var_craft_queue_order );
+        add_msg( m_info, _( "已将%s移出%s的制造清单，制造中物品仍留在工作地点。" ),
+                 queue[index]->get_making().result_name(), who.get_name() );
+        return true;
+    }
+    return false;
+}
+
+} // namespace
+
 // TODO: Convert these globals to handling categories via generic_factory?
 static std::vector<std::string> craft_cat_list;
 static std::map<std::string, std::vector<std::string> > craft_subcat_list;
@@ -83,8 +690,9 @@ static std::map<std::string, std::vector<std::string> > craft_subcat_list;
 static bool query_is_yes( const std::string &query );
 static int craft_info_width( int window_width );
 static void draw_hidden_amount( const catacurses::window &w, int amount, int num_recipe );
-static void draw_can_craft_indicator(const catacurses::window& w, const recipe& rec,
-    Character& crafter);
+static void draw_can_craft_indicator( const catacurses::window &w, const recipe &rec,
+                                     Character &crafter,
+                                     const std::optional<tripoint> &workplace );
 static std::map<size_t, inclusive_rectangle<point>> draw_recipe_tabs(const catacurses::window& w,
     const tab_list& tab, TAB_MODE mode,
     bool filtered_unread, std::map<std::string, bool>& unread);
@@ -93,6 +701,10 @@ static std::map<size_t, inclusive_rectangle<point>> draw_recipe_subtabs(
             size_t subtab,
             const recipe_subset &available_recipes, TAB_MODE mode,
             std::map<std::string, bool> &unread );
+
+static bool choose_crafting_settings( const std::vector<Character *> &crafting_group,
+        int &current_crafter, const std::vector<crafting_workplace> &workplaces,
+        std::optional<tripoint> &workplace, const recipe *rec );
 
 static std::string peek_related_recipe(const recipe* current, const recipe_subset& available,
     Character& crafter);
@@ -166,26 +778,40 @@ static bool cannot_gain_skill_or_prof(const Character& crafter, const recipe& re
 namespace
 {
 struct availability {
-    explicit availability(Character& _crafter, const recipe* r, int batch_size = 1) :
-        crafter(_crafter) {
+    explicit availability( Character &_crafter, const recipe *r, int batch_size = 1,
+                           const recipe_subset *known_recipes = nullptr,
+                           const std::optional<tripoint> &workplace = std::nullopt ) :
+        crafter( _crafter ) {
             rec = r;
-            const inventory& inv = crafter.crafting_inventory();
+            const inventory &inv = crafting_inventory_at( crafter, workplace );
             auto all_items_filter = r->get_component_filter( recipe_filter_flags::none );
             auto no_rotten_filter = r->get_component_filter( recipe_filter_flags::no_rotten );
             auto no_favorite_filter = r->get_component_filter( recipe_filter_flags::no_favorite );
             const deduped_requirement_data &req = r->deduped_requirements();
+            knows_recipe = known_recipes == nullptr || known_recipes->contains( r );
             has_all_skills = r->skill_used.is_null() ||
                 crafter.get_skill_level( r->skill_used ) >= r->get_difficulty(crafter);
-            has_proficiencies = r->character_has_required_proficiencies(crafter);
-            if( r->is_nested() ) {
-                can_craft = check_can_craft_nested(_crafter, *r );
-            } else {
-                can_craft = ( !r->is_practice() || has_all_skills ) && has_proficiencies &&
-                            req.can_make_with_inventory( inv, all_items_filter, batch_size, craft_flags::start_only );
+            for( const std::pair<const skill_id, int> &e : r->required_skills ) {
+                if( crafter.get_skill_level( e.first ) < e.second ) {
+                    has_all_skills = false;
+                    break;
+                }
             }
+            has_proficiencies = r->character_has_required_proficiencies(crafter);
+            has_light = crafting_light_at( crafter, *r, workplace ) > 0.0f;
+            has_morale = crafter.morale_crafting_speed_multiplier( *r ) > 0.0f;
+            workplace_usable = !workplace || ( !get_map().dangerous_field_at( *workplace ) &&
+                                has_adjacent_work_position( *workplace ) &&
+                                can_reach_workplace( crafter, *workplace ) );
             std::string reason;
-            if (crafter.is_npc() && !r->npc_can_craft(reason)) {
-                can_craft = false;
+            npc_allowed = !crafter.is_npc() || r->npc_can_craft( reason );
+            if( r->is_nested() ) {
+                can_craft = check_can_craft_nested( _crafter, *r, known_recipes, workplace );
+            } else {
+                can_craft = knows_recipe && ( !r->is_practice() || has_all_skills ) &&
+                            has_proficiencies && has_light && has_morale && npc_allowed &&
+                            workplace_usable && req.can_make_with_inventory(
+                                inv, all_items_filter, batch_size, craft_flags::start_only );
             }
             would_use_rotten = !req.can_make_with_inventory( inv, no_rotten_filter, batch_size,
                                craft_flags::start_only );
@@ -194,14 +820,10 @@ struct availability {
             would_not_benefit = r->is_practice() && cannot_gain_skill_or_prof(crafter, *r );
             is_nested_category = r->is_nested();
             const requirement_data &simple_req = r->simple_requirements();
-            apparently_craftable = ( !r->is_practice() || has_all_skills ) && has_proficiencies &&
-                                   simple_req.can_make_with_inventory( inv, all_items_filter, batch_size, craft_flags::start_only );
-            for( const std::pair<const skill_id, int> &e : r->required_skills ) {
-                if(crafter.get_skill_level( e.first ) < e.second ) {
-                    has_all_skills = false;
-                    break;
-                }
-            }
+            apparently_craftable = knows_recipe && ( !r->is_practice() || has_all_skills ) &&
+                                   has_proficiencies && has_light && has_morale && npc_allowed &&
+                                   workplace_usable && simple_req.can_make_with_inventory(
+                                       inv, all_items_filter, batch_size, craft_flags::start_only );
         }
         Character& crafter;
         bool can_craft;
@@ -212,6 +834,11 @@ struct availability {
         bool has_proficiencies;
         bool has_all_skills;
         bool is_nested_category;
+        bool knows_recipe;
+        bool has_light;
+        bool has_morale;
+        bool npc_allowed;
+        bool workplace_usable;
     private:
         const recipe *rec;
         mutable float proficiency_time_maluses = -1.0f;
@@ -266,11 +893,14 @@ struct availability {
             }
         }
 
-        static bool check_can_craft_nested(Character& _crafter, const recipe &r ) {
+        static bool check_can_craft_nested( Character &_crafter, const recipe &r,
+                                            const recipe_subset *known_recipes,
+                                            const std::optional<tripoint> &workplace ) {
             // recursively check if you can craft anything in the nest
             bool can_craft = false;
             for( const recipe_id &nested_r : r.nested_category_data ) {
-                if (availability(_crafter, &nested_r.obj()).can_craft) {
+                if( availability( _crafter, &nested_r.obj(), 1, known_recipes,
+                                  workplace ).can_craft ) {
                     return true;
                 }
             }
@@ -284,6 +914,8 @@ static std::vector<std::string> recipe_info(
     const recipe &recp,
     const availability &avail,
     Character &guy,
+    const std::optional<tripoint> &selected_workplace,
+    const std::optional<tripoint> &effective_workplace,
     const std::string &qry_comps,
     const int batch_size,
     const int fold_width,
@@ -311,10 +943,16 @@ static std::vector<std::string> recipe_info(
     }
 
     if( !recp.is_nested() ) {
-        const int expected_turns = guy.expected_time_to_craft( recp, batch_size )
-                                   / to_moves<int>( 1_turns );
-        oss << string_format( _( "Time to complete: <color_cyan>%s</color>\n" ),
-                              to_string( time_duration::from_turns( expected_turns ) ) );
+        const int assistants = guy.available_assistant_count( recp );
+        const float speed = crafting_speed_at( guy, recp, effective_workplace );
+        if( speed > 0.0f ) {
+            const int expected_turns = recp.batch_time( guy, batch_size, speed, assistants ) /
+                                       to_moves<int>( 1_turns );
+            oss << string_format( _( "Time to complete: <color_cyan>%s</color>\n" ),
+                                  to_string( time_duration::from_turns( expected_turns ) ) );
+        } else {
+            oss << _( "完成时间：<color_red>无法制作</color>\n" );
+        }
 
     }
 
@@ -336,7 +974,7 @@ static std::vector<std::string> recipe_info(
                           recp.has_flag( flag_BLIND_HARD ) ? _( "Hard" ) :
                           _( "Impossible" ) );
 
-    const inventory &crafting_inv = guy.crafting_inventory();
+    const inventory &crafting_inv = crafting_inventory_at( guy, effective_workplace );
     if( recp.result() ) {
         const int nearby_amount = crafting_inv.count_item( recp.result() );
         std::string nearby_string;
@@ -351,7 +989,24 @@ static std::vector<std::string> recipe_info(
         oss << string_format( _( "Nearby: %s\n" ), nearby_string );
     }
 
+    oss << string_format( _( "制作者：<color_cyan>%s</color>\n" ),
+                          guy.is_avatar() ? _( "你" ) : guy.get_name() );
+    oss << string_format( _( "工作地点：<color_cyan>%s</color>\n" ),
+                          selected_workplace_text( guy, selected_workplace, effective_workplace ) );
+
     const bool can_craft_this = avail.can_craft;
+    if( !can_craft_this && !avail.knows_recipe && !recp.is_nested() ) {
+        oss << _( "<color_red>当前制作者不知道这个配方。</color>\n" );
+    }
+    if( !can_craft_this && !avail.workplace_usable && !recp.is_nested() ) {
+        oss << _( "<color_red>当前制作者无法在所选工作地点开始制作。</color>\n" );
+    }
+    if( !can_craft_this && !avail.has_light && !recp.is_nested() ) {
+        oss << _( "<color_red>所选工作地点光照不足。</color>\n" );
+    }
+    if( !can_craft_this && !avail.has_morale && !recp.is_nested() ) {
+        oss << _( "<color_red>当前制作者的士气过低。</color>\n" );
+    }
     if( can_craft_this && avail.would_use_rotten ) {
         oss << _( "<color_red>Will use rotten ingredients</color>\n" );
     }
@@ -484,6 +1139,9 @@ static input_context make_crafting_context( bool highlight_unread_recipes )
 {
     input_context ctxt( "CRAFTING" );
     ctxt.register_cardinal();
+    // QUEUE_CRAFT defaults to q, which is also part of the global QUIT binding.  Input actions
+    // are resolved in registration order, so register it first to make q reliably add a queue item.
+    ctxt.register_action( "QUEUE_CRAFT" );
     ctxt.register_action( "QUIT" );
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "SCROLL_RECIPE_INFO_UP" );
@@ -502,6 +1160,8 @@ static input_context make_crafting_context( bool highlight_unread_recipes )
     ctxt.register_action( "HELP_RECIPE" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "CYCLE_BATCH" );
+    ctxt.register_action( "CHOOSE_CRAFTER" );
+    ctxt.register_action( "CHOOSE_CRAFTING_LOCATION" );
     ctxt.register_action( "RELATED_RECIPES" );
     ctxt.register_action( "HIDE_SHOW_RECIPE" );
     ctxt.register_action( "SELECT" );
@@ -517,7 +1177,7 @@ static input_context make_crafting_context( bool highlight_unread_recipes )
 
 class recipe_result_info_cache
 {       
-        Character& crafter;
+        Character *crafter;
         std::vector<iteminfo> info;
         const recipe *last_recipe = nullptr;
         int last_terminal_width = 0;
@@ -533,7 +1193,13 @@ class recipe_result_info_cache
         void insert_iteminfo_block_separator( std::vector<iteminfo> &info_vec,
                                               const std::string &title ) const;
     public:
-        explicit recipe_result_info_cache(Character& _crafter) : crafter(_crafter) {};
+        explicit recipe_result_info_cache( Character &_crafter ) : crafter( &_crafter ) {}
+        void set_crafter( Character &new_crafter ) {
+            if( crafter != &new_crafter ) {
+                crafter = &new_crafter;
+                last_recipe = nullptr;
+            }
+        }
         item_info_data get_result_data( const recipe *rec, int batch_size, int &scroll_pos,
                                         const catacurses::window &window );
 };
@@ -641,7 +1307,7 @@ item_info_data recipe_result_info_cache::get_result_data( const recipe *rec, con
     //Check if recipe result is a clothing item that can be properly fitted
     if( dummy_result.has_flag( flag_VARSIZE ) && !dummy_result.has_flag( flag_FIT ) ) {
         //Check if it can actually fit.  If so, list the fitted info
-        item::sizing general_fit = dummy_result.get_sizing(crafter);
+        item::sizing general_fit = dummy_result.get_sizing( *crafter );
         if( general_fit == item::sizing::small_sized_small_char ||
             general_fit == item::sizing::human_sized_human_char ||
             general_fit == item::sizing::big_sized_big_char ||
@@ -745,7 +1411,9 @@ struct recipe_info_cache {
 };
 
 static const std::vector<std::string> &cached_recipe_info( recipe_info_cache &info_cache,
-        const recipe &recp, const availability &avail, Character &guy, const std::string &qry_comps,
+        const recipe &recp, const availability &avail, Character &guy,
+        const std::optional<tripoint> &selected_workplace,
+        const std::optional<tripoint> &effective_workplace, const std::string &qry_comps,
         const int batch_size, const int fold_width, const nc_color &color )
 {
     if( info_cache.recp != &recp ||
@@ -756,7 +1424,9 @@ static const std::vector<std::string> &cached_recipe_info( recipe_info_cache &in
         info_cache.qry_comps = qry_comps;
         info_cache.batch_size = batch_size;
         info_cache.fold_width = fold_width;
-        info_cache.text = recipe_info( recp, avail, guy, qry_comps, batch_size, fold_width, color );
+        info_cache.text = recipe_info( recp, avail, guy, selected_workplace,
+                                      effective_workplace, qry_comps, batch_size,
+                                      fold_width, color );
     }
     return info_cache.text;
 }
@@ -900,8 +1570,10 @@ static bool mouse_in_window( std::optional<point> coord, const catacurses::windo
 
 static void recursively_expance_recipes( std::vector<const recipe *> &current,
         std::vector<int> &indent, std::map<const recipe *, availability> &availability_cache, int i,
-        Character &crafter, bool unread_recipes_first, bool highlight_unread_recipes,
-        const recipe_subset &available_recipes, const std::set<recipe_id> &hidden_recipes )
+        Character &crafter, const recipe_subset *known_recipes,
+        const std::optional<tripoint> &workplace, bool unread_recipes_first,
+        bool highlight_unread_recipes, const recipe_subset &available_recipes,
+        const std::set<recipe_id> &hidden_recipes )
 {
     std::vector<const recipe *> tmp;
     for( const recipe_id &nested : current[i]->nested_category_data ) {
@@ -912,7 +1584,9 @@ static void recursively_expance_recipes( std::vector<const recipe *> &current,
             tmp.push_back( &nested.obj() );
             indent.insert( indent.begin() + i + 1, indent[i] + 2 );
             if( !availability_cache.count( &nested.obj() ) ) {
-                availability_cache.emplace(&nested.obj(), availability(crafter, &nested.obj()));
+                availability_cache.emplace(
+                    &nested.obj(), availability( crafter, &nested.obj(), 1, known_recipes,
+                                                 workplace ) );
             }
         }
     }
@@ -951,7 +1625,9 @@ static void recursively_expance_recipes( std::vector<const recipe *> &current,
 // take the current and itterate through expanding each recipe
 static void expand_recipes( std::vector<const recipe *> &current,
                             std::vector<int> &indent, std::map<const recipe *, availability> &availability_cache,
-                            Character &crafter, bool unread_recipes_first, bool highlight_unread_recipes,
+                            Character &crafter, const recipe_subset *known_recipes,
+                            const std::optional<tripoint> &workplace,
+                            bool unread_recipes_first, bool highlight_unread_recipes,
                             const recipe_subset &available_recipes, const std::set<recipe_id> &hidden_recipes )
 {
     //TODO Make this more effecient
@@ -960,23 +1636,27 @@ static void expand_recipes( std::vector<const recipe *> &current,
             uistate.expanded_recipes.find( current[i]->ident() ) != uistate.expanded_recipes.end() ) {
             // add all the recipes from the nests
             recursively_expance_recipes( current, indent, availability_cache, i, crafter,
-                                         unread_recipes_first, highlight_unread_recipes, available_recipes, hidden_recipes );
+                                         known_recipes, workplace, unread_recipes_first,
+                                         highlight_unread_recipes, available_recipes,
+                                         hidden_recipes );
         }
     }
 }
 
-static std::string list_nested(Character& crafter, const recipe* rec,
-    const recipe_subset& available_recipes,
-    int indent = 0)
-{   
+static std::string list_nested( Character &crafter, const recipe *rec,
+                                const recipe_subset &available_recipes,
+                                const recipe_subset *known_recipes,
+                                const std::optional<tripoint> &workplace, int indent = 0 )
+{
     std::string description;
-    availability avail(crafter, rec);
+    availability avail( crafter, rec, 1, known_recipes, workplace );
     if (rec->is_nested()) {
         description += colorize(std::string(indent,
             ' ') + rec->result_name() + ":\n", avail.color());
         for (const recipe_id& r : rec->nested_category_data) {
             
-            description += list_nested(crafter, &r.obj(), available_recipes, indent + 2);
+            description += list_nested( crafter, &r.obj(), available_recipes, known_recipes,
+                                        workplace, indent + 2 );
         }
     }
     else if (available_recipes.contains(rec)) {
@@ -1017,10 +1697,13 @@ static bool selection_ok( const std::vector<const recipe *> &list, const int cur
     return false;
 }
 
-const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_recipe,
-    Character& crafter)
+crafting_selection select_crafter_and_crafting_recipe(
+    int &batch_size_out, const recipe_id &goto_recipe, Character &initial_crafter,
+    const std::optional<tripoint> &initial_workplace )
 {
-    recipe_result_info_cache result_info (crafter);
+    Character *crafter = &initial_crafter;
+    std::optional<tripoint> workplace = initial_workplace;
+    recipe_result_info_cache result_info( *crafter );
     recipe_info_cache r_info_cache;
     int recipe_info_scroll = 0;
     int item_info_scroll = 0;
@@ -1086,6 +1769,8 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
         add_action_desc( "RELATED_RECIPES", pgettext( "crafting gui", "Related" ) );
         add_action_desc( "TOGGLE_FAVORITE", pgettext( "crafting gui", "Favorite" ) );
         add_action_desc( "CYCLE_BATCH", pgettext( "crafting gui", "Batch" ) );
+        add_action_desc( "QUEUE_CRAFT", _( "加入清单" ) );
+        add_action_desc( "CHOOSE_CRAFTER", _( "制造设置" ) );
         add_action_desc( "HELP_KEYBINDINGS", pgettext( "crafting gui", "Keybindings" ) );
         keybinding_x = isWide ? 5 : 2;
         keybinding_tips = foldstring( enumerate_as_string( act_descs, enumeration_conjunction::none ),
@@ -1099,7 +1784,7 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
         w_head_tabs = catacurses::newwin( headHeight, ( width - header_info_width ), point( wStart, 0 ) );
         w_head_info = catacurses::newwin( headHeight, header_info_width,
                                           point( wStart + ( width - header_info_width ), 0 ) );
-        w_subhead = catacurses::newwin( subHeadHeight, width, point( wStart, 3 ) );
+        w_subhead = catacurses::newwin( subHeadHeight, width, point( wStart, headHeight ) );
         w_data = catacurses::newwin( dataHeight, width, point( wStart,
                                      headHeight + subHeadHeight ) );
 
@@ -1138,6 +1823,7 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
     bool recalc_unread = highlight_unread_recipes;
     bool keepline = false;
     bool done = false;
+    std::optional<static_popup> queue_notice;
     bool batch = false;
     bool show_hidden = false;
     size_t num_hidden = 0;
@@ -1147,13 +1833,75 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
     int last_line = -1;
     bool just_toggled_unread = false;
 
-    const inventory& crafting_inv = crafter.crafting_inventory();
-    const std::vector<npc*> helpers = crafter.get_crafting_helpers();
+    const std::vector<Character *> crafting_group = initial_crafter.get_crafting_group();
+    if( last_crafting_settings.initialized ) {
+        const auto remembered_crafter = std::find_if(
+                                            crafting_group.begin(), crafting_group.end(),
+        []( const Character *member ) {
+            return member->getID() == last_crafting_settings.crafter;
+        } );
+        if( remembered_crafter != crafting_group.end() ) {
+            Character *remembered = *remembered_crafter;
+            const npc *remembered_npc = remembered->as_npc();
+            const bool busy = remembered_npc != nullptr &&
+                              ( remembered_npc->has_activity() || !remembered->activity.is_null() );
+            const bool crafting_queue = remembered_npc != nullptr &&
+                                        npc_has_crafting_queue_activity( *remembered_npc );
+            if( remembered->is_avatar() ||
+                ( !remembered->in_sleep_state() && ( !busy || crafting_queue ) ) ) {
+                crafter = remembered;
+            }
+        }
+    }
+    int crafter_i = std::find( crafting_group.begin(), crafting_group.end(), crafter ) -
+                    crafting_group.begin();
+    result_info.set_crafter( *crafter );
     std::string filterstring;
 
-    const recipe_subset &available_recipes = crafter.get_available_recipes( crafting_inv,
-            &helpers );
+    std::optional<tripoint> remembered_workplace = initial_workplace;
+    if( !initial_workplace && last_crafting_settings.initialized &&
+        last_crafting_settings.workplace ) {
+        const tripoint local_workplace = get_map().getlocal( *last_crafting_settings.workplace );
+        if( get_map().inbounds( local_workplace ) ) {
+            remembered_workplace = local_workplace;
+        }
+    }
+    const std::vector<crafting_workplace> workplaces = collect_crafting_workplaces(
+                initial_crafter, crafting_group, remembered_workplace );
+    if( !initial_workplace && last_crafting_settings.initialized ) {
+        if( last_crafting_settings.workplace && remembered_workplace &&
+            std::any_of( workplaces.begin(), workplaces.end(),
+        [&remembered_workplace]( const crafting_workplace &entry ) {
+            return entry.location == remembered_workplace;
+        } ) ) {
+            workplace = remembered_workplace;
+        } else {
+            workplace = std::nullopt;
+        }
+    }
+
+    recipe_subset available_recipes;
+    std::map<Character *, recipe_subset> recipes_by_crafter;
+    const recipe_subset *known_recipes = nullptr;
     std::map<const recipe *, availability> availability_cache;
+    std::optional<tripoint> effective_workplace;
+    const auto rebuild_recipes = [&]() {
+        effective_workplace = resolve_crafting_workplace( *crafter, workplace );
+        available_recipes = recipe_subset();
+        recipes_by_crafter.clear();
+        for( Character *group_member : crafting_group ) {
+            const std::optional<tripoint> member_workplace = resolve_crafting_workplace(
+                        *group_member, workplace );
+            recipe_subset member_recipes = group_member->get_available_recipes(
+                                               crafting_inventory_at( *group_member,
+                                                       member_workplace ) );
+            available_recipes.include( member_recipes );
+            recipes_by_crafter.emplace( group_member, std::move( member_recipes ) );
+        }
+        known_recipes = &recipes_by_crafter.at( crafter );
+        availability_cache.clear();
+    };
+    rebuild_recipes();
 
     const std::string new_recipe_str = pgettext( "crafting gui", "NEW!" );
     const nc_color new_recipe_str_col = c_light_green;
@@ -1238,6 +1986,7 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
         if( !show_hidden ) {
             draw_hidden_amount( w_head_info, num_hidden, num_recipe );
         }
+        wnoutrefresh( w_head_info );
 
         // Clear the screen of recipe data, and draw it anew
         werase( w_data );
@@ -1313,7 +2062,7 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
         if( !current.empty() ) {
             const recipe &recp = *current[line];
 
-            draw_can_craft_indicator( w_head_info, recp ,crafter);
+            draw_can_craft_indicator( w_head_info, recp, *crafter, effective_workplace );
 
             const availability &avail = available[line];
             // border + padding + name + padding
@@ -1332,8 +2081,9 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
                 qry_comps = qry.substr( 2 );
             }
 
-            const std::vector<std::string> &info = cached_recipe_info( r_info_cache,
-                                                   recp, avail, crafter, qry_comps, batch_size, fold_width, color );
+            const std::vector<std::string> &info = cached_recipe_info(
+                        r_info_cache, recp, avail, *crafter, workplace, effective_workplace,
+                        qry_comps, batch_size, fold_width, color );
 
             const int total_lines = info.size();
             if( recipe_info_scroll < 0 ) {
@@ -1369,14 +2119,15 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
             const recipe *cur_recipe = current[line];
             werase( w_iteminfo );
             if( cur_recipe->is_practice() ) {
-                const std::string desc = practice_recipe_description( *cur_recipe, crafter );
+                const std::string desc = practice_recipe_description( *cur_recipe, *crafter );
                 fold_and_print( w_iteminfo, point_zero, item_info_width, c_light_gray, desc );
                 scrollbar().offset_x( item_info_width - 1 ).offset_y( 0 ).content_size( 1 ).viewport_size( getmaxy(
                             w_iteminfo ) ).apply( w_iteminfo );
                 wnoutrefresh( w_iteminfo );
             } else if( cur_recipe->is_nested() ) {
                 std::string desc = cur_recipe->description.translated() + "\n\n";;
-                desc += list_nested(crafter, cur_recipe, available_recipes);
+                desc += list_nested( *crafter, cur_recipe, available_recipes, known_recipes,
+                                     effective_workplace );
                 fold_and_print( w_iteminfo, point_zero, item_info_width, c_light_gray, desc );
                 scrollbar().offset_x( item_info_width - 1 ).offset_y( 0 ).content_size( 1 ).viewport_size( getmaxy(
                             w_iteminfo ) ).apply( w_iteminfo );
@@ -1411,7 +2162,8 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
                 current.clear();
                 for( int i = 1; i <= 50; i++ ) {
                     current.push_back( chosen );
-                    available.emplace_back(crafter, chosen, i);
+                    available.emplace_back( *crafter, chosen, i, known_recipes,
+                                            effective_workplace );
                 }
                 indent.assign( current.size(), 0 );
             } else {
@@ -1437,7 +2189,7 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
                 if( !filterstring.empty() ) {
                     std::string qry = trim(filterstring);
                     recipe_subset filtered_recipes =
-                        filter_recipes( available_recipes, qry, crafter, progress_callback );
+                        filter_recipes( available_recipes, qry, *crafter, progress_callback );
                     picking.insert( picking.end(), filtered_recipes.begin(), filtered_recipes.end() );
                 } else {
                     const std::pair<std::vector<const recipe *>, bool> result = recipes_from_cat( available_recipes,
@@ -1465,13 +2217,15 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
                 // cache recipe availability on first display
                 for( const recipe *e : current ) {
                     if( !availability_cache.count( e ) ) {
-                        availability_cache.emplace(e, availability(crafter, e));
+                        availability_cache.emplace(
+                            e, availability( *crafter, e, 1, known_recipes,
+                                             effective_workplace ) );
                     }
                 }
 
                 if( subtab.cur() != "CSC_*_RECENT" ) {
                     std::stable_sort( current.begin(), current.end(), [
-                       &crafter, &availability_cache, unread_recipes_first,
+                       crafter, &availability_cache, unread_recipes_first,
                        highlight_unread_recipes
                     ]( const recipe * const a, const recipe * const b ) {
                         if( highlight_unread_recipes && unread_recipes_first ) {
@@ -1494,16 +2248,18 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
                         if( a_name != b_name ) {
                             return localized_compare( a_name, b_name );
                         }
-                        return b->time_to_craft( crafter ) <
-                               a->time_to_craft( crafter );
+                        return b->time_to_craft( *crafter ) <
+                               a->time_to_craft( *crafter );
                     } );
                 }
 
                 // set up indents and append the expanded entries
                 // have to do this after we sort the list
                 indent.assign( current.size(), 0 );
-                expand_recipes( current, indent, availability_cache, crafter, unread_recipes_first,
-                                highlight_unread_recipes, available_recipes, uistate.hidden_recipes );
+                expand_recipes( current, indent, availability_cache, *crafter, known_recipes,
+                                effective_workplace, unread_recipes_first,
+                                highlight_unread_recipes, available_recipes,
+                                uistate.hidden_recipes );
 
                 std::transform( current.begin(), current.end(),
                 std::back_inserter( available ), [&]( const recipe * e ) {
@@ -1543,7 +2299,11 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
         just_toggled_unread = false;
         ui_manager::redraw();
         const int scroll_item_info_lines = catacurses::getmaxy( w_iteminfo ) - 4;
+        const bool dismiss_queue_notice = queue_notice.has_value();
         std::string action = ctxt.handle_input();
+        if( dismiss_queue_notice ) {
+            queue_notice.reset();
+        }
         const int recmax = static_cast<int>( current.size() );
         const int scroll_rate = recmax > 20 ? 10 : 3;
 
@@ -1681,6 +2441,41 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
         } else if( action == "END" ) {
             line = -1;
             user_moved_line = highlight_unread_recipes;
+        } else if( action == "QUEUE_CRAFT" ) {
+            if( available.empty() || line < 0 || static_cast<size_t>( line ) >= current.size() ||
+                current[line]->is_nested() || !available[line].can_craft ) {
+                query_popup()
+                .message( "%s", _( "当前配方不能加入制造清单。" ) )
+                .option( "QUIT" )
+                .query();
+            } else if( crafter->is_avatar() ) {
+                popup( _( "制造清单目前只用于附近的NPC盟友。" ), PF_NONE );
+            } else {
+                const int queue_batch_size = batch ? line + 1 : 1;
+                const std::string queued_name = current[line]->result_name();
+                if( crafter->check_eligible_containers_for_crafting( *current[line],
+                        queue_batch_size ) &&
+                    crafter->queue_craft( current[line]->ident(), queue_batch_size, workplace ) ) {
+                    queue_notice.emplace();
+                    queue_notice->on_top( true )
+                    .default_color( c_light_green )
+                    .message( _( "已加入%s的制造清单：%s × %d。" ),
+                              crafter->get_name(), queued_name, queue_batch_size );
+                    uistate.read_recipes.insert( current[line]->ident() );
+                    rebuild_recipes();
+                    result_info.set_crafter( *crafter );
+                    r_info_cache.recp = nullptr;
+                    if( batch ) {
+                        batch = false;
+                        line = batch_line;
+                    }
+                    recalc = true;
+                    recalc_unread = highlight_unread_recipes;
+                    keepline = true;
+                    recipe_info_scroll = 0;
+                    item_info_scroll = 0;
+                }
+            }
         } else if( action == "CONFIRM" ) {
             if( available.empty() || ( !available[line].can_craft && !current[line]->is_nested() ) ) {
                 query_popup()
@@ -1689,14 +2484,40 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
                 .query();
             } else if( current[line]->is_nested() ) {
                 nested_toggle( current[line]->ident(), recalc, keepline );
-            } else if( !crafter.check_eligible_containers_for_crafting( *current[line],
+            } else if( !crafter->check_eligible_containers_for_crafting( *current[line],
                        batch ? line + 1 : 1 ) ) {
                 // popup is already inside check
             } else {
-                chosen = current[line];
-                batch_size_out = batch ? line + 1 : 1;
-                done = true;
-                uistate.read_recipes.insert( chosen->ident() );
+                npc *selected_npc = crafter->as_npc();
+                const int selected_batch_size = batch ? line + 1 : 1;
+                if( selected_npc != nullptr && npc_has_crafting_queue_activity( *selected_npc ) ) {
+                    const std::string queued_name = current[line]->result_name();
+                    if( crafter->queue_craft( current[line]->ident(), selected_batch_size, workplace ) ) {
+                        queue_notice.emplace();
+                        queue_notice->on_top( true )
+                        .default_color( c_light_green )
+                        .message( _( "已加入%s的制造清单：%s × %d。" ),
+                                  crafter->get_name(), queued_name, selected_batch_size );
+                        uistate.read_recipes.insert( current[line]->ident() );
+                        rebuild_recipes();
+                        result_info.set_crafter( *crafter );
+                        r_info_cache.recp = nullptr;
+                        if( batch ) {
+                            batch = false;
+                            line = batch_line;
+                        }
+                        recalc = true;
+                        recalc_unread = highlight_unread_recipes;
+                        keepline = true;
+                        recipe_info_scroll = 0;
+                        item_info_scroll = 0;
+                    }
+                } else {
+                    chosen = current[line];
+                    batch_size_out = selected_batch_size;
+                    done = true;
+                    uistate.read_recipes.insert( chosen->ident() );
+                }
             }
         } else if( action == "HELP_RECIPE" && selection_ok( current, line, false ) ) {
             uistate.read_recipes.insert( current[line]->ident() );
@@ -1783,6 +2604,25 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
                 keepline = true;
             }
             recalc = true;
+        } else if( action == "CHOOSE_CRAFTER" || action == "CHOOSE_CRAFTING_LOCATION" ) {
+            const recipe *selected_recipe =
+                line >= 0 && static_cast<size_t>( line ) < current.size() ? current[line] : nullptr;
+            if( choose_crafting_settings( crafting_group, crafter_i, workplaces, workplace,
+                                          selected_recipe ) ) {
+                crafter = crafting_group[crafter_i];
+                rebuild_recipes();
+                result_info.set_crafter( *crafter );
+                r_info_cache.recp = nullptr;
+                if( batch ) {
+                    batch = false;
+                    line = batch_line;
+                }
+                recalc = true;
+                recalc_unread = highlight_unread_recipes;
+                keepline = true;
+                recipe_info_scroll = 0;
+                item_info_scroll = 0;
+            }
         } else if( action == "TOGGLE_FAVORITE" && selection_ok( current, line, true ) ) {
             keepline = true;
             recalc = filterstring.empty() && subtab.cur() == "CSC_*_FAVORITE";
@@ -1868,7 +2708,8 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
             recalc_unread = highlight_unread_recipes;
             ui.invalidate_ui();
 
-            std::string recipe_name = peek_related_recipe(current[line], available_recipes, crafter);
+            std::string recipe_name = peek_related_recipe( current[line], available_recipes,
+                                      *crafter );
             if( !recipe_name.empty() ) {
                 filterstring = recipe_name;
                 recalc = true;
@@ -1885,7 +2726,279 @@ const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_
         }
     } while( !done );
 
-    return chosen;
+    last_crafting_settings.initialized = true;
+    last_crafting_settings.crafter = crafter->getID();
+    last_crafting_settings.workplace = workplace ?
+            std::optional<tripoint_abs_ms>( tripoint_abs_ms( get_map().getabs( *workplace ) ) ) :
+            std::nullopt;
+
+    return { chosen ? crafter : nullptr, chosen, workplace };
+}
+
+static bool choose_crafting_settings( const std::vector<Character *> &crafting_group,
+        int &current_crafter, const std::vector<crafting_workplace> &workplaces,
+        std::optional<tripoint> &workplace, const recipe *rec )
+{
+    struct option_status {
+        std::string craftable = "-";
+        std::string missing = "-";
+        std::string condition;
+    };
+
+    const auto summarize = [&]( Character &candidate,
+                                const std::optional<tripoint> &candidate_workplace ) {
+        const std::optional<tripoint> effective_candidate_workplace = resolve_crafting_workplace(
+                    candidate, candidate_workplace );
+        const npc *candidate_npc = candidate.as_npc();
+        const bool asleep = candidate.in_sleep_state();
+        const bool queue_busy = candidate_npc != nullptr &&
+                                npc_has_crafting_queue_activity( *candidate_npc );
+        const bool busy = candidate_npc != nullptr &&
+                          ( candidate_npc->has_activity() || !candidate.activity.is_null() );
+        std::vector<std::string> conditions = { asleep ? _( "正在睡觉" ) :
+                                                queue_busy ? _( "正在制造" ) :
+                                                busy ? _( "正在忙碌" ) : _( "空闲" ) };
+        if( candidate.get_fatigue() >= fatigue_levels::TIRED ) {
+            conditions.emplace_back( _( "疲倦" ) );
+        }
+        if( candidate.get_morale_level() < 0 ) {
+            conditions.emplace_back( _( "士气低落" ) );
+        }
+        if( candidate.get_perceived_pain() > 0 ) {
+            conditions.emplace_back( _( "疼痛" ) );
+        }
+        option_status result;
+        result.condition = enumerate_as_string( conditions, enumeration_conjunction::none );
+        if( rec == nullptr || rec->is_nested() ) {
+            return result;
+        }
+
+        if( candidate_npc != nullptr ) {
+            const std::optional<tripoint> queue_location = npc_crafting_queue_location( *candidate_npc );
+            const tripoint desired_location = effective_candidate_workplace ?
+                                              *effective_candidate_workplace : candidate.pos();
+            if( queue_location && *queue_location != desired_location ) {
+                result.craftable = colorize( _( "否" ), c_red );
+                result.missing = _( "清单绑定其他地点" );
+                return result;
+            }
+        }
+
+        recipe_subset candidate_recipes = candidate.get_available_recipes(
+                                              crafting_inventory_at( candidate,
+                                                      effective_candidate_workplace ) );
+        const availability avail( candidate, rec, 1, &candidate_recipes,
+                                  effective_candidate_workplace );
+        const inventory &inv = crafting_inventory_at( candidate, effective_candidate_workplace );
+        const bool has_requirements = rec->deduped_requirements().can_make_with_inventory(
+                                          inv,
+                                          rec->get_component_filter( recipe_filter_flags::none ),
+                                          1, craft_flags::start_only );
+        std::vector<std::string> missing;
+        if( !avail.knows_recipe ) {
+            missing.emplace_back( _( "配方" ) );
+        }
+        if( !has_requirements ) {
+            missing.emplace_back( _( "工具或材料" ) );
+        }
+        if( !avail.has_all_skills ) {
+            missing.emplace_back( _( "技能" ) );
+        }
+        if( !avail.has_proficiencies ) {
+            missing.emplace_back( _( "熟练度" ) );
+        }
+        if( !avail.has_light ) {
+            missing.emplace_back( _( "光照" ) );
+        }
+        if( !avail.has_morale ) {
+            missing.emplace_back( _( "士气" ) );
+        }
+        if( !avail.npc_allowed ) {
+            missing.emplace_back( _( "NPC限制" ) );
+        }
+        if( !avail.workplace_usable ) {
+            missing.emplace_back( candidate.is_avatar() ? _( "需靠近工作地点" ) :
+                                  _( "无法到达工作地点" ) );
+        }
+        result.craftable = avail.can_craft ? colorize( _( "是" ), c_green ) :
+                           colorize( _( "否" ), c_red );
+        result.missing = missing.empty() ? "-" :
+                         enumerate_as_string( missing, enumeration_conjunction::none );
+        return result;
+    };
+
+    enum class settings_page : int {
+        crafter,
+        workplace,
+        queue
+    };
+
+    const int original_crafter = current_crafter;
+    const std::optional<tripoint> original_workplace = workplace;
+    settings_page page = settings_page::crafter;
+    int crafter_selected_row = current_crafter;
+    int workplace_selected_row = 0;
+    int queue_selected_row = 0;
+    for( size_t i = 0; i < workplaces.size(); ++i ) {
+        if( workplaces[i].location == workplace ) {
+            workplace_selected_row = static_cast<int>( i );
+            break;
+        }
+    }
+
+    while( true ) {
+        Character &selected_crafter = *crafting_group[current_crafter];
+        const int columns = page == settings_page::workplace ? 5 :
+                            page == settings_page::queue ? 3 : 4;
+        crafting_uimenu menu( columns );
+        menu.set_title( _( "制造设置" ) );
+        menu.set_tabs( { _( "制作者" ), _( "工作地点" ), _( "制造清单" ) },
+                       static_cast<int>( page ) );
+
+        if( page == settings_page::crafter ) {
+            menu.set_column_weights( { 34, 14, 28, 24 } );
+            menu.set_header( { _( "制作者" ), _( "可制作" ), _( "缺少" ), _( "状态" ) } );
+            const std::optional<tripoint> effective = resolve_crafting_workplace(
+                        selected_crafter, workplace );
+            menu.set_footer( string_format(
+                                 _( "Tab／Shift+Tab切换分页，回车选择，Esc返回。当前工作地点：%s" ),
+                                 selected_workplace_text( selected_crafter, workplace,
+                                         effective ) ) );
+
+            for( size_t i = 0; i < crafting_group.size(); ++i ) {
+                Character *candidate = crafting_group[i];
+                const npc *candidate_npc = candidate->as_npc();
+                const bool asleep = candidate->in_sleep_state();
+                const bool busy = candidate_npc != nullptr &&
+                                  ( candidate_npc->has_activity() ||
+                                    !candidate->activity.is_null() );
+                const bool queue_busy = candidate_npc != nullptr &&
+                                        npc_has_crafting_queue_activity( *candidate_npc );
+                const bool selectable = candidate->is_avatar() ||
+                                        ( !asleep && ( !busy || queue_busy ) );
+                const option_status status = summarize( *candidate, workplace );
+                const std::string marker = static_cast<int>( i ) == current_crafter ?
+                                           colorize( "* ", c_green ) : "  ";
+                menu.addentry( 1000 + static_cast<int>( i ), selectable,
+                               { marker + ( candidate->is_avatar() ? _( "你" ) :
+                                            candidate->get_name() ),
+                                 status.craftable, status.missing, status.condition } );
+            }
+            menu.set_selected( crafter_selected_row );
+        } else if( page == settings_page::workplace ) {
+            menu.set_column_weights( { 24, 10, 22, 18, 26 } );
+            const std::string crafter_name = selected_crafter.is_avatar() ? _( "你" ) :
+                                             selected_crafter.get_name();
+            menu.set_header( { _( "工作地点" ), _( "可制作" ), _( "缺少" ),
+                               string_format( _( "距%s" ), crafter_name ), _( "说明" ) } );
+            menu.set_footer( _( "Tab／Shift+Tab切换分页，回车选择，Esc返回。蓝色名称表示已标记工作台。" ) );
+
+            const npc *selected_npc = selected_crafter.as_npc();
+            const std::optional<tripoint> queue_location = selected_npc ?
+                    npc_crafting_queue_location( *selected_npc ) : std::nullopt;
+            for( size_t i = 0; i < workplaces.size(); ++i ) {
+                const crafting_workplace &candidate_workplace = workplaces[i];
+                option_status status = summarize( selected_crafter, candidate_workplace.location );
+                const std::optional<tripoint> effective = resolve_crafting_workplace(
+                            selected_crafter, candidate_workplace.location );
+                const tripoint desired_location = effective ? *effective : selected_crafter.pos();
+                const bool queue_matches = !queue_location || *queue_location == desired_location;
+                const bool selectable = candidate_workplace.selectable && queue_matches;
+                if( !queue_matches ) {
+                    status.craftable = colorize( _( "否" ), c_red );
+                    status.missing = _( "清单绑定其他地点" );
+                }
+                const std::string marker = candidate_workplace.location == workplace ?
+                                           colorize( "* ", c_green ) : "  ";
+                const std::string displayed_name = candidate_workplace.marked ?
+                        colorize( candidate_workplace.name, c_light_blue ) : candidate_workplace.name;
+                menu.addentry( 2000 + static_cast<int>( i ), selectable,
+                               { marker + displayed_name,
+                                 status.craftable, status.missing,
+                                 workplace_relative_text( candidate_workplace, selected_crafter ),
+                                 workplace_detail_text( candidate_workplace, selected_crafter ) } );
+            }
+            menu.set_selected( workplace_selected_row );
+        } else {
+            menu.set_column_weights( { 58, 14, 28 } );
+            menu.set_header( { _( "制造项目" ), _( "批量" ), _( "状态" ) } );
+            npc *selected_npc = selected_crafter.as_npc();
+            if( selected_npc == nullptr ) {
+                menu.set_footer( _( "制造清单目前只用于NPC盟友。Tab／Shift+Tab切换分页，Esc返回。" ) );
+                menu.addentry( 3999, false, { _( "请选择一名NPC制作者" ), "-", "-" } );
+            } else {
+                std::vector<item_location> queue = crafting_queue_items( *selected_npc, workplace );
+                menu.set_footer( _( "回车管理项目，上下选择，Tab／Shift+Tab切换分页，Esc返回。" ) );
+                if( queue.empty() ) {
+                    menu.addentry( 3999, false, { _( "制造清单为空，按q从配方列表加入" ),
+                                                 "-", _( "空闲" ) } );
+                } else {
+                    for( size_t i = 0; i < queue.size(); ++i ) {
+                        item &queued_item = *queue[i];
+                        const bool active = npc_is_crafting_item( *selected_npc, queue[i] );
+                        const int progress = std::max( 0, std::min( 100,
+                                                     queued_item.item_counter / 100000 ) );
+                        const std::string status = active ?
+                                string_format( _( "制作中 %d%%" ), progress ) : _( "等待中" );
+                        menu.addentry( 3000 + static_cast<int>( i ), true,
+                                       { queued_item.get_making().result_name(),
+                                         string_format( "%d", queued_item.get_making_batch_size() ),
+                                         status } );
+                    }
+                }
+            }
+            menu.set_selected( queue_selected_row );
+        }
+
+        const crafting_uimenu::query_result result = menu.query( true );
+        if( result.retval == UILIST_ADDITIONAL &&
+            ( result.action == "PREV_TAB" || result.action == "NEXT_TAB" ||
+              result.action == "UILIST.LEFT" || result.action == "UILIST.RIGHT" ) ) {
+            const bool next_page = result.action == "NEXT_TAB" ||
+                                   result.action == "UILIST.RIGHT";
+            const int direction = next_page ? 1 : -1;
+            int page_index = static_cast<int>( page );
+            page_index = ( page_index + direction + 3 ) % 3;
+            if( page == settings_page::crafter ) {
+                crafter_selected_row = result.selected;
+            } else if( page == settings_page::workplace ) {
+                workplace_selected_row = result.selected;
+            } else {
+                queue_selected_row = result.selected;
+            }
+            page = static_cast<settings_page>( page_index );
+            continue;
+        }
+        if( result.retval == UILIST_CANCEL ) {
+            break;
+        }
+        const int choice = result.retval;
+        if( choice >= 1000 && choice < 2000 ) {
+            const int selected = choice - 1000;
+            if( selected >= 0 && static_cast<size_t>( selected ) < crafting_group.size() ) {
+                current_crafter = selected;
+                crafter_selected_row = selected;
+            }
+        } else if( choice >= 2000 && choice < 3000 ) {
+            const int selected = choice - 2000;
+            if( selected >= 0 && static_cast<size_t>( selected ) < workplaces.size() ) {
+                workplace = workplaces[selected].location;
+                workplace_selected_row = selected;
+            }
+        } else if( choice >= 3000 && choice < 3999 ) {
+            npc *selected_npc = selected_crafter.as_npc();
+            if( selected_npc != nullptr ) {
+                std::vector<item_location> queue = crafting_queue_items( *selected_npc, workplace );
+                const size_t selected = static_cast<size_t>( choice - 3000 );
+                if( edit_crafting_queue_item( *selected_npc, queue, selected ) ) {
+                    queue_selected_row = std::max( 0, std::min( result.selected,
+                                                      static_cast<int>( queue.size() ) - 1 ) );
+                }
+            }
+        }
+    }
+
+    return current_crafter != original_crafter || workplace != original_workplace;
 }
 
 std::string peek_related_recipe(const recipe* current, const recipe_subset& available,
@@ -2052,21 +3165,23 @@ static void draw_hidden_amount( const catacurses::window &w, int amount, int num
 }
 
 // Anchors top-right
-static void draw_can_craft_indicator(const catacurses::window& w, const recipe& rec,
-    Character& crafter)
+static void draw_can_craft_indicator( const catacurses::window &w, const recipe &rec,
+                                     Character &crafter,
+                                     const std::optional<tripoint> &workplace )
 {
-    if (crafter.lighting_craft_speed_multiplier(rec) <= 0.0f) {
+    const float speed = crafting_speed_at( crafter, rec, workplace );
+    if( crafting_light_at( crafter, rec, workplace ) <= 0.0f ) {
         right_print( w, 0, 1, i_red, craft_speed_reason_strings.at( TOO_DARK_TO_CRAFT ).translated() );
-    } else if( crafter.crafting_speed_multiplier( rec ) <= 0.0f ) {
+    } else if( speed <= 0.0f ) {
         right_print( w, 0, 1, i_red, craft_speed_reason_strings.at( TOO_SLOW_TO_CRAFT ).translated() );
-    } else if( crafter.crafting_speed_multiplier( rec ) < 1.0f ) {
+    } else if( speed < 1.0f ) {
         right_print( w, 0, 1, i_yellow,
                      string_format( craft_speed_reason_strings.at( SLOW_BUT_CRAFTABLE ).translated(),
-                                    static_cast<int>( crafter.crafting_speed_multiplier( rec ) * 100 ) ) );
-    } else if( crafter.crafting_speed_multiplier( rec ) > 1.0f ) {
+                                    static_cast<int>( speed * 100 ) ) );
+    } else if( speed > 1.0f ) {
         right_print( w, 0, 1, i_green,
                      string_format( craft_speed_reason_strings.at( FAST_CRAFTING ).translated(),
-                                    static_cast<int>( crafter.crafting_speed_multiplier( rec ) * 100 ) ) );
+                                    static_cast<int>( speed * 100 ) ) );
     } else {
         right_print( w, 0, 1, i_green, craft_speed_reason_strings.at( NORMAL_CRAFTING ).translated() );
     }

--- a/src/crafting_gui.h
+++ b/src/crafting_gui.h
@@ -3,17 +3,31 @@
 #define CATA_SRC_CRAFTING_GUI_H
 
 #include <iosfwd>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "point.h"
 #include "type_id.h"
 
 class Character;
 class JsonObject;
 class recipe;
 
-const recipe* select_crafting_recipe(int& batch_size_out, const recipe_id& goto_recipe,
-    Character& crafter);
+struct crafting_selection {
+    Character *crafter = nullptr;
+    const recipe *rec = nullptr;
+    std::optional<tripoint> workplace;
+};
+
+/**
+ * Open the crafting menu and choose the recipe, nearby allied crafter and
+ * workplace.  A null workplace keeps the original automatic behavior.
+ */
+crafting_selection select_crafter_and_crafting_recipe(
+    int &batch_size_out, const recipe_id &goto_recipe, Character &initial_crafter,
+    const std::optional<tripoint> &initial_workplace );
 
 void load_recipe_category( const JsonObject &jsobj );
 void reset_recipe_categories();

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -133,8 +133,11 @@ static const efftype_id effect_teleglow( "teleglow" );
 static const efftype_id effect_tetanus( "tetanus" );
 static const efftype_id effect_weak_antibiotic( "weak_antibiotic" );
 
+static const field_type_str_id fd_crafting_spot( "fd_crafting_spot" );
+
 static const furn_str_id furn_f_diesel_tank( "f_diesel_tank" );
 static const furn_str_id furn_f_gas_tank( "f_gas_tank" );
+static const furn_str_id furn_f_ground_crafting_spot( "f_ground_crafting_spot" );
 static const furn_str_id furn_f_metal_smoking_rack( "f_metal_smoking_rack" );
 static const furn_str_id furn_f_metal_smoking_rack_active( "f_metal_smoking_rack_active" );
 static const furn_str_id furn_f_rope_up( "f_rope_up" );
@@ -6519,7 +6522,9 @@ void iexamine::open_safe( Character &, const tripoint &examp )
 
 void iexamine::workbench( Character &you, const tripoint &examp )
 {
-    if( get_option<bool>( "WORKBENCH_ALL_OPTIONS" ) ) {
+    if( get_option<bool>( "WORKBENCH_ALL_OPTIONS" ) ||
+        get_map().furn( examp ) == furn_f_ground_crafting_spot ||
+        get_map().get_field( examp, fd_crafting_spot ) != nullptr ) {
         workbench_internal( you, examp, std::nullopt );
     } else {
         if( !get_map().i_at( examp ).empty() ) {
@@ -6573,7 +6578,8 @@ void iexamine::workbench_internal( Character &you, const tripoint &examp,
         start_long_craft,
         work_on_craft,
         get_items,
-        undeploy
+        undeploy,
+        remove_crafting_spot
     };
 
     amenu.text = string_format( pgettext( "furniture", "What to do at the %s?" ), name );
@@ -6586,6 +6592,10 @@ void iexamine::workbench_internal( Character &you, const tripoint &examp,
     }
     if( is_undeployable ) {
         amenu.addentry( undeploy,     true,            't', _( "Take down the %s" ), name );
+    }
+    if( here.furn( examp ) == furn_f_ground_crafting_spot ||
+        here.get_field( examp, fd_crafting_spot ) != nullptr ) {
+        amenu.addentry( remove_crafting_spot, true, 'd', _( "移除制造点" ) );
     }
 
     amenu.query();
@@ -6672,6 +6682,15 @@ void iexamine::workbench_internal( Character &you, const tripoint &examp,
         }
         case undeploy: {
             deployed_furniture( you, examp );
+            break;
+        }
+        case remove_crafting_spot: {
+            if( here.get_field( examp, fd_crafting_spot ) != nullptr ) {
+                here.remove_field( examp, fd_crafting_spot );
+            } else if( here.furn( examp ) == furn_f_ground_crafting_spot ) {
+                here.furn_set( examp, f_null );
+            }
+            you.add_msg_if_player( m_info, _( "你移除了制造点。" ) );
             break;
         }
     }


### PR DESCRIPTION
- 普通制作菜单可以切换附近的NPC盟友作为当前制作者。
- 可以选择并记忆制造地点，在制造设置中统一管理制作者、制造点和制造清单。
- 每名NPC拥有独立制造清单，可连续加入配方、调整顺序或移出。
- NPC缺少材料时暂停，周围补充可用材料后自动恢复。
- c键可以打开制作者和工作地点选择界面，q键可以快速将物品加入制造清单，NPC会按顺序完成。玩家也可以使用b进行批量制造，再按q加入NPC的工作清单。
- 让制造点可堪一用，现在它可以放置在工作台上标记你喜欢的工作台，被标记的会显示为深蓝色。另外你可以按e快速移除制造点，而原版需要花七分半的拆除简单家具移除。
- MSVC编译测试通过。
- 理论上操作相对原有对话式制作更简便，但本次PR暂时不做移除。
<img width="1280" height="743" alt="{BD1750C8-D2F3-4362-91A8-09D1384168D9}" src="https://github.com/user-attachments/assets/bb6f4679-f7c2-4142-bb03-3d17257d37c6" />
<img width="745" height="335" alt="{046004AB-6A66-423C-B162-E8A1C939EABA}" src="https://github.com/user-attachments/assets/3467d7b2-3702-4671-9a90-99f382697fa0" />
<img width="170" height="146" alt="{947BB488-5A90-4263-A7E1-B3A169F08781}" src="https://github.com/user-attachments/assets/8c127989-a5cc-40c7-9733-c20daabfaf29" />
<img width="765" height="384" alt="{F40CCCAC-0403-4803-9614-16855B4CF241}" src="https://github.com/user-attachments/assets/a6aac3d4-a06a-49ef-9e55-37f3044f8751" />
<img width="410" height="742" alt="{893D0DD3-8AA8-43C2-A7CA-1BC814C14725}" src="https://github.com/user-attachments/assets/1d5659e4-6914-4c41-aefe-c6c1466297b5" />
