### PR TITLE
使用公历显示与场景日期编辑

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1590,6 +1590,27 @@
   },
   {
     "type": "keybinding",
+    "id": "CHANGE_START_OF_CATACLYSM",
+    "category": "NEW_CHAR_SCENARIOS",
+    "name": "Change cataclysm start date",
+    "bindings": [ { "input_method": "keyboard_char", "key": "#" }, { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "CHANGE_START_OF_GAME",
+    "category": "NEW_CHAR_SCENARIOS",
+    "name": "Change game start date",
+    "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "RESET_CALENDAR",
+    "category": "NEW_CHAR_SCENARIOS",
+    "name": "Reset scenario calendar",
+    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
     "id": "SCROLL_SKILL_INFO_UP",
     "category": "NEW_CHAR_SKILLS",
     "name": "Scroll description up",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4467,6 +4467,17 @@
   },
   {
     "type": "keybinding",
+    "id": "RESET",
+    "category": "CALENDAR_UI",
+    "name": "Reset time point to initial value",
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+    ]
+  },
+  {
+    "type": "keybinding",
     "id": "退出到游戏开始界面",
     "name": "退出到游戏开始界面",
     "category": "DEFAULTMODE"

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -869,7 +869,8 @@ time_duration calendar::turn_zero_offset()
 
 int calendar::years_since_cataclysm( time_point turn )
 {
-    return to_turn<int>( ( turn + turn_zero_offset() ) / calendar::year_length() );
+    const time_duration elapsed = turn - calendar::turn_zero + turn_zero_offset();
+    return to_turns<int>( elapsed ) / to_turns<int>( calendar::year_length() );
 }
 
 std::pair<month, int> month_and_day( time_point turn )

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -887,9 +887,7 @@ std::pair<month, int> month_and_day( time_point turn )
         }
     };
 
-    const time_duration since_new_year =
-        ( turn - calendar::turn_zero + calendar::turn_zero_offset() ) % calendar::year_length();
-    int day = to_days<int>( since_new_year );
+    int day = to_days<int>( time_past_new_year( turn ) );
     int month_index = ( day / 91 ) * 3;
     day %= 91;
     if( day < 31 ) {

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -17,6 +17,7 @@
 #include "options.h"
 #include "rng.h"
 #include "string_formatter.h"
+#include "translation.h"
 #include "translations.h"
 #include "units.h"
 #include "units_utility.h"
@@ -686,6 +687,20 @@ weekdays day_of_week( const time_point &p )
     return static_cast<weekdays>( result % 7 );
 }
 
