### PR TITLE
移植大地图特殊建筑完整继承支持

### DIFF
--- a/doc/JSON_INHERITANCE.md
+++ b/doc/JSON_INHERITANCE.md
@@ -108,7 +108,9 @@ MATERIAL
 MONSTER
 MONSTER_FACTION
 mutation
+overmap_special
 overmap_terrain
+city_building
 recipe
 terrain
 TOOL

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2818,8 +2818,12 @@ void overmap_special::load( const JsonObject &jo, const std::string &src )
     }
     switch( subtype_ ) {
         case overmap_special_subtype::fixed: {
-            shared_ptr_fast<fixed_overmap_special_data> fixed_data =
-                make_shared_fast<fixed_overmap_special_data>();
+            // Preserve inherited map data when loading an overmap_special with copy-from.
+            const fixed_overmap_special_data *existing =
+                std::dynamic_pointer_cast<const fixed_overmap_special_data>( data_ ).get();
+            shared_ptr_fast<fixed_overmap_special_data> fixed_data = existing ?
+                    make_shared_fast<fixed_overmap_special_data>( *existing ) :
+                    make_shared_fast<fixed_overmap_special_data>();
             mandatory( jo, was_loaded, "overmaps", fixed_data->terrains );
             if( is_special ) {
                 optional( jo, was_loaded, "connections", fixed_data->connections );
@@ -2828,9 +2832,15 @@ void overmap_special::load( const JsonObject &jo, const std::string &src )
             break;
         }
         case overmap_special_subtype::mutable_: {
-            shared_ptr_fast<mutable_overmap_special_data> mutable_data =
-                make_shared_fast<mutable_overmap_special_data>( id );
-            std::vector<overmap_special_locations> check_for_locations_merged_data;
+            // Preserve inherited mutable special data, then load fields supplied by the child.
+            const mutable_overmap_special_data *existing =
+                std::dynamic_pointer_cast<const mutable_overmap_special_data>( data_ ).get();
+            shared_ptr_fast<mutable_overmap_special_data> mutable_data = existing ?
+                    make_shared_fast<mutable_overmap_special_data>( *existing ) :
+                    make_shared_fast<mutable_overmap_special_data>( id );
+            mutable_data->parent_id = id;
+            std::vector<overmap_special_locations> check_for_locations_merged_data =
+                mutable_data->check_for_locations;
             optional( jo, was_loaded, "check_for_locations", check_for_locations_merged_data );
             if( jo.has_array( "check_for_locations_area" ) ) {
                 JsonArray jar = jo.get_array( "check_for_locations_area" );


### PR DESCRIPTION
- 本次修改移植CDDA上游PR #86488的核心逻辑，使overmap_special与city_building能够正确使用copy-from继承父对象数据。
- 微风原有实现会在加载子对象时重新创建fixed_overmap_special_data或mutable_overmap_special_data。当模组只覆盖occurrences等少数字段时，父对象已有的overmaps、connections及其他地图结构可能被空数据替换，导致难民中心围栏、道路或完整布局丢失。
- 修改后，固定式与可变式大地图特殊建筑都会先复制父对象现有数据，再读取子对象明确提供的字段。模组因此可以继承本体特殊建筑，只覆盖需要调整的生成参数，不再需要复制整套地图定义。 十分方便调整地图生成。
- 上游来源：CleverRaven/Cataclysm-DDA PR #86488 
- 上游作者：ehughsbaird