+std::string to_string( const weekdays &d )
+{
+    static const std::array<std::string, 7> weekday_names = {{
+            translate_marker( "Sunday" ), translate_marker( "Monday" ),
+            translate_marker( "Tuesday" ), translate_marker( "Wednesday" ),
+            translate_marker( "Thursday" ), translate_marker( "Friday" ),
+            translate_marker( "Saturday" )
+        }
+    };
+    static_assert( static_cast<int>( weekdays::SUNDAY ) == 0,
+                   "weekday_names array is out of sync with weekdays enumeration values" );
+    return _( weekday_names[static_cast<int>( d )] );
+}
+
 bool calendar::eternal_season()
 {
     return is_eternal_season;
@@ -819,19 +834,92 @@ season_type season_of_year( const time_point &p )
 
 std::string to_string( const time_point &p )
 {
-    const int year = to_turns<int>( p - calendar::turn_zero ) / to_turns<int>
-                     ( calendar::year_length() ) + 1;
+    const int year = calendar::years_since_cataclysm( p ) + 1;
     const std::string time = to_string_time_of_day( p );
-    if( calendar::eternal_season() ) {
+    if( get_option<bool>( "SHOW_MONTHS" ) && calendar::year_length() == 364_days ) {
+        const std::pair<month, int> month_day = month_and_day( p );
+
+        //~ 1 is the year, 2 is the month, 3 is the day, 4 is the time of the day in its usual format
+        return string_format( _( "Year %1$d, %2$s %3$d %4$s" ), year, to_string( month_day.first ),
+                              month_day.second, time );
+    } else if( calendar::eternal_season() ) {
         const int day = to_days<int>( time_past_new_year( p ) );
         //~ 1 is the year, 2 is the day (of the *year*), 3 is the time of the day in its usual format
         return string_format( _( "Year %1$d, day %2$d %3$s" ), year, day, time );
-    } else {
-        const int day = day_of_season<int>( p ) + 1;
-        //~ 1 is the year, 2 is the season name, 3 is the day (of the season), 4 is the time of the day in its usual format
-        return string_format( _( "Year %1$d, %2$s, day %3$d %4$s" ), year,
-                              calendar::name_season( season_of_year( p ) ), day, time );
     }
+
+    const int day = day_of_season<int>( p ) + 1;
+    //~ 1 is the year, 2 is the season name, 3 is the day (of the season), 4 is the time of the day in its usual format
+    return string_format( _( "Year %1$d, %2$s, day %3$d %4$s" ), year,
+                          calendar::name_season( season_of_year( p ) ), day, time );
+}
+
+time_duration calendar::turn_zero_offset()
+{
+    // Turn zero is March 21.  The display calendar starts on January 1.
+    const time_duration winter_at_start = 31_days + 30_days + 20_days;
+    if( calendar::year_length() == 364_days ) {
+        return winter_at_start;
+    }
+
+    // Keep the same point in winter for custom season lengths.
+    const double fraction = to_days<double>( winter_at_start ) / 91.0;
+    return fraction * calendar::season_length();
+}
+
+int calendar::years_since_cataclysm( time_point turn )
+{
+    return to_turn<int>( ( turn + turn_zero_offset() ) / calendar::year_length() );
+}
+
+std::pair<month, int> month_and_day( time_point turn )
+{
+    if( calendar::year_length() != 364_days ) {
+        return std::make_pair( month::UNKNOWN, to_days<int>( time_past_new_year( turn ) ) );
+    }
+
+    // The 364-day display calendar uses 31 days for Jan/Apr/Jul/Oct and 30 for the rest.
+    static const std::array<month, 12> months = {{
+            month::JANUARY, month::FEBRUARY, month::MARCH, month::APRIL, month::MAY, month::JUNE,
+            month::JULY, month::AUGUST, month::SEPTEMBER, month::OCTOBER, month::NOVEMBER,
+            month::DECEMBER
+        }
+    };
+
+    const time_duration since_new_year =
+        ( turn - calendar::turn_zero + calendar::turn_zero_offset() ) % calendar::year_length();
+    int day = to_days<int>( since_new_year );
+    int month_index = ( day / 91 ) * 3;
+    day %= 91;
+    if( day < 31 ) {
+        ++day;
+    } else if( day < 61 ) {
+        ++month_index;
+        day -= 30;
+    } else {
+        month_index += 2;
+        day -= 60;
+    }
+    return std::make_pair( months[month_index], day );
+}
+
+std::string to_string( month m )
+{
+    static const std::array<translation, 12> months = {{
+            to_translation( "month", "Jan" ), to_translation( "month", "Feb" ),
+            to_translation( "month", "Mar" ), to_translation( "month", "Apr" ),
+            to_translation( "month", "May" ), to_translation( "month", "Jun" ),
+            to_translation( "month", "Jul" ), to_translation( "month", "Aug" ),
+            to_translation( "month", "Sep" ), to_translation( "month", "Oct" ),
+            to_translation( "month", "Nov" ), to_translation( "month", "Dec" )
+        }
+    };
+
+    static_assert( static_cast<month>( 0 ) == month::JANUARY, "month enum out of phase" );
+    if( m == month::UNKNOWN ) {
+        return _( "Cataclysm" );
+    }
+    return months[static_cast<int>( m )].translated();
 }
 
 std::string get_diary_time_since_str( const time_duration &turn_diff, time_accuracy acc )
@@ -880,22 +968,23 @@ std::string get_diary_time_since_str( const time_duration &turn_diff, time_accur
 
 std::string get_diary_time_str( const time_point &turn, time_accuracy acc )
 {
-    const int year = to_turns<int>( turn - calendar::turn_zero ) /
-                     to_turns<int>( calendar::year_length() ) + 1;
+    const int year = calendar::years_since_cataclysm( turn ) + 1;
     const int day = day_of_season<int>( turn ) + 1;
     switch( acc ) {
         case time_accuracy::FULL:
             return to_string( turn );
         case time_accuracy::PARTIAL:
-            // partial accuracy, able to see the sky
-            //~ Time of year:
-            //~ $1 = year since Cataclysm
-            //~ $2 = season
-            //~ $3 = day of season
-            //~ $4 = approximate time of day
+            if( get_option<bool>( "SHOW_MONTHS" ) && calendar::year_length() == 364_days ) {
+                const std::pair<month, int> month_day = month_and_day( turn );
+                //~ Time of year: $1 = year, $2 = month, $3 = day of month, $4 = approximate time
+                return string_format( _( "Year %1$d, %2$s day %3$d, %4$s" ), year,
+                                      to_string( month_day.first ), month_day.second,
+                                      display::time_approx( turn ) );
+            }
+            //~ Time of year: $1 = year, $2 = season, $3 = day of season, $4 = approximate time
             return string_format( _( "Year %1$d, %2$s, day %3$d, %4$s" ), year,
-                                  calendar::name_season( season_of_year( turn ) ),
-                                  day, display::time_approx( turn ) );
+                                  calendar::name_season( season_of_year( turn ) ), day,
+                                  display::time_approx( turn ) );
         default:
             DebugLog( DebugLevel::D_WARNING, DebugClass::D_GAME )
                     << "Unknown time_accuracy " << io::enum_to_string<time_accuracy>( acc );

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -134,6 +134,12 @@ float season_from_default_ratio();
 /** Returns the translated name of the season (with first letter being uppercase). */
 std::string name_season( season_type s );
 
+/** Offset from the first day of spring to January 1 in the display calendar. */
+time_duration turn_zero_offset();
+
+/** Number of January 1 boundaries crossed since the Cataclysm year began. */
+int years_since_cataclysm( time_point turn );
+
 extern time_point start_of_cataclysm;
 extern time_point start_of_game;
 extern time_point turn;
@@ -640,6 +646,27 @@ enum class weekdays : int {
 };
 
 weekdays day_of_week( const time_point &p );
+std::string to_string( const weekdays &d );
+
+enum class month : int {
+    JANUARY = 0,
+    FEBRUARY,
+    MARCH,
+    APRIL,
+    MAY,
+    JUNE,
+    JULY,
+    AUGUST,
+    SEPTEMBER,
+    OCTOBER,
+    NOVEMBER,
+    DECEMBER,
+    UNKNOWN
+};
+
+/** Converts an in-game time point to its month and day in the 364-day calendar. */
+std::pair<month, int> month_and_day( time_point turn );
+std::string to_string( month m );
 
 // To support the eternal season option we create a strong typedef of timepoint
 // which is a season_effective_time.  This converts a regular time to a time

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -554,6 +554,13 @@ inline time_duration time_past_midnight( const time_point &p )
 
 inline time_duration time_past_new_year( const time_point &p )
 {
+    return ( p - calendar::turn_zero + calendar::turn_zero_offset() ) %
+           calendar::year_length();
+}
+
+/** Time elapsed since the spring-based seasonal cycle began. */
+inline time_duration time_past_season_year( const time_point &p )
+{
     return ( p - calendar::turn_zero ) % calendar::year_length();
 }
 

--- a/src/calendar_ui.cpp
+++ b/src/calendar_ui.cpp
@@ -1,0 +1,162 @@
+#include "calendar_ui.h"
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "color.h"
+#include "input.h"
+#include "string_formatter.h"
+#include "string_input_popup.h"
+#include "translations.h"
+#include "ui.h"
+
+time_point calendar_ui::select_time_point( time_point initial_value, const std::string &title,
+        calendar_ui::granularity granularity_level )
+{
+    time_point return_value = initial_value;
+    auto set_turn = [&]( const int initial, const time_duration & factor, const char *const msg,
+    int auto_value = 0 ) {
+        int new_value = initial + auto_value;
+        if( new_value == initial ) {
+            string_input_popup time_query;
+            new_value = time_query
+                        .title( msg )
+                        .width( 24 )
+                        .text( std::to_string( initial ) )
+                        .only_digits( true )
+                        .query_int();
+            if( time_query.canceled() || new_value == initial ) {
+                return;
+            }
+        }
+        const time_duration offset = ( new_value - initial ) * factor;
+        const time_point maximum = calendar::turn_zero + time_duration::from_turns(
+                                       std::numeric_limits<int>::max() / 2 );
+        return_value = std::max( std::min( maximum, return_value + offset ), calendar::turn_zero );
+    };
+
+    uilist smenu;
+    static const auto years = []( const time_point & p ) {
+        return static_cast<int>( ( p - calendar::turn_zero ) / calendar::year_length() );
+    };
+    int selected_entry = smenu.ret;
+    do {
+        smenu.reset();
+        smenu.title = title;
+        smenu.text = string_format( _( "Old date: %1$s\nNew date: %2$s" ),
+                                    colorize( to_string( initial_value ), c_light_red ),
+                                    colorize( to_string( return_value ), c_light_cyan ) );
+        smenu.desc_enabled = true;
+        smenu.allow_additional = true;
+        smenu.input_category = "CALENDAR_UI";
+        smenu.additional_actions = {
+            { "LEFT", to_translation( "Decrease value" ) },
+            { "RIGHT", to_translation( "Increase value" ) },
+            { "RESET", to_translation( "Reset value" ) }
+        };
+        const input_context ctxt( smenu.input_category );
+        smenu.footer_text = string_format(
+                                _( "Press <color_light_green>%s</color> to decrease value.\n" ),
+                                ctxt.get_desc( "LEFT" ) );
+        smenu.footer_text += string_format(
+                                 _( "Press <color_light_green>%s</color> to increase value.\n" ),
+                                 ctxt.get_desc( "RIGHT" ) );
+        smenu.footer_text += string_format(
+                                 _( "Press <color_light_green>%s</color> to reset value.\n" ),
+                                 ctxt.get_desc( "RESET" ) );
+        smenu.footer_text += string_format(
+                                 _( "Press <color_light_green>%s</color> when done selecting time point." ),
+                                 ctxt.get_desc( "UILIST.QUIT" ) );
+
+        smenu.addentry( static_cast<int>( calendar_ui::granularity::year ), true,
+                        'y', "%s: %d", _( "year" ), years( return_value ) + 1 );
+        smenu.addentry( static_cast<int>( calendar_ui::granularity::season ),
+                        !calendar::eternal_season(), 's', "%s: %s", _( "season" ),
+                        calendar::name_season( season_of_year( return_value ) ) );
+        smenu.addentry( static_cast<int>( calendar_ui::granularity::day ), true,
+                        'd', "%s: %d", _( "day" ), day_of_season<int>( return_value ) + 1 );
+        smenu.addentry( static_cast<int>( calendar_ui::granularity::hour ), true,
+                        'h', "%s: %d", _( "hour" ), hour_of_day<int>( return_value ) );
+        smenu.addentry( static_cast<int>( calendar_ui::granularity::minute ), true,
+                        'm', "%s: %d", _( "minute" ), minute_of_hour<int>( return_value ) );
+        smenu.addentry( static_cast<int>( calendar_ui::granularity::turn ), true,
+                        't', "%s: %d", _( "turn" ),
+                        to_turns<int>( return_value - calendar::turn_zero ) );
+
+        for( uilist_entry &entry : smenu.entries ) {
+            if( entry.retval > static_cast<int>( granularity_level ) ) {
+                entry.enabled = false;
+            }
+        }
+        smenu.selected = selected_entry;
+        smenu.query();
+
+        int auto_value = 0;
+        switch( smenu.ret ) {
+            case static_cast<int>( calendar_ui::granularity::year ):
+                set_turn( years( return_value ) + 1, calendar::year_length(), _( "Set year to?" ) );
+                break;
+            case static_cast<int>( calendar_ui::granularity::season ):
+                set_turn( static_cast<int>( season_of_year( return_value ) ), calendar::season_length(),
+                          _( "Set season to?  (0 = spring)" ) );
+                break;
+            case static_cast<int>( calendar_ui::granularity::day ):
+                set_turn( day_of_season<int>( return_value ) + 1, 1_days, _( "Set days to?" ) );
+                break;
+            case static_cast<int>( calendar_ui::granularity::hour ):
+                set_turn( hour_of_day<int>( return_value ), 1_hours, _( "Set hour to?" ) );
+                break;
+            case static_cast<int>( calendar_ui::granularity::minute ):
+                set_turn( minute_of_hour<int>( return_value ), 1_minutes, _( "Set minute to?" ) );
+                break;
+            case static_cast<int>( calendar_ui::granularity::turn ):
+                set_turn( to_turns<int>( return_value - calendar::turn_zero ), 1_turns,
+                          string_format( _( "Set turn to?  (One day is %i turns)" ),
+                                         to_turns<int>( 1_days ) ).c_str() );
+                break;
+            case UILIST_ADDITIONAL:
+                if( smenu.ret_act == "LEFT" ) {
+                    auto_value = -1;
+                } else if( smenu.ret_act == "RIGHT" ) {
+                    auto_value = 1;
+                } else if( smenu.ret_act == "RESET" ) {
+                    return_value = initial_value;
+                }
+                if( auto_value != 0 ) {
+                    switch( smenu.selected ) {
+                        case static_cast<int>( calendar_ui::granularity::year ):
+                            set_turn( years( return_value ) + 1, calendar::year_length(), "", auto_value );
+                            break;
+                        case static_cast<int>( calendar_ui::granularity::season ):
+                            set_turn( static_cast<int>( season_of_year( return_value ) ),
+                                      calendar::season_length(), "", auto_value );
+                            break;
+                        case static_cast<int>( calendar_ui::granularity::day ):
+                            set_turn( day_of_season<int>( return_value ) + 1, 1_days, "", auto_value );
+                            break;
+                        case static_cast<int>( calendar_ui::granularity::hour ):
+                            set_turn( hour_of_day<int>( return_value ), 1_hours, "", auto_value );
+                            break;
+                        case static_cast<int>( calendar_ui::granularity::minute ):
+                            set_turn( minute_of_hour<int>( return_value ), 1_minutes, "", auto_value );
+                            break;
+                        case static_cast<int>( calendar_ui::granularity::turn ):
+                            set_turn( to_turns<int>( return_value - calendar::turn_zero ), 1_turns, "",
+                                      auto_value );
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                break;
+            default:
+                break;
+        }
+        selected_entry = smenu.selected;
+    } while( smenu.ret != UILIST_CANCEL );
+
+    return return_value;
+}

--- a/src/calendar_ui.h
+++ b/src/calendar_ui.h
@@ -1,0 +1,30 @@
+#pragma once
+#ifndef CATA_SRC_CALENDAR_UI_H
+#define CATA_SRC_CALENDAR_UI_H
+
+#include <string>
+
+#include "calendar.h"
+
+namespace calendar_ui
+{
+
+enum class granularity : int {
+    year,
+    season,
+    day,
+    hour,
+    minute,
+    turn,
+    last,
+};
+
+/**
+ * Displays a UI element that allows selecting and returning a time point.
+ */
+time_point select_time_point( time_point initial_value, const std::string &title,
+                              granularity granularity_level = granularity::turn );
+
+} // namespace calendar_ui
+
+#endif // CATA_SRC_CALENDAR_UI_H

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -32,6 +32,7 @@
 #include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"
+#include "calendar_ui.h"
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "character.h"
@@ -2511,67 +2512,7 @@ static void debug_menu_spawn_vehicle()
 
 static void debug_menu_change_time()
 {
-    auto set_turn = [&]( const int initial, const time_duration & factor, const char *const msg ) {
-        string_input_popup pop;
-        const int new_value = pop
-                              .title( msg )
-                              .width( 20 )
-                              .text( std::to_string( initial ) )
-                              .only_digits( true )
-                              .query_int();
-        if( pop.canceled() ) {
-            return;
-        }
-        const time_duration offset = ( new_value - initial ) * factor;
-        // Arbitrary maximal value.
-        const time_point max = calendar::turn_zero + time_duration::from_turns(
-                                   std::numeric_limits<int>::max() / 2 );
-        calendar::turn = std::max( std::min( max, calendar::turn + offset ), calendar::turn_zero );
-    };
-
-    uilist smenu;
-    static const auto years = []( const time_point & p ) {
-        return static_cast<int>( ( p - calendar::turn_zero ) / calendar::year_length() );
-    };
-    do {
-        const int iSel = smenu.ret;
-        smenu.reset();
-        smenu.addentry( 0, true, 'y', "%s: %d", _( "year" ), years( calendar::turn ) );
-        smenu.addentry( 1, !calendar::eternal_season(), 's', "%s: %d",
-                        _( "season" ), static_cast<int>( season_of_year( calendar::turn ) ) );
-        smenu.addentry( 2, true, 'd', "%s: %d", _( "day" ), day_of_season<int>( calendar::turn ) );
-        smenu.addentry( 3, true, 'h', "%s: %d", _( "hour" ), hour_of_day<int>( calendar::turn ) );
-        smenu.addentry( 4, true, 'm', "%s: %d", _( "minute" ), minute_of_hour<int>( calendar::turn ) );
-        smenu.addentry( 5, true, 't', "%s: %d", _( "turn" ),
-                        to_turns<int>( calendar::turn - calendar::turn_zero ) );
-        smenu.selected = iSel;
-        smenu.query();
-
-        switch( smenu.ret ) {
-            case 0:
-                set_turn( years( calendar::turn ), calendar::year_length(), _( "Set year to?" ) );
-                break;
-            case 1:
-                set_turn( static_cast<int>( season_of_year( calendar::turn ) ), calendar::season_length(),
-                          _( "Set season to?  (0 = spring)" ) );
-                break;
-            case 2:
-                set_turn( day_of_season<int>( calendar::turn ), 1_days, _( "Set days to?" ) );
-                break;
-            case 3:
-                set_turn( hour_of_day<int>( calendar::turn ), 1_hours, _( "Set hour to?" ) );
-                break;
-            case 4:
-                set_turn( minute_of_hour<int>( calendar::turn ), 1_minutes, _( "Set minute to?" ) );
-                break;
-            case 5:
-                set_turn( to_turns<int>( calendar::turn - calendar::turn_zero ), 1_turns,
-                          string_format( _( "Set turn to?  (One day is %i turns)" ), to_turns<int>( 1_days ) ).c_str() );
-                break;
-            default:
-                break;
-        }
-    } while( smenu.ret != UILIST_CANCEL );
+    calendar::turn = calendar_ui::select_time_point( calendar::turn, _( "Select time point" ) );
 }
 
 static void debug_menu_force_temperature()

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -261,9 +261,17 @@ std::string display::time_approx()
 
 std::string display::date_string()
 {
-    const std::string season = calendar::name_season( season_of_year( calendar::turn ) );
-    const int day_num = day_of_season<int>( calendar::turn ) + 1;
-    return string_format( _( "%s, day %d" ), season, day_num );
+    if( calendar::year_length() != 364_days || !get_option<bool>( "SHOW_MONTHS" ) ) {
+        const std::string season = calendar::name_season( season_of_year( calendar::turn ) );
+        const int day_num = day_of_season<int>( calendar::turn ) + 1;
+        return string_format( _( "%s, day %d" ), season, day_num );
+    }
+
+    const std::pair<month, int> month_day = month_and_day( calendar::turn );
+    const weekdays day = day_of_week( calendar::turn );
+    //~ 1 is the weekday, 2 is the month, 3 is the day of the month
+    return string_format( _( "%1$s, %2$s %3$d" ), to_string( day ), to_string( month_day.first ),
+                          month_day.second );
 }
 
 std::string display::time_string( const Character &u )

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13203,7 +13203,7 @@ const scenario *get_scenario()
 }
 void set_scenario( const scenario *new_scenario )
 {
-    new_scenario->rerandomize();
+    new_scenario->ensure_calendar();
     g->scen = new_scenario;
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8879,10 +8879,10 @@ void map::produce_sap( const tripoint &p, const time_duration &time_since_last_a
         const time_duration late_winter_start = 3.75f * calendar::season_length();
 
         const time_point last_actualize = calendar::turn - time_since_last_actualize;
-        const time_duration last_actualize_tof = time_past_new_year( last_actualize );
+        const time_duration last_actualize_tof = time_past_season_year( last_actualize );
         bool last_producing = last_actualize_tof >= late_winter_start ||
                               last_actualize_tof < early_spring_end;
-        const time_duration current_tof = time_past_new_year( calendar::turn );
+        const time_duration current_tof = time_past_season_year( calendar::turn );
         bool current_producing = current_tof >= late_winter_start ||
                                  current_tof < early_spring_end;
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2953,6 +2953,72 @@ static struct {
     }
 } scenario_sorter;
 
+static time_point select_scenario_time( const time_point &initial, const std::string &title )
+{
+    time_point selected = initial;
+    const time_point maximum_time = time_point::from_turn( INT_MAX / 2 );
+    const auto set_time_part = [&]( const int initial_value, const int minimum, const int maximum,
+                                    const time_duration &factor, const char *const prompt ) {
+        string_input_popup pop;
+        int new_value = pop
+                        .title( prompt )
+                        .width( 20 )
+                        .text( std::to_string( initial_value ) )
+                        .only_digits( true )
+                        .query_int();
+        if( pop.canceled() ) {
+            return;
+        }
+        new_value = std::clamp( new_value, minimum, maximum );
+        selected = std::max( calendar::turn_zero,
+                             std::min( maximum_time,
+                                       selected + ( new_value - initial_value ) * factor ) );
+    };
+    const auto year_number = []( const time_point & p ) {
+        return calendar::years_since_cataclysm( p ) + 1;
+    };
+
+    uilist menu;
+    do {
+        const int previous_selection = menu.ret;
+        menu.reset();
+        menu.text = title;
+        menu.addentry( 0, true, 'y', "%s: %d", _( "year" ), year_number( selected ) );
+        menu.addentry( 1, !calendar::eternal_season(), 's', "%s: %s", _( "season" ),
+                       calendar::name_season( season_of_year( selected ) ) );
+        menu.addentry( 2, true, 'd', "%s: %d", _( "day" ),
+                       day_of_season<int>( selected ) + 1 );
+        menu.addentry( 3, true, 'h', "%s: %d", _( "hour" ), hour_of_day<int>( selected ) );
+        menu.selected = previous_selection;
+        menu.query();
+
+        switch( menu.ret ) {
+            case 0:
+                set_time_part( year_number( selected ), 1,
+                               to_turns<int>( maximum_time - calendar::turn_zero ) /
+                               to_turns<int>( calendar::year_length() ) + 1,
+                               calendar::year_length(),
+                               _( "Set year to?" ) );
+                break;
+            case 1:
+                set_time_part( static_cast<int>( season_of_year( selected ) ), 0, 3,
+                               calendar::season_length(), _( "Set season to?  (0 = spring)" ) );
+                break;
+            case 2:
+                set_time_part( day_of_season<int>( selected ) + 1, 1,
+                               get_option<int>( "SEASON_LENGTH" ), 1_days, _( "Set days to?" ) );
+                break;
+            case 3:
+                set_time_part( hour_of_day<int>( selected ), 0, 23, 1_hours, _( "Set hour to?" ) );
+                break;
+            default:
+                break;
+        }
+    } while( menu.ret != UILIST_CANCEL );
+
+    return selected;
+}
+
 static std::string assemble_scenario_details( const avatar &u, const input_context &ctxt,
         const scenario *current_scenario )
 {
@@ -3012,7 +3078,16 @@ static std::string assemble_scenario_details( const avatar &u, const input_conte
     }
 
     assembled += "\n" + colorize( _( "Scenario calendar:" ), COL_HEADER ) + "\n";
-    if( current_scenario->custom_start_date() ) {
+    if( current_scenario == get_scenario() ) {
+        assembled += colorize( ctxt.get_desc( "CHANGE_START_OF_CATACLYSM" ), c_light_green ) + " " +
+                     _( "Start of cataclysm:" ) + " " +
+                     to_string( current_scenario->start_of_cataclysm() ) + "\n";
+        assembled += colorize( ctxt.get_desc( "CHANGE_START_OF_GAME" ), c_light_green ) + " " +
+                     _( "Start of game:" ) + " " + to_string( current_scenario->start_of_game() ) +
+                     "\n";
+        assembled += colorize( ctxt.get_desc( "RESET_CALENDAR" ), c_light_green ) + " " +
+                     _( "Reset scenario calendar" ) + "\n";
+    } else if( current_scenario->custom_start_date() ) {
         assembled += string_format( current_scenario->is_random_year() ?
                                     _( "Year:   Random" ) : _( "Year:   %s" ),
                                     current_scenario->start_year() ) + "\n";
@@ -3099,6 +3174,9 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
     ctxt.register_action( "FILTER" );
     ctxt.register_action( "RESET_FILTER" );
     ctxt.register_action( "RANDOMIZE" );
+    ctxt.register_action( "CHANGE_START_OF_CATACLYSM" );
+    ctxt.register_action( "CHANGE_START_OF_GAME" );
+    ctxt.register_action( "RESET_CALENDAR" );
 
     bool recalc_scens = true;
     int scens_length = 0;
@@ -3291,6 +3369,31 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
                 continue;
             }
             reset_scenario( u, sorted_scens[cur_id] );
+        } else if( action == "CHANGE_START_OF_CATACLYSM" ||
+                   action == "CHANGE_START_OF_GAME" || action == "RESET_CALENDAR" ) {
+            const scenario *scen = sorted_scens[cur_id];
+            const ret_val<void> can_pick = scen->can_pick();
+            if( !can_pick.success() ) {
+                popup( can_pick.str() );
+                continue;
+            }
+            if( scen->has_flag( "CITY_START" ) && !scenario_sorter.cities_enabled ) {
+                continue;
+            }
+            if( scen != get_scenario() ) {
+                reset_scenario( u, scen );
+            }
+            if( action == "CHANGE_START_OF_CATACLYSM" ) {
+                scen->change_start_of_cataclysm(
+                    select_scenario_time( scen->start_of_cataclysm(),
+                                          _( "Select cataclysm start date" ) ) );
+            } else if( action == "CHANGE_START_OF_GAME" ) {
+                scen->change_start_of_game(
+                    select_scenario_time( scen->start_of_game(), _( "Select game start date" ) ) );
+            } else {
+                scen->reset_calendar();
+            }
+            details_recalc = true;
         } else if( action == "CHANGE_GENDER" ) {
             u.male = !u.male;
             recalc_scens = true;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1,7 +1,6 @@
 #include "avatar.h" // IWYU pragma: associated
 
 #include <algorithm>
-#include <climits>
 #include <cstdlib>
 #include <functional>
 #include <initializer_list>
@@ -22,6 +21,7 @@
 #include "bionics.h"
 #include "cata_utility.h"
 #include "catacharset.h"
+#include "calendar_ui.h"
 #include "character.h"
 #include "character_martial_arts.h"
 #include "color.h"
@@ -660,6 +660,9 @@ bool avatar::create( character_type type, const std::string &tempname )
     set_wielded_item( item() );
 
     prof = profession::generic();
+    for( const scenario &scen : scenario::get_all() ) {
+        scen.rerandomize();
+    }
     set_scenario( scenario::generic() );
 
     const bool interactive = type != character_type::NOW &&
@@ -2953,136 +2956,6 @@ static struct {
     }
 } scenario_sorter;
 
-static time_point select_scenario_time( const time_point &initial, const std::string &title )
-{
-    time_point selected = initial;
-    const time_point maximum_time = time_point::from_turn( INT_MAX / 2 );
-    const auto query_number = []( const int initial_value, const int minimum, const int maximum,
-                                  const char *const prompt ) -> std::optional<int> {
-        string_input_popup pop;
-        int new_value = pop
-                        .title( prompt )
-                        .width( 24 )
-                        .text( std::to_string( initial_value ) )
-                        .only_digits( true )
-                        .query_int();
-        if( pop.canceled() ) {
-            return std::nullopt;
-        }
-        return std::clamp( new_value, minimum, maximum );
-    };
-    const auto clamp_time = [&]( const time_point & value ) {
-        return std::max( calendar::turn_zero, std::min( maximum_time, value ) );
-    };
-    const auto set_time_part = [&]( const int initial_value, const int minimum, const int maximum,
-                                    const time_duration &factor, const char *const prompt ) {
-        const std::optional<int> new_value =
-            query_number( initial_value, minimum, maximum, prompt );
-        if( !new_value ) {
-            return;
-        }
-        selected = clamp_time( selected + ( *new_value - initial_value ) * factor );
-    };
-    const auto year_number = []( const time_point & p ) {
-        return calendar::years_since_cataclysm( p ) + 1;
-    };
-    const auto month_length = []( const int month_index ) {
-        return month_index == static_cast<int>( month::JANUARY ) ||
-               month_index == static_cast<int>( month::APRIL ) ||
-               month_index == static_cast<int>( month::JULY ) ||
-               month_index == static_cast<int>( month::OCTOBER ) ? 31 : 30;
-    };
-    const auto month_start_day = [&]( const int month_index ) {
-        int result = 0;
-        for( int i = 0; i < month_index; ++i ) {
-            result += month_length( i );
-        }
-        return result;
-    };
-    const auto set_month_day = [&]( const int month_index, const int day_of_month ) {
-        const int current_day = to_days<int>( time_past_new_year( selected ) );
-        const int target_day = month_start_day( month_index ) +
-                               std::clamp( day_of_month, 1, month_length( month_index ) ) - 1;
-        selected = clamp_time( selected + ( target_day - current_day ) * 1_days );
-    };
-
-    uilist menu;
-    do {
-        const int previous_selection = menu.ret;
-        const bool show_months = get_option<bool>( "SHOW_MONTHS" ) &&
-                                 calendar::year_length() == 364_days;
-        const std::pair<month, int> month_day = show_months ?
-                                                month_and_day( selected ) :
-                                                std::make_pair( month::UNKNOWN, 0 );
-
-        menu.reset();
-        menu.text = title + "\n" + to_string( selected );
-        menu.addentry( 0, true, 'y', "%s: %d", _( "year" ), year_number( selected ) );
-        if( show_months ) {
-            menu.addentry( 1, true, 'm', "%s: %s", _( "month" ),
-                           to_string( month_day.first ) );
-            menu.addentry( 2, true, 'd', "%s: %d", _( "day of month" ),
-                           month_day.second );
-        } else {
-            menu.addentry( 1, !calendar::eternal_season(), 's', "%s: %s", _( "season" ),
-                           calendar::name_season( season_of_year( selected ) ) );
-            menu.addentry( 2, true, 'd', "%s: %d", _( "day" ),
-                           day_of_season<int>( selected ) + 1 );
-        }
-        menu.addentry( 3, true, 'h', "%s: %d", _( "hour" ), hour_of_day<int>( selected ) );
-        menu.selected = previous_selection;
-        menu.query();
-
-        switch( menu.ret ) {
-            case 0:
-                set_time_part( year_number( selected ), 1,
-                               to_turns<int>( maximum_time - calendar::turn_zero ) /
-                               to_turns<int>( calendar::year_length() ) + 1,
-                               calendar::year_length(),
-                               _( "Set year to?" ) );
-                break;
-            case 1:
-                if( show_months ) {
-                    const int current_month = static_cast<int>( month_day.first ) + 1;
-                    const std::optional<int> new_month =
-                        query_number( current_month, 1, 12,
-                                      _( "Set month to?  (1 = January)" ) );
-                    if( new_month ) {
-                        set_month_day( *new_month - 1,
-                                       std::min( month_day.second, month_length( *new_month - 1 ) ) );
-                    }
-                } else {
-                    set_time_part( static_cast<int>( season_of_year( selected ) ), 0, 3,
-                                   calendar::season_length(),
-                                   _( "Set season to?  (0 = spring)" ) );
-                }
-                break;
-            case 2:
-                if( show_months ) {
-                    const int current_month = static_cast<int>( month_day.first );
-                    const std::optional<int> new_day =
-                        query_number( month_day.second, 1, month_length( current_month ),
-                                      _( "Set day of month to?" ) );
-                    if( new_day ) {
-                        set_month_day( current_month, *new_day );
-                    }
-                } else {
-                    set_time_part( day_of_season<int>( selected ) + 1, 1,
-                                   get_option<int>( "SEASON_LENGTH" ), 1_days,
-                                   _( "Set days to?" ) );
-                }
-                break;
-            case 3:
-                set_time_part( hour_of_day<int>( selected ), 0, 23, 1_hours,
-                               _( "Set hour to?" ) );
-                break;
-            default:
-                break;
-        }
-    } while( menu.ret != UILIST_CANCEL );
-
-    return selected;
-}
 
 static std::string assemble_scenario_details( const avatar &u, const input_context &ctxt,
         const scenario *current_scenario )
@@ -3436,11 +3309,14 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
             }
             if( action == "CHANGE_START_OF_CATACLYSM" ) {
                 scen->change_start_of_cataclysm(
-                    select_scenario_time( scen->start_of_cataclysm(),
-                                          _( "Select cataclysm start date" ) ) );
+                    calendar_ui::select_time_point( scen->start_of_cataclysm(),
+                                                    _( "Select cataclysm start date" ),
+                                                    calendar_ui::granularity::hour ) );
             } else if( action == "CHANGE_START_OF_GAME" ) {
                 scen->change_start_of_game(
-                    select_scenario_time( scen->start_of_game(), _( "Select game start date" ) ) );
+                    calendar_ui::select_time_point( scen->start_of_game(),
+                                                    _( "Select game start date" ),
+                                                    calendar_ui::granularity::hour ) );
             } else {
                 scen->reset_calendar();
             }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2957,37 +2957,78 @@ static time_point select_scenario_time( const time_point &initial, const std::st
 {
     time_point selected = initial;
     const time_point maximum_time = time_point::from_turn( INT_MAX / 2 );
-    const auto set_time_part = [&]( const int initial_value, const int minimum, const int maximum,
-                                    const time_duration &factor, const char *const prompt ) {
+    const auto query_number = []( const int initial_value, const int minimum, const int maximum,
+                                  const char *const prompt ) -> std::optional<int> {
         string_input_popup pop;
         int new_value = pop
                         .title( prompt )
-                        .width( 20 )
+                        .width( 24 )
                         .text( std::to_string( initial_value ) )
                         .only_digits( true )
                         .query_int();
         if( pop.canceled() ) {
+            return std::nullopt;
+        }
+        return std::clamp( new_value, minimum, maximum );
+    };
+    const auto clamp_time = [&]( const time_point & value ) {
+        return std::max( calendar::turn_zero, std::min( maximum_time, value ) );
+    };
+    const auto set_time_part = [&]( const int initial_value, const int minimum, const int maximum,
+                                    const time_duration &factor, const char *const prompt ) {
+        const std::optional<int> new_value =
+            query_number( initial_value, minimum, maximum, prompt );
+        if( !new_value ) {
             return;
         }
-        new_value = std::clamp( new_value, minimum, maximum );
-        selected = std::max( calendar::turn_zero,
-                             std::min( maximum_time,
-                                       selected + ( new_value - initial_value ) * factor ) );
+        selected = clamp_time( selected + ( *new_value - initial_value ) * factor );
     };
     const auto year_number = []( const time_point & p ) {
         return calendar::years_since_cataclysm( p ) + 1;
+    };
+    const auto month_length = []( const int month_index ) {
+        return month_index == static_cast<int>( month::JANUARY ) ||
+               month_index == static_cast<int>( month::APRIL ) ||
+               month_index == static_cast<int>( month::JULY ) ||
+               month_index == static_cast<int>( month::OCTOBER ) ? 31 : 30;
+    };
+    const auto month_start_day = [&]( const int month_index ) {
+        int result = 0;
+        for( int i = 0; i < month_index; ++i ) {
+            result += month_length( i );
+        }
+        return result;
+    };
+    const auto set_month_day = [&]( const int month_index, const int day_of_month ) {
+        const int current_day = to_days<int>( time_past_new_year( selected ) );
+        const int target_day = month_start_day( month_index ) +
+                               std::clamp( day_of_month, 1, month_length( month_index ) ) - 1;
+        selected = clamp_time( selected + ( target_day - current_day ) * 1_days );
     };
 
     uilist menu;
     do {
         const int previous_selection = menu.ret;
+        const bool show_months = get_option<bool>( "SHOW_MONTHS" ) &&
+                                 calendar::year_length() == 364_days;
+        const std::pair<month, int> month_day = show_months ?
+                                                month_and_day( selected ) :
+                                                std::make_pair( month::UNKNOWN, 0 );
+
         menu.reset();
-        menu.text = title;
+        menu.text = title + "\n" + to_string( selected );
         menu.addentry( 0, true, 'y', "%s: %d", _( "year" ), year_number( selected ) );
-        menu.addentry( 1, !calendar::eternal_season(), 's', "%s: %s", _( "season" ),
-                       calendar::name_season( season_of_year( selected ) ) );
-        menu.addentry( 2, true, 'd', "%s: %d", _( "day" ),
-                       day_of_season<int>( selected ) + 1 );
+        if( show_months ) {
+            menu.addentry( 1, true, 'm', "%s: %s", _( "month" ),
+                           to_string( month_day.first ) );
+            menu.addentry( 2, true, 'd', "%s: %d", _( "day of month" ),
+                           month_day.second );
+        } else {
+            menu.addentry( 1, !calendar::eternal_season(), 's', "%s: %s", _( "season" ),
+                           calendar::name_season( season_of_year( selected ) ) );
+            menu.addentry( 2, true, 'd', "%s: %d", _( "day" ),
+                           day_of_season<int>( selected ) + 1 );
+        }
         menu.addentry( 3, true, 'h', "%s: %d", _( "hour" ), hour_of_day<int>( selected ) );
         menu.selected = previous_selection;
         menu.query();
@@ -3001,15 +3042,39 @@ static time_point select_scenario_time( const time_point &initial, const std::st
                                _( "Set year to?" ) );
                 break;
             case 1:
-                set_time_part( static_cast<int>( season_of_year( selected ) ), 0, 3,
-                               calendar::season_length(), _( "Set season to?  (0 = spring)" ) );
+                if( show_months ) {
+                    const int current_month = static_cast<int>( month_day.first ) + 1;
+                    const std::optional<int> new_month =
+                        query_number( current_month, 1, 12,
+                                      _( "Set month to?  (1 = January)" ) );
+                    if( new_month ) {
+                        set_month_day( *new_month - 1,
+                                       std::min( month_day.second, month_length( *new_month - 1 ) ) );
+                    }
+                } else {
+                    set_time_part( static_cast<int>( season_of_year( selected ) ), 0, 3,
+                                   calendar::season_length(),
+                                   _( "Set season to?  (0 = spring)" ) );
+                }
                 break;
             case 2:
-                set_time_part( day_of_season<int>( selected ) + 1, 1,
-                               get_option<int>( "SEASON_LENGTH" ), 1_days, _( "Set days to?" ) );
+                if( show_months ) {
+                    const int current_month = static_cast<int>( month_day.first );
+                    const std::optional<int> new_day =
+                        query_number( month_day.second, 1, month_length( current_month ),
+                                      _( "Set day of month to?" ) );
+                    if( new_day ) {
+                        set_month_day( current_month, *new_day );
+                    }
+                } else {
+                    set_time_part( day_of_season<int>( selected ) + 1, 1,
+                                   get_option<int>( "SEASON_LENGTH" ), 1_days,
+                                   _( "Set days to?" ) );
+                }
                 break;
             case 3:
-                set_time_part( hour_of_day<int>( selected ), 0, 23, 1_hours, _( "Set hour to?" ) );
+                set_time_part( hour_of_day<int>( selected ), 0, 23, 1_hours,
+                               _( "Set hour to?" ) );
                 break;
             default:
                 break;
@@ -3078,29 +3143,14 @@ static std::string assemble_scenario_details( const avatar &u, const input_conte
     }
 
     assembled += "\n" + colorize( _( "Scenario calendar:" ), COL_HEADER ) + "\n";
-    if( current_scenario == get_scenario() ) {
-        assembled += colorize( ctxt.get_desc( "CHANGE_START_OF_CATACLYSM" ), c_light_green ) + " " +
-                     _( "Start of cataclysm:" ) + " " +
-                     to_string( current_scenario->start_of_cataclysm() ) + "\n";
-        assembled += colorize( ctxt.get_desc( "CHANGE_START_OF_GAME" ), c_light_green ) + " " +
-                     _( "Start of game:" ) + " " + to_string( current_scenario->start_of_game() ) +
-                     "\n";
-        assembled += colorize( ctxt.get_desc( "RESET_CALENDAR" ), c_light_green ) + " " +
-                     _( "Reset scenario calendar" ) + "\n";
-    } else if( current_scenario->custom_start_date() ) {
-        assembled += string_format( current_scenario->is_random_year() ?
-                                    _( "Year:   Random" ) : _( "Year:   %s" ),
-                                    current_scenario->start_year() ) + "\n";
-        assembled += string_format( _( "Season: %s" ),
-                                    calendar::name_season( current_scenario->start_season() ) ) + "\n";
-        assembled += string_format( current_scenario->is_random_day() ? _( "Day:    Random" ) :
-                                    _( "Day:    %d" ), current_scenario->start_day() ) + "\n";
-        assembled += string_format( current_scenario->is_random_hour() ? _( "Hour:   Random" ) :
-                                    _( "Hour:   %d" ), current_scenario->start_hour() ) + "\n";
-    } else {
-        assembled += _( "Default" );
-        assembled += "\n";
-    }
+    assembled += colorize( ctxt.get_desc( "CHANGE_START_OF_CATACLYSM" ), c_light_green ) + " " +
+                 _( "Start of cataclysm:" ) + " " +
+                 to_string( current_scenario->start_of_cataclysm() ) + "\n";
+    assembled += colorize( ctxt.get_desc( "CHANGE_START_OF_GAME" ), c_light_green ) + " " +
+                 _( "Start of game:" ) + " " + to_string( current_scenario->start_of_game() ) +
+                 "\n";
+    assembled += colorize( ctxt.get_desc( "RESET_CALENDAR" ), c_light_green ) + " " +
+                 _( "Reset scenario calendar" ) + "\n";
 
     if( !current_scenario->missions().empty() ) {
         assembled += "\n" + colorize( _( "Scenario missions:" ), COL_HEADER ) + "\n";
@@ -3276,6 +3326,7 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
                 if( !lcmatch( scen.gender_appropriate_name( u.male ), filterstring ) ) {
                     continue;
                 }
+                scen.ensure_calendar();
                 sorted_scens.push_back( &scen );
             }
             if( sorted_scens.empty() ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1658,6 +1658,10 @@ void options_manager::add_options_interface()
     },
     "12h" );
 
+    add( "SHOW_MONTHS", "interface", to_translation( "Show day/month" ),
+         to_translation( "Show day/month instead of season in time displays." ),
+         true );
+
     add_empty_line();
 
     add( "SHOW_GUN_VARIANTS", "interface", to_translation( "Show gun brand names" ),

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2521,12 +2521,12 @@ void options_manager::add_options_world_default()
        );
 
     add( "INITIAL_DAY", "world_default", to_translation( "Initial day" ),
-         to_translation( "How many days into the year the Cataclysm ended.  Day 0 is Spring 1.  Day -1 randomizes the start date.  Can be overridden by scenarios.  This does not advance food rot or monster evolution." ),
+         to_translation( "How many days into the year the player starts.  Day 0 is Spring 1.  Day -1 randomizes the start date.  The Cataclysm begins five days earlier.  Can be overridden by scenarios." ),
          -1, 999, 60
        );
 
     add( "SPAWN_DELAY", "world_default", to_translation( "Spawn delay" ),
-         to_translation( "How many days after the end of the Cataclysm the player spawns.  Day 0 is immediately after the end of the Cataclysm.  Can be overridden by scenarios.  Increasing this will cause food rot and monster evolution to advance." ),
+         to_translation( "How many additional days after the configured start date the player spawns.  Day 0 uses the configured start date.  Can be overridden by scenarios.  Increasing this will cause food rot and monster evolution to advance." ),
          0, 9999, 0
        );
 

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -493,16 +493,17 @@ void scenario::rerandomize() const
         hack->_start_day = rng( 0, get_option<int>( "SEASON_LENGTH" ) - 1 );
     }
 
-    // Initial day is the time of the Cataclysm. Limit it to occur on the first year.
-    hack->_default_start_of_cataclysm = calendar::turn_zero;
-    if( get_option<int>( "INITIAL_DAY" )  == -1 ) {
-        hack->_default_start_of_cataclysm +=
-            1_days * rng( 0, get_option<int>( "SEASON_LENGTH" ) * 4 - 1 );
-    } else {
-        hack->_default_start_of_cataclysm +=
-            1_days * std::min( get_option<int>( "INITIAL_DAY" ),
-                               get_option<int>( "SEASON_LENGTH" ) * 4 );
-    }
+    // INITIAL_DAY is the ordinary game-start day.  As in CCB, the Cataclysm begins
+    // five days earlier, so the default day 60 becomes May 15 / May 20.
+    const int days_in_year = get_option<int>( "SEASON_LENGTH" ) * 4;
+    const int configured_day = get_option<int>( "INITIAL_DAY" );
+    const int game_start_day = configured_day == -1 ?
+                               rng( 0, days_in_year - 1 ) :
+                               std::min( configured_day, days_in_year );
+    const int cataclysm_start_day = std::max( 0, game_start_day - 5 );
+
+    hack->_default_start_of_cataclysm = calendar::turn_zero
+                                        + 1_days * cataclysm_start_day;
 
     if( custom_start_date() ) {
         hack->_default_start_of_game = calendar::turn_zero
@@ -515,7 +516,8 @@ void scenario::rerandomize() const
             hack->_default_start_of_game += calendar::year_length();
         }
     } else {
-        hack->_default_start_of_game = hack->_default_start_of_cataclysm
+        hack->_default_start_of_game = calendar::turn_zero
+                                       + 1_days * game_start_day
                                        + 1_hours * get_option<int>( "INITIAL_TIME" )
                                        + 1_days * get_option<int>( "SPAWN_DELAY" );
     }

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -521,6 +521,7 @@ void scenario::rerandomize() const
     }
 
     hack->reset_calendar();
+    hack->_calendar_initialized = true;
 }
 
 bool scenario::is_random_hour() const
@@ -556,6 +557,13 @@ season_type scenario::start_season() const
 int scenario::start_year() const
 {
     return _start_year;
+}
+
+void scenario::ensure_calendar() const
+{
+    if( !_calendar_initialized ) {
+        rerandomize();
+    }
 }
 
 void scenario::normalize_calendar() const

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -494,13 +494,33 @@ void scenario::rerandomize() const
     }
 
     // Initial day is the time of the Cataclysm. Limit it to occur on the first year.
-    hack->_start_of_cataclysm = calendar::turn_zero;
+    hack->_default_start_of_cataclysm = calendar::turn_zero;
     if( get_option<int>( "INITIAL_DAY" )  == -1 ) {
-        hack->_start_of_cataclysm += 1_days * rng( 0, get_option<int>( "SEASON_LENGTH" ) * 4 - 1 );
+        hack->_default_start_of_cataclysm +=
+            1_days * rng( 0, get_option<int>( "SEASON_LENGTH" ) * 4 - 1 );
     } else {
-        hack->_start_of_cataclysm += 1_days * std::min( get_option<int>( "INITIAL_DAY" ),
-                                     get_option<int>( "SEASON_LENGTH" ) * 4 );
+        hack->_default_start_of_cataclysm +=
+            1_days * std::min( get_option<int>( "INITIAL_DAY" ),
+                               get_option<int>( "SEASON_LENGTH" ) * 4 );
     }
+
+    if( custom_start_date() ) {
+        hack->_default_start_of_game = calendar::turn_zero
+                                       + 1_hours * start_hour()
+                                       + 1_days * start_day()
+                                       + 1_days * get_option<int>( "SEASON_LENGTH" ) * start_season()
+                                       + calendar::year_length() * ( start_year() - 1 );
+        if( hack->_default_start_of_game < hack->_default_start_of_cataclysm ) {
+            // Preserve the old custom-date behavior by moving the start to the same date next year.
+            hack->_default_start_of_game += calendar::year_length();
+        }
+    } else {
+        hack->_default_start_of_game = hack->_default_start_of_cataclysm
+                                       + 1_hours * get_option<int>( "INITIAL_TIME" )
+                                       + 1_days * get_option<int>( "SPAWN_DELAY" );
+    }
+
+    hack->reset_calendar();
 }
 
 bool scenario::is_random_hour() const
@@ -538,6 +558,39 @@ int scenario::start_year() const
     return _start_year;
 }
 
+void scenario::normalize_calendar() const
+{
+    scenario *hack = const_cast<scenario *>( this );
+    if( hack->_default_start_of_game < hack->_default_start_of_cataclysm ) {
+        hack->_default_start_of_game = hack->_default_start_of_cataclysm;
+    }
+    if( hack->_start_of_game < hack->_start_of_cataclysm ) {
+        hack->_start_of_game = hack->_start_of_cataclysm;
+    }
+}
+
+void scenario::reset_calendar() const
+{
+    scenario *hack = const_cast<scenario *>( this );
+    hack->_start_of_cataclysm = _default_start_of_cataclysm;
+    hack->_start_of_game = _default_start_of_game;
+    hack->normalize_calendar();
+}
+
+void scenario::change_start_of_cataclysm( const time_point &t ) const
+{
+    scenario *hack = const_cast<scenario *>( this );
+    hack->_start_of_cataclysm = t;
+    hack->normalize_calendar();
+}
+
+void scenario::change_start_of_game( const time_point &t ) const
+{
+    scenario *hack = const_cast<scenario *>( this );
+    hack->_start_of_game = t;
+    hack->normalize_calendar();
+}
+
 time_point scenario::start_of_cataclysm() const
 {
     return _start_of_cataclysm;
@@ -545,25 +598,7 @@ time_point scenario::start_of_cataclysm() const
 
 time_point scenario::start_of_game() const
 {
-    time_point ret;
-
-    if( custom_start_date() ) {
-        ret = calendar::turn_zero
-              + 1_hours * start_hour()
-              + 1_days * start_day()
-              + 1_days * get_option<int>( "SEASON_LENGTH" ) * start_season()
-              + calendar::year_length() * ( start_year() - 1 );
-        if( ret < start_of_cataclysm() ) {
-            // If the Cataclysm has been set to happen late or the scenario has random start it may try to start before the Cataclysm happens.
-            // That is unacceptable. So lets just jump to same day on next year.
-            ret += calendar::year_length();
-        }
-    } else {
-        ret = start_of_cataclysm()
-              + 1_hours * get_option<int>( "INITIAL_TIME" )
-              + 1_days * get_option<int>( "SPAWN_DELAY" );
-    }
-    return ret;
+    return _start_of_game;
 }
 
 vproto_id scenario::vehicle() const

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -63,7 +63,11 @@ class scenario
         season_type _start_season = SPRING;
         bool _is_random_year = false;
         int _start_year = 1;
+
+        time_point _default_start_of_cataclysm;
+        time_point _default_start_of_game;
         time_point _start_of_cataclysm;
+        time_point _start_of_game;
 
         vproto_id _starting_vehicle = vproto_id::NULL_ID();
 
@@ -112,6 +116,10 @@ class scenario
         season_type start_season() const;
         int start_year() const;
 
+        void normalize_calendar() const;
+        void reset_calendar() const;
+        void change_start_of_cataclysm( const time_point &t ) const;
+        void change_start_of_game( const time_point &t ) const;
         time_point start_of_cataclysm() const;
         time_point start_of_game() const;
 

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -68,6 +68,7 @@ class scenario
         time_point _default_start_of_game;
         time_point _start_of_cataclysm;
         time_point _start_of_game;
+        bool _calendar_initialized = false;
 
         vproto_id _starting_vehicle = vproto_id::NULL_ID();
 
@@ -116,6 +117,7 @@ class scenario
         season_type start_season() const;
         int start_year() const;
 
+        void ensure_calendar() const;
         void normalize_calendar() const;
         void reset_calendar() const;
         void change_start_of_cataclysm( const time_point &t ) const;

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -511,20 +511,6 @@ void handle_weather_effects( const weather_type_id &w )
     get_weather().lightning_active = false;
 }
 
-static std::string to_string( const weekdays &d )
-{
-    static const std::array<std::string, 7> weekday_names = {{
-            translate_marker( "Sunday" ), translate_marker( "Monday" )
-            translate_marker( "Tuesday" ), translate_marker( "Wednesday" )
-            translate_marker( "Thursday" ), translate_marker( "Friday" )
-            translate_marker( "Saturday" )
-        }
-    };
-    static_assert( static_cast<int>( weekdays::SUNDAY ) == 0,
-                   "weekday_names array is out of sync with weekdays enumeration values" );
-    return _( weekday_names[ static_cast<int>( d ) ] );
-}
-
 static std::string print_time_just_hour( const time_point &p )
 {
     const int hour = to_hours<int>( time_past_midnight( p ) );

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -64,11 +64,14 @@ static weather_gen_common get_common_data( const tripoint &location, const time_
     const double year_fraction( time_past_new_year( t.t ) /
                                 calendar::year_length() ); // [0,1)
 
-    result.cyf = std::cos( tau * ( year_fraction + .125 ) ); // [-1, 1]
-    // We add one-eighth to line up `cyf` so that 1 is at
-    // midwinter and -1 at midsummer. (Cataclsym DDA years
-    // start when spring starts. Gregorian years start when
-    // winter starts.)
+    // The public calendar now starts on January 1, while seasons still begin on March 21.
+    // Keep the temperature curve aligned with the actual middle of winter and summer.
+    const double days_year_start_to_midwinter =
+        to_days<double>( ( calendar::season_length() / 2 ) -
+                         ( calendar::season_length() - calendar::turn_zero_offset() ) );
+    const double offset = days_year_start_to_midwinter /
+                          to_days<double>( calendar::year_length() );
+    result.cyf = std::cos( tau * ( year_fraction - offset ) ); // [-1, 1]
     result.season = season_of_year( t.t );
 
     return result;
@@ -257,7 +260,7 @@ units::temperature weather_generator::get_water_temperature() const
 
     season_effective_time t( calendar::turn );
     int season_length = to_days<int>( calendar::season_length() );
-    int day = to_days<int>( time_past_new_year( t.t ) );
+    int day = to_days<int>( time_past_season_year( t.t ) );
     int hour = hour_of_day<int>( t.t );
 
     float water_temperature = 0;
@@ -294,8 +297,7 @@ void weather_generator::test_weather( unsigned seed ) const
             w_point w = get_weather( tripoint_zero, i, seed );
             weather_type_id conditions = get_weather_conditions( w );
 
-            int year = to_turns<int>( i - calendar::turn_zero ) / to_turns<int>
-                       ( calendar::year_length() ) + 1;
+            const int year = calendar::years_since_cataclysm( i ) + 1;
             const int hour = hour_of_day<int>( i );
             const int minute = minute_of_hour<int>( i );
             int day;


### PR DESCRIPTION
## 改动内容

- 在标准 91 天季节长度下，以月/日显示游戏日期，并保留季节显示选项。
- 增加角色创建与调试菜单的日期选择界面，可分别调整大灾变和游戏开始时间。
- 保持天气、采汁等季节逻辑以春季起点计算。

## 植物影响审查

- 种子成长仍由种子年龄及原有季节长度比例决定，未改动成长阶段计算。
- 种植门槛仍按当前气温判断。
- 枫树采汁改用季节年，避免公历显示偏移造成采汁季错位。

## 验证

- 已通过 `git diff --check` 和完整静态差异审查。
- Windows MSVC 测试通过。