### PR TITLE
角色创建界面加入贴图预览

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2718,6 +2718,12 @@
   },
   {
     "type": "keybinding",
+    "name": "切换角色预览服装",
+    "id": "TOGGLE_CHARACTER_PREVIEW_CLOTHES",
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+  },
+  {
+    "type": "keybinding",
     "name": "Toggle debug mode",
     "category": "DEFAULTMODE",
     "id": "debug_mode"

--- a/src/character_preview.cpp
+++ b/src/character_preview.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <list>
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -49,6 +50,21 @@ bool is_clothing_overlay( const std::string &id )
     return id.rfind( "worn_", 0 ) == 0 || id.rfind( "wielded_", 0 ) == 0;
 }
 
+void add_profession_bionic_overlay( const bionic_id &bio, std::set<bionic_id> &visited,
+                                    std::multimap<int, std::pair<std::string, std::string>> &overlays )
+{
+    if( !bio.is_valid() || !visited.insert( bio ).second ) {
+        return;
+    }
+
+    const std::string overlay_id = bio.str();
+    overlays.emplace( get_overlay_order_of_mutation( overlay_id ),
+                      std::make_pair( "mutation_" + overlay_id, "" ) );
+    for( const bionic_id &included : bio->included_bionics ) {
+        add_profession_bionic_overlay( included, visited, overlays );
+    }
+}
+
 class char_preview_adapter : public cata_tiles
 {
   public:
@@ -79,24 +95,18 @@ class char_preview_adapter : public cata_tiles
             }
         }
 
+        // 角色创建早期的临时角色尚未建立完整身体；不要通过 add_bionic() 构造职业义体预览。
         std::multimap<int, std::pair<std::string, std::string>> profession_bionics;
+        std::set<bionic_id> visited_bionics;
         if( ch.prof != nullptr ) {
-            avatar profession_bionic_holder;
             for( const bionic_id &bio : ch.prof->CBMs() ) {
-                profession_bionic_holder.add_bionic( bio );
-            }
-            for( int i = 0; i < profession_bionic_holder.num_bionics(); ++i ) {
-                const bionic &bio = profession_bionic_holder.bionic_at_index( i );
-                if( !bio.show_sprite ) {
-                    continue;
-                }
-                const std::string overlay_id = bio.id.str();
-                profession_bionics.emplace( get_overlay_order_of_mutation( overlay_id ),
-                                             std::make_pair( "mutation_" + overlay_id, "" ) );
+                add_profession_bionic_overlay( bio, visited_bionics, profession_bionics );
             }
         }
         for( const auto &entry : profession_bionics ) {
-            overlays.push_back( entry.second );
+            if( std::find( overlays.begin(), overlays.end(), entry.second ) == overlays.end() ) {
+                overlays.push_back( entry.second );
+            }
         }
 
         if( with_clothing && ch.prof != nullptr ) {
@@ -149,18 +159,21 @@ void character_preview_window::prepare( const int nlines, const int ncols,
         return;
     }
 
+    // 页面切换不应因文本区大小不同而改变同一角色的预览尺寸。
+    static_cast<void>( nlines );
+    static_cast<void>( ncols );
     zoom = default_zoom;
     tilecontext->set_draw_scale( zoom );
     termx_pixels = termx_to_pixel_value();
     termy_pixels = termy_to_pixel_value();
     hide_below_ncols = hide_below;
 
-    const int desired_width = std::max( 1, ncols ) * termx_pixels;
-    const int desired_height = std::max( 1, nlines ) * termy_pixels;
     int tile_width = tilecontext->get_tile_width();
     int tile_height = tilecontext->get_tile_height();
 
-    while( zoom > min_zoom && ( desired_width < tile_width || desired_height < tile_height ) ) {
+    while( zoom > min_zoom &&
+           ( tile_width + 4 * termx_pixels > projected_window_width() ||
+             tile_height + 3 * termy_pixels > projected_window_height() ) ) {
         zoom /= 2;
         tilecontext->set_draw_scale( zoom );
         tile_width = tilecontext->get_tile_width();

--- a/src/character_preview.cpp
+++ b/src/character_preview.cpp
@@ -1,0 +1,308 @@
+#if defined( TILES )
+
+// 角色创建预览逻辑移植并适配自 Cataclysm-BN。
+
+#include "character_preview.h"
+
+#include <algorithm>
+#include <list>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "avatar.h"
+#include "bionics.h"
+#include "cata_tiles.h"
+#include "cata_utility.h"
+#include "creature.h"
+#include "cursesport.h"
+#include "game.h"
+#include "item.h"
+#include "itype.h"
+#include "output.h"
+#include "overlay_ordering.h"
+#include "profession.h"
+#include "sdltiles.h"
+#include "translations.h"
+
+namespace
+{
+
+static const flag_id json_flag_auto_wield( "auto_wield" );
+static const flag_id json_flag_no_auto_equip( "no_auto_equip" );
+
+int termx_to_pixel_value()
+{
+    return std::max( 1, projected_window_width() / std::max( 1, TERMX ) /
+                     std::max( 1, get_scaling_factor() ) );
+}
+
+int termy_to_pixel_value()
+{
+    return std::max( 1, projected_window_height() / std::max( 1, TERMY ) /
+                     std::max( 1, get_scaling_factor() ) );
+}
+
+bool is_clothing_overlay( const std::string &id )
+{
+    return id.rfind( "worn_", 0 ) == 0 || id.rfind( "wielded_", 0 ) == 0;
+}
+
+class char_preview_adapter : public cata_tiles
+{
+  public:
+    static char_preview_adapter *convert( cata_tiles *tiles )
+    {
+        return static_cast<char_preview_adapter *>( tiles );
+    }
+
+    void display_avatar_preview_with_overlays( const avatar &ch, const tripoint &p,
+            const bool with_clothing )
+    {
+        int height_3d = 0;
+        const int previous_height_3d = height_3d;
+        const int rotation = ch.facing == FacingDirection::LEFT ? -1 : 0;
+        const std::string entity_id = ch.male ? "player_male" : "player_female";
+
+        draw_from_id_string( entity_id, TILE_CATEGORY::NONE, "", p, corner, rotation,
+                             lit_level::LIT, false, height_3d );
+
+        std::vector<std::pair<std::string, std::string>> overlays;
+        const std::vector<std::pair<std::string, std::string>> current_overlays =
+            ch.get_overlay_ids();
+        overlays.reserve( current_overlays.size() + 16 );
+
+        for( const std::pair<std::string, std::string> &overlay : current_overlays ) {
+            if( with_clothing || !is_clothing_overlay( overlay.first ) ) {
+                overlays.push_back( overlay );
+            }
+        }
+
+        std::multimap<int, std::pair<std::string, std::string>> profession_bionics;
+        if( ch.prof != nullptr ) {
+            avatar profession_bionic_holder;
+            for( const bionic_id &bio : ch.prof->CBMs() ) {
+                profession_bionic_holder.add_bionic( bio );
+            }
+            for( int i = 0; i < profession_bionic_holder.num_bionics(); ++i ) {
+                const bionic &bio = profession_bionic_holder.bionic_at_index( i );
+                if( !bio.show_sprite ) {
+                    continue;
+                }
+                const std::string overlay_id = bio.id.str();
+                profession_bionics.emplace( get_overlay_order_of_mutation( overlay_id ),
+                                             std::make_pair( "mutation_" + overlay_id, "" ) );
+            }
+        }
+        for( const auto &entry : profession_bionics ) {
+            overlays.push_back( entry.second );
+        }
+
+        if( with_clothing && ch.prof != nullptr ) {
+            const std::list<item> profession_items = ch.prof->items( ch.male, ch.get_mutations() );
+            for( const item &it : profession_items ) {
+                if( it.has_flag( json_flag_no_auto_equip ) ) {
+                    continue;
+                }
+                const std::string variant = it.has_itype_variant() ? it.itype_variant().id : "";
+                if( it.has_flag( json_flag_auto_wield ) ) {
+                    overlays.emplace_back( "wielded_" + it.typeId().str(), variant );
+                } else if( it.is_armor() && ch.can_wear( it ).success() ) {
+                    overlays.emplace_back( "worn_" + it.typeId().str(), variant );
+                }
+            }
+        }
+
+        for( const std::pair<std::string, std::string> &overlay : overlays ) {
+            std::string draw_id = overlay.first;
+            if( !find_overlay_looks_like( ch.male, overlay.first, overlay.second, draw_id ) ) {
+                continue;
+            }
+            int overlay_height_3d = previous_height_3d;
+            draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p, corner, rotation,
+                                 lit_level::LIT, false, overlay_height_3d );
+            height_3d = std::max( height_3d, overlay_height_3d );
+        }
+    }
+};
+
+} // namespace
+
+character_preview_window::~character_preview_window()
+{
+    clear();
+}
+
+void character_preview_window::init( avatar *new_character )
+{
+    character = new_character;
+}
+
+void character_preview_window::prepare( const int nlines, const int ncols,
+                                        const orientation &where, const int hide_below )
+{
+    prepared = false;
+    w_preview = catacurses::window();
+
+    if( character == nullptr || !tilecontext || !tilecontext->is_valid() ) {
+        return;
+    }
+
+    zoom = default_zoom;
+    tilecontext->set_draw_scale( zoom );
+    termx_pixels = termx_to_pixel_value();
+    termy_pixels = termy_to_pixel_value();
+    hide_below_ncols = hide_below;
+
+    const int desired_width = std::max( 1, ncols ) * termx_pixels;
+    const int desired_height = std::max( 1, nlines ) * termy_pixels;
+    int tile_width = tilecontext->get_tile_width();
+    int tile_height = tilecontext->get_tile_height();
+
+    while( zoom > min_zoom && ( desired_width < tile_width || desired_height < tile_height ) ) {
+        zoom /= 2;
+        tilecontext->set_draw_scale( zoom );
+        tile_width = tilecontext->get_tile_width();
+        tile_height = tilecontext->get_tile_height();
+    }
+
+    ncols_width = std::max( 5, divide_round_up( tile_width, termx_pixels ) + 4 );
+    nlines_height = std::max( 5, divide_round_up( tile_height, termy_pixels ) + 3 );
+
+    switch( where.type ) {
+        case TOP_LEFT:
+            pos = point_zero;
+            break;
+        case TOP_RIGHT:
+            pos = point( TERMX - ncols_width, 0 );
+            break;
+        case BOTTOM_LEFT:
+            pos = point( 0, TERMY - nlines_height );
+            break;
+        case BOTTOM_RIGHT:
+            pos = point( TERMX - ncols_width, TERMY - nlines_height );
+            break;
+    }
+
+    pos.x += where.margins.left - where.margins.right;
+    pos.y += where.margins.top - where.margins.bottom;
+    pos.x = clamp( pos.x, 0, std::max( 0, TERMX - ncols_width ) );
+    pos.y = clamp( pos.y, 0, std::max( 0, TERMY - nlines_height ) );
+
+    w_preview = catacurses::newwin( nlines_height, ncols_width, pos );
+    prepared = true;
+}
+
+void character_preview_window::zoom_in()
+{
+    if( !prepared || !tilecontext ) {
+        return;
+    }
+    zoom *= 2;
+    if( zoom > max_zoom ) {
+        zoom = min_zoom;
+    }
+    tilecontext->set_draw_scale( zoom );
+}
+
+void character_preview_window::zoom_out()
+{
+    if( !prepared || !tilecontext ) {
+        return;
+    }
+    zoom /= 2;
+    if( zoom < min_zoom ) {
+        zoom = max_zoom;
+    }
+    tilecontext->set_draw_scale( zoom );
+}
+
+void character_preview_window::toggle_clothes()
+{
+    show_clothes = !show_clothes;
+}
+
+void character_preview_window::display() const
+{
+    if( !visible() || character == nullptr || !tilecontext || !tilecontext->is_valid() ) {
+        return;
+    }
+
+    tilecontext->set_draw_scale( zoom );
+
+    werase( w_preview );
+    draw_border( w_preview, BORDER_COLOR, _( "角色预览" ), BORDER_COLOR );
+    wnoutrefresh( w_preview );
+
+    const int tile_width = tilecontext->get_tile_width();
+    const int tile_height = tilecontext->get_tile_height();
+    const int inner_left = ( pos.x + 1 ) * termx_pixels;
+    const int inner_top = ( pos.y + 1 ) * termy_pixels;
+    const int inner_width = std::max( 1, ( ncols_width - 2 ) * termx_pixels );
+    const int inner_height = std::max( 1, ( nlines_height - 2 ) * termy_pixels );
+    const point draw_origin( inner_left + ( inner_width - tile_width ) / 2,
+                             inner_top + ( inner_height - tile_height ) / 2 );
+
+    const SDL_Renderer_Ptr &renderer = get_sdl_renderer();
+    if( !renderer ) {
+        return;
+    }
+    const bool had_clip = SDL_RenderIsClipEnabled( renderer.get() ) == SDL_TRUE;
+    SDL_Rect previous_clip = {};
+    if( had_clip ) {
+        SDL_RenderGetClipRect( renderer.get(), &previous_clip );
+    }
+    const SDL_Rect clip_rect = { inner_left, inner_top, inner_width, inner_height };
+    SDL_RenderSetClipRect( renderer.get(), &clip_rect );
+
+    const point old_o = cata_tiles::get_o();
+    const point old_op = cata_tiles::get_op();
+    const int old_width = cata_tiles::get_screentile_wdith();
+    const int old_height = cata_tiles::get_screentile_height();
+
+    cata_tiles::get_o() = point_zero;
+    cata_tiles::get_op() = draw_origin;
+    cata_tiles::get_screentile_wdith() = 1;
+    cata_tiles::get_screentile_height() = 1;
+
+    char_preview_adapter::convert( tilecontext.get() )->display_avatar_preview_with_overlays(
+        *character, tripoint_zero, show_clothes );
+
+    cata_tiles::get_o() = old_o;
+    cata_tiles::get_op() = old_op;
+    cata_tiles::get_screentile_wdith() = old_width;
+    cata_tiles::get_screentile_height() = old_height;
+
+    if( had_clip ) {
+        SDL_RenderSetClipRect( renderer.get(), &previous_clip );
+    } else {
+        SDL_RenderSetClipRect( renderer.get(), nullptr );
+    }
+}
+
+void character_preview_window::clear()
+{
+    if( prepared && tilecontext && tilecontext->is_valid() ) {
+        tilecontext->set_draw_scale( DEFAULT_TILESET_ZOOM );
+    }
+    w_preview = catacurses::window();
+    prepared = false;
+}
+
+bool character_preview_window::clothes_showing() const
+{
+    return show_clothes;
+}
+
+bool character_preview_window::visible() const
+{
+    return prepared && TERMX - ncols_width >= hide_below_ncols;
+}
+
+int character_preview_window::width() const
+{
+    return visible() ? ncols_width : 0;
+}
+
+#endif // TILES

--- a/src/character_preview.h
+++ b/src/character_preview.h
@@ -1,0 +1,70 @@
+#pragma once
+#ifndef CATA_SRC_CHARACTER_PREVIEW_H
+#define CATA_SRC_CHARACTER_PREVIEW_H
+
+#if defined( TILES )
+
+#include <cstdint>
+
+#include "cursesdef.h"
+#include "point.h"
+
+class avatar;
+
+/** 角色创建界面中的贴图角色预览窗口。 */
+struct character_preview_window {
+    enum orientation_type : std::uint8_t {
+        TOP_LEFT,
+        TOP_RIGHT,
+        BOTTOM_LEFT,
+        BOTTOM_RIGHT
+    };
+
+    struct margin {
+        int left = 0;
+        int right = 0;
+        int top = 0;
+        int bottom = 0;
+    };
+
+    struct orientation {
+        orientation_type type = TOP_RIGHT;
+        margin margins;
+    };
+
+    character_preview_window() = default;
+    ~character_preview_window();
+
+    void init( avatar *character );
+    void prepare( int nlines, int ncols, const orientation &where, int hide_below_ncols );
+    void zoom_in();
+    void zoom_out();
+    void toggle_clothes();
+    void display() const;
+    void clear();
+
+    bool clothes_showing() const;
+    bool visible() const;
+    int width() const;
+
+  private:
+    static constexpr int min_zoom = 32;
+    static constexpr int max_zoom = 128;
+    static constexpr int default_zoom = 128;
+
+    point pos = point_zero;
+    int termx_pixels = 0;
+    int termy_pixels = 0;
+    int zoom = default_zoom;
+    int hide_below_ncols = 0;
+    int ncols_width = 0;
+    int nlines_height = 0;
+    avatar *character = nullptr;
+    catacurses::window w_preview;
+    bool show_clothes = true;
+    bool prepared = false;
+};
+
+#endif // TILES
+
+#endif // CATA_SRC_CHARACTER_PREVIEW_H

--- a/src/character_preview.h
+++ b/src/character_preview.h
@@ -50,7 +50,9 @@ struct character_preview_window {
   private:
     static constexpr int min_zoom = 32;
     static constexpr int max_zoom = 128;
-    static constexpr int default_zoom = 128;
+    // 微风的贴图缩放单位比 CBN 当前界面更大，128 会让预览占据过多空间。
+    // 默认使用 64，仍可用缩放按键切换到 32 或 128。
+    static constexpr int default_zoom = 64;
 
     point pos = point_zero;
     int termx_pixels = 0;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3786,7 +3786,7 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                                                 preview_ncols_min );
             const character_preview_window::orientation preview_position = {
                 character_preview_window::TOP_RIGHT,
-                character_preview_window::margin{ 0, 2, 10, 0 }
+                character_preview_window::margin{ 0, 2, 5, 0 }
             };
             character_preview.prepare( preview_nlines, preview_ncols, preview_position,
                                        page_width * 3 + 5 );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -990,11 +990,6 @@ void set_points( tab_manager &tabs, avatar &u, pool_type &pool )
     ui_adaptor ui;
     catacurses::window w;
     catacurses::window w_description;
-#if defined( TILES )
-    character_preview_window character_preview;
-    character_preview.init( &u );
-    const bool use_character_preview = character_preview_is_enabled();
-#endif
     const auto init_windows = [&]( ui_adaptor & ui ) {
         w = catacurses::newwin( TERMY, TERMX, point_zero );
         w_description = catacurses::newwin( TERMY - 10, TERMX - 35, point( 31, 5 ) );
@@ -1434,6 +1429,11 @@ void set_traits( tab_manager &tabs, avatar &u, pool_type pool )
     ui_adaptor ui;
     catacurses::window w;
     catacurses::window w_description;
+#if defined( TILES )
+    character_preview_window character_preview;
+    character_preview.init( &u );
+    const bool use_character_preview = character_preview_is_enabled();
+#endif
     const auto init_windows = [&]( ui_adaptor & ui ) {
         w = catacurses::newwin( TERMY, TERMX, point_zero );
         w_description = catacurses::newwin( 3, TERMX - 2, point( 1, TERMY - 4 ) );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -22,6 +22,11 @@
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "calendar_ui.h"
+#if defined( TILES )
+#include "character_preview.h"
+#include "cata_tiles.h"
+#include "sdltiles.h"
+#endif
 #include "character.h"
 #include "character_martial_arts.h"
 #include "color.h"
@@ -84,6 +89,39 @@ static const trait_id trait_SMELLY( "SMELLY" );
 static const trait_id trait_WEAKSCENT( "WEAKSCENT" );
 static const trait_id trait_XS( "XS" );
 static const trait_id trait_XXXL( "XXXL" );
+
+#if defined( TILES )
+static bool character_preview_is_enabled()
+{
+    return get_option<bool>( "USE_CHARACTER_PREVIEW" ) && get_option<bool>( "USE_TILES" ) &&
+           tilecontext && tilecontext->is_valid();
+}
+
+static void register_character_preview_actions( input_context &ctxt )
+{
+    ctxt.register_action( "zoom_in" );
+    ctxt.register_action( "zoom_out" );
+    ctxt.register_action( "TOGGLE_CHARACTER_PREVIEW_CLOTHES" );
+}
+
+static bool handle_character_preview_action( character_preview_window &preview,
+        const std::string &action )
+{
+    if( action == "zoom_in" ) {
+        preview.zoom_in();
+        return true;
+    }
+    if( action == "zoom_out" ) {
+        preview.zoom_out();
+        return true;
+    }
+    if( action == "TOGGLE_CHARACTER_PREVIEW_CLOTHES" ) {
+        preview.toggle_clothes();
+        return true;
+    }
+    return false;
+}
+#endif
 
 // Responsive screen behavior for small terminal sizes
 static bool isWide = false;
@@ -952,6 +990,11 @@ void set_points( tab_manager &tabs, avatar &u, pool_type &pool )
     ui_adaptor ui;
     catacurses::window w;
     catacurses::window w_description;
+#if defined( TILES )
+    character_preview_window character_preview;
+    character_preview.init( &u );
+    const bool use_character_preview = character_preview_is_enabled();
+#endif
     const auto init_windows = [&]( ui_adaptor & ui ) {
         w = catacurses::newwin( TERMY, TERMX, point_zero );
         w_description = catacurses::newwin( TERMY - 10, TERMX - 35, point( 31, 5 ) );
@@ -1396,6 +1439,22 @@ void set_traits( tab_manager &tabs, avatar &u, pool_type pool )
         w_description = catacurses::newwin( 3, TERMX - 2, point( 1, TERMY - 4 ) );
         ui.position_from_window( w );
         page_width = std::min( ( TERMX - 4 ) / used_pages, 38 );
+#if defined( TILES )
+        if( use_character_preview ) {
+            constexpr int preview_nlines_min = 7;
+            constexpr int preview_ncols_min = 10;
+            const int int_page_width = static_cast<int>( page_width );
+            const int preview_nlines = std::max( ( TERMY - 9 ) / 3, preview_nlines_min );
+            const int preview_ncols = std::max( ( TERMX - int_page_width * 3 - 4 ) / 3 - 5,
+                                                preview_ncols_min );
+            const character_preview_window::orientation preview_position = {
+                character_preview_window::TOP_RIGHT,
+                character_preview_window::margin{ 0, 2, 5, 0 }
+            };
+            character_preview.prepare( preview_nlines, preview_ncols, preview_position,
+                                       int_page_width * 3 + 5 );
+        }
+#endif
         iContentHeight = TERMY - 9;
 
         pos_calc();
@@ -1418,6 +1477,11 @@ void set_traits( tab_manager &tabs, avatar &u, pool_type pool )
     ctxt.register_action( "FILTER" );
     ctxt.register_action( "RESET_FILTER" );
     ctxt.register_action( "SORT" );
+#if defined( TILES )
+    if( use_character_preview ) {
+        register_character_preview_actions( ctxt );
+    }
+#endif
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
         werase( w );
@@ -1545,6 +1609,11 @@ void set_traits( tab_manager &tabs, avatar &u, pool_type pool )
 
         wnoutrefresh( w );
         wnoutrefresh( w_description );
+#if defined( TILES )
+        if( use_character_preview ) {
+            character_preview.display();
+        }
+#endif
     } );
 
     do {
@@ -1604,6 +1673,12 @@ void set_traits( tab_manager &tabs, avatar &u, pool_type pool )
 
         ui_manager::redraw();
         const std::string action = ctxt.handle_input();
+#if defined( TILES )
+        if( use_character_preview &&
+            handle_character_preview_action( character_preview, action ) ) {
+            continue;
+        }
+#endif
         std::array< int, 3> cur_sb_pos = iStartPos;
         bool scrollbar_handled = false;
         for( int i = 0; i < static_cast<int>( trait_sbs.size() ); ++i ) {
@@ -1953,10 +2028,33 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
     bool details_recalc = true;
     const int iHeaderHeight = 5;
     scrollbar list_sb;
+#if defined( TILES )
+    character_preview_window character_preview;
+    character_preview.init( &u );
+    const bool use_character_preview = character_preview_is_enabled();
+#endif
     const auto init_windows = [&]( ui_adaptor & ui ) {
         iContentHeight = TERMY - iHeaderHeight - 1;
         w = catacurses::newwin( TERMY, TERMX, point_zero );
-        w_details_pane = catacurses::newwin( iContentHeight, TERMX / 2 - 1, point( TERMX / 2,
+        int details_width = TERMX / 2 - 1;
+#if defined( TILES )
+        if( use_character_preview ) {
+            constexpr int preview_nlines_min = 7;
+            constexpr int preview_ncols_min = 10;
+            const int page_width = TERMX / 2 - 1;
+            const int preview_nlines = std::max( ( TERMY - 9 ) / 3, preview_nlines_min );
+            const int preview_ncols = std::max( ( TERMX - page_width - 4 ) / 3 - 5,
+                                                preview_ncols_min );
+            const character_preview_window::orientation preview_position = {
+                character_preview_window::TOP_RIGHT,
+                character_preview_window::margin{ 0, 2, 5, 0 }
+            };
+            character_preview.prepare( preview_nlines, preview_ncols, preview_position,
+                                       page_width + 5 );
+            details_width = std::max( 20, details_width - character_preview.width() - 1 );
+        }
+#endif
+        w_details_pane = catacurses::newwin( iContentHeight, details_width, point( TERMX / 2,
                                              iHeaderHeight ) );
         details_recalc =  true;
         ui.position_from_window( w );
@@ -1980,6 +2078,11 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
     ctxt.register_action( "FILTER" );
     ctxt.register_action( "RESET_FILTER" );
     ctxt.register_action( "RANDOMIZE" );
+#if defined( TILES )
+    if( use_character_preview ) {
+        register_character_preview_actions( ctxt );
+    }
+#endif
 
     bool recalc_profs = true;
     int profs_length = 0;
@@ -2065,6 +2168,16 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
 
         wnoutrefresh( w );
         details.draw( c_light_gray );
+#if defined( TILES )
+        if( use_character_preview ) {
+            const profession *previous_profession = u.prof;
+            if( cur_id_is_valid ) {
+                u.prof = &sorted_profs[cur_id].obj();
+            }
+            character_preview.display();
+            u.prof = previous_profession;
+        }
+#endif
     } );
 
     do {
@@ -2106,6 +2219,12 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
 
         ui_manager::redraw();
         const std::string action = ctxt.handle_input();
+#if defined( TILES )
+        if( use_character_preview &&
+            handle_character_preview_action( character_preview, action ) ) {
+            continue;
+        }
+#endif
         const int recmax = profs_length;
         const int scroll_rate = recmax > 20 ? 10 : 2;
         const int id_for_curr_description = cur_id;
@@ -3451,6 +3570,11 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
     catacurses::window w_height;
     catacurses::window w_age;
     catacurses::window w_blood;
+#if defined( TILES )
+    character_preview_window character_preview;
+    character_preview.init( &you );
+    const bool use_character_preview = character_preview_is_enabled();
+#endif
     const auto init_windows = [&]( ui_adaptor & ui ) {
         const int freeWidth = TERMX - FULL_SCREEN_WIDTH;
         isWide = ( TERMX > FULL_SCREEN_WIDTH && freeWidth > 15 );
@@ -3499,6 +3623,22 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
             w_guide = catacurses::newwin( 2, TERMX - 3, point( 2, TERMY - 3 ) );
             ui.position_from_window( w );
         }
+#if defined( TILES )
+        if( use_character_preview ) {
+            constexpr int preview_nlines_min = 7;
+            constexpr int preview_ncols_min = 10;
+            constexpr int page_width = 38;
+            const int preview_nlines = std::max( ( TERMY - 9 ) / 3, preview_nlines_min );
+            const int preview_ncols = std::max( ( TERMX - page_width * 3 - 4 ) / 3 - 5,
+                                                preview_ncols_min );
+            const character_preview_window::orientation preview_position = {
+                character_preview_window::TOP_RIGHT,
+                character_preview_window::margin{ 0, 2, 10, 0 }
+            };
+            character_preview.prepare( preview_nlines, preview_ncols, preview_position,
+                                       page_width * 3 + 5 );
+        }
+#endif
     };
     init_windows( ui );
     ui.on_screen_resize( init_windows );
@@ -3522,6 +3662,11 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
     }
     ctxt.register_action( "CHOOSE_LOCATION" );
     ctxt.register_action( "CONFIRM" );
+#if defined( TILES )
+    if( use_character_preview ) {
+        register_character_preview_actions( ctxt );
+    }
+#endif
 
     uilist select_location;
     select_location.text = _( "Select a starting location." );
@@ -3920,6 +4065,11 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
             }
         }
         wnoutrefresh( w_hobbies );
+#if defined( TILES )
+        if( use_character_preview ) {
+            character_preview.display();
+        }
+#endif
     } );
 
     int min_allowed_age = 16;
@@ -3931,6 +4081,12 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
     do {
         ui_manager::redraw();
         const std::string action = ctxt.handle_input();
+#if defined( TILES )
+        if( use_character_preview &&
+            handle_character_preview_action( character_preview, action ) ) {
+            continue;
+        }
+#endif
         if( action == "NEXT_TAB" ) {
             if( pool == pool_type::ONE_POOL ) {
                 if( points_used_total( you ) > point_pool_total() ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1114,14 +1114,40 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
     ui_adaptor ui;
     catacurses::window w;
     catacurses::window w_description;
+#if defined( TILES )
+    character_preview_window character_preview;
+    character_preview.init( &u );
+    const bool use_character_preview = character_preview_is_enabled();
+#endif
     const auto init_windows = [&]( ui_adaptor & ui ) {
         w = catacurses::newwin( TERMY, TERMX, point_zero );
-        w_description = catacurses::newwin( 8, TERMX - iSecondColumn - 1,
-                                            point( iSecondColumn, 5 ) );
+        int description_width = TERMX - iSecondColumn - 1;
+#if defined( TILES )
+        if( use_character_preview ) {
+            constexpr int preview_nlines_min = 7;
+            constexpr int preview_ncols_min = 10;
+            const int preview_nlines = std::max( ( TERMY - 9 ) / 3, preview_nlines_min );
+            const int preview_ncols = std::max( ( TERMX - iSecondColumn - 4 ) / 3 - 5,
+                                                preview_ncols_min );
+            const character_preview_window::orientation preview_position = {
+                character_preview_window::TOP_RIGHT,
+                character_preview_window::margin{ 0, 2, 5, 0 }
+            };
+            character_preview.prepare( preview_nlines, preview_ncols, preview_position,
+                                       iSecondColumn + 21 );
+            description_width = std::max( 20, description_width - character_preview.width() - 1 );
+        }
+#endif
+        w_description = catacurses::newwin( 8, description_width, point( iSecondColumn, 5 ) );
         ui.position_from_window( w );
     };
     init_windows( ui );
     ui.on_screen_resize( init_windows );
+#if defined( TILES )
+    if( use_character_preview ) {
+        register_character_preview_actions( ctxt );
+    }
+#endif
 
     u.reset();
 
@@ -1238,11 +1264,22 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
 
         wnoutrefresh( w );
         wnoutrefresh( w_description );
+#if defined( TILES )
+        if( use_character_preview ) {
+            character_preview.display();
+        }
+#endif
     } );
 
     do {
         ui_manager::redraw();
         const std::string action = ctxt.handle_input();
+#if defined( TILES )
+        if( use_character_preview &&
+            handle_character_preview_action( character_preview, action ) ) {
+            continue;
+        }
+#endif
         if( tabs.handle_input( action, ctxt ) ) {
             break; // Tab has changed or user has quit the screen
         } else if( action == "DOWN" ) {
@@ -2434,11 +2471,34 @@ void set_hobbies( tab_manager &tabs, avatar &u, pool_type pool )
     bool details_recalc = true;
     const int iHeaderHeight = 5;
     scrollbar list_sb;
+#if defined( TILES )
+    character_preview_window character_preview;
+    character_preview.init( &u );
+    const bool use_character_preview = character_preview_is_enabled();
+#endif
 
     const auto init_windows = [&]( ui_adaptor & ui ) {
         iContentHeight = TERMY - iHeaderHeight - 1;
         w = catacurses::newwin( TERMY, TERMX, point_zero );
-        w_details_pane = catacurses::newwin( iContentHeight, TERMX / 2 - 1, point( TERMX / 2,
+        int details_width = TERMX / 2 - 1;
+#if defined( TILES )
+        if( use_character_preview ) {
+            constexpr int preview_nlines_min = 7;
+            constexpr int preview_ncols_min = 10;
+            const int page_width = TERMX / 2 - 1;
+            const int preview_nlines = std::max( ( TERMY - 9 ) / 3, preview_nlines_min );
+            const int preview_ncols = std::max( ( TERMX - page_width - 4 ) / 3 - 5,
+                                                preview_ncols_min );
+            const character_preview_window::orientation preview_position = {
+                character_preview_window::TOP_RIGHT,
+                character_preview_window::margin{ 0, 2, 5, 0 }
+            };
+            character_preview.prepare( preview_nlines, preview_ncols, preview_position,
+                                       page_width + 5 );
+            details_width = std::max( 20, details_width - character_preview.width() - 1 );
+        }
+#endif
+        w_details_pane = catacurses::newwin( iContentHeight, details_width, point( TERMX / 2,
                                              iHeaderHeight ) );
         details_recalc = true;
         ui.position_from_window( w );
@@ -2462,6 +2522,11 @@ void set_hobbies( tab_manager &tabs, avatar &u, pool_type pool )
     ctxt.register_action( "FILTER" );
     ctxt.register_action( "RESET_FILTER" );
     ctxt.register_action( "RANDOMIZE" );
+#if defined( TILES )
+    if( use_character_preview ) {
+        register_character_preview_actions( ctxt );
+    }
+#endif
 
     bool recalc_hobbies = true;
     int profs_length = 0;
@@ -2537,6 +2602,11 @@ void set_hobbies( tab_manager &tabs, avatar &u, pool_type pool )
 
         wnoutrefresh( w );
         details.draw( c_light_gray );
+#if defined( TILES )
+        if( use_character_preview ) {
+            character_preview.display();
+        }
+#endif
     } );
 
     do {
@@ -2569,6 +2639,12 @@ void set_hobbies( tab_manager &tabs, avatar &u, pool_type pool )
         ui_manager::redraw();
         const int id_for_curr_description = cur_id;
         const std::string action = ctxt.handle_input();
+#if defined( TILES )
+        if( use_character_preview &&
+            handle_character_preview_action( character_preview, action ) ) {
+            continue;
+        }
+#endif
         const int recmax = profs_length;
         const int scroll_rate = recmax > 20 ? 10 : 2;
         int scrollbar_pos = iStartPos;
@@ -2780,6 +2856,11 @@ void set_skills( tab_manager &tabs, avatar &u, pool_type pool )
     int iContentHeight = 0;
     const int iHeaderHeight = 5;
     scrollbar list_sb;
+#if defined( TILES )
+    character_preview_window character_preview;
+    character_preview.init( &u );
+    const bool use_character_preview = character_preview_is_enabled();
+#endif
     input_context ctxt( "NEW_CHAR_SKILLS" );
     details.set_up_navigation( ctxt, scrolling_key_scheme::angle_bracket_scroll );
     list_sb.set_draggable( ctxt );
@@ -2792,6 +2873,11 @@ void set_skills( tab_manager &tabs, avatar &u, pool_type pool )
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "QUIT" );
+#if defined( TILES )
+    if( use_character_preview ) {
+        register_character_preview_actions( ctxt );
+    }
+#endif
 
     const auto init_windows = [&]( ui_adaptor & ui ) {
         keybinding_hint = foldstring( string_format(
@@ -2807,7 +2893,25 @@ void set_skills( tab_manager &tabs, avatar &u, pool_type pool )
         iContentHeight = TERMY - static_cast<int>( keybinding_hint.size() ) - iHeaderHeight - 1;
         w = catacurses::newwin( TERMY, TERMX, point_zero );
         w_list = catacurses::newwin( iContentHeight, 35, point( 1, iHeaderHeight ) );
-        w_details_pane = catacurses::newwin( iContentHeight, TERMX - 35, point( 31, 5 ) );
+        int details_width = TERMX - 35;
+#if defined( TILES )
+        if( use_character_preview ) {
+            constexpr int preview_nlines_min = 7;
+            constexpr int preview_ncols_min = 10;
+            constexpr int list_width = 35;
+            const int preview_nlines = std::max( ( TERMY - 9 ) / 3, preview_nlines_min );
+            const int preview_ncols = std::max( ( TERMX - list_width - 4 ) / 3 - 5,
+                                                preview_ncols_min );
+            const character_preview_window::orientation preview_position = {
+                character_preview_window::TOP_RIGHT,
+                character_preview_window::margin{ 0, 2, 5, 0 }
+            };
+            character_preview.prepare( preview_nlines, preview_ncols, preview_position,
+                                       list_width + 25 );
+            details_width = std::max( 20, details_width - character_preview.width() - 1 );
+        }
+#endif
+        w_details_pane = catacurses::newwin( iContentHeight, details_width, point( 31, 5 ) );
         details_recalc = true;
         w_keybindings = catacurses::newwin( static_cast<int>( keybinding_hint.size() ), TERMX - 2, point( 1,
                                             iHeaderHeight + iContentHeight ) );
@@ -2975,11 +3079,22 @@ void set_skills( tab_manager &tabs, avatar &u, pool_type pool )
         wnoutrefresh( w_list );
         wnoutrefresh( w_keybindings );
         details.draw( c_light_gray );
+#if defined( TILES )
+        if( use_character_preview ) {
+            character_preview.display();
+        }
+#endif
     } );
 
     do {
         ui_manager::redraw();
         const std::string action = ctxt.handle_input();
+#if defined( TILES )
+        if( use_character_preview &&
+            handle_character_preview_action( character_preview, action ) ) {
+            continue;
+        }
+#endif
         const int pos_for_curr_description = cur_pos;
         int scrollbar_pos = cur_offset;
 
@@ -3187,13 +3302,35 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
     bool details_recalc = true;
     const int iHeaderHeight = 5;
     scrollbar list_sb;
+#if defined( TILES )
+    character_preview_window character_preview;
+    character_preview.init( &u );
+    const bool use_character_preview = character_preview_is_enabled();
+#endif
 
     const auto init_windows = [&]( ui_adaptor & ui ) {
         iContentHeight = TERMY - iHeaderHeight - 1;
         w = catacurses::newwin( TERMY, TERMX, point_zero );
         const int second_column_w = TERMX / 2 - 1;
+        int details_width = second_column_w;
+#if defined( TILES )
+        if( use_character_preview ) {
+            constexpr int preview_nlines_min = 7;
+            constexpr int preview_ncols_min = 10;
+            const int preview_nlines = std::max( ( TERMY - 9 ) / 3, preview_nlines_min );
+            const int preview_ncols = std::max( ( TERMX - second_column_w - 4 ) / 3 - 5,
+                                                preview_ncols_min );
+            const character_preview_window::orientation preview_position = {
+                character_preview_window::TOP_RIGHT,
+                character_preview_window::margin{ 0, 2, 5, 0 }
+            };
+            character_preview.prepare( preview_nlines, preview_ncols, preview_position,
+                                       second_column_w + 5 );
+            details_width = std::max( 20, details_width - character_preview.width() - 1 );
+        }
+#endif
         point origin = point( second_column_w + 1, iHeaderHeight );
-        w_details_pane = catacurses::newwin( iContentHeight, second_column_w, origin );
+        w_details_pane = catacurses::newwin( iContentHeight, details_width, origin );
         details_recalc = true;
         ui.position_from_window( w );
     };
@@ -3219,6 +3356,11 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
     ctxt.register_action( "CHANGE_START_OF_CATACLYSM" );
     ctxt.register_action( "CHANGE_START_OF_GAME" );
     ctxt.register_action( "RESET_CALENDAR" );
+#if defined( TILES )
+    if( use_character_preview ) {
+        register_character_preview_actions( ctxt );
+    }
+#endif
 
     bool recalc_scens = true;
     int scens_length = 0;
@@ -3305,6 +3447,11 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
 
         wnoutrefresh( w );
         details.draw( c_light_gray );
+#if defined( TILES )
+        if( use_character_preview ) {
+            character_preview.display();
+        }
+#endif
     } );
 
     do {
@@ -3355,6 +3502,12 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
 
         ui_manager::redraw();
         const std::string action = ctxt.handle_input();
+#if defined( TILES )
+        if( use_character_preview &&
+            handle_character_preview_action( character_preview, action ) ) {
+            continue;
+        }
+#endif
         const int scroll_rate = scens_length > 20 ? 5 : 2;
         const int id_for_curr_description = cur_id;
         int scrollbar_pos = iStartPos;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2169,7 +2169,7 @@ void options_manager::add_options_graphics()
        );
 
     add( "USE_CHARACTER_PREVIEW", "graphics", to_translation( "角色创建贴图预览" ),
-         to_translation( "在角色创建的职业、特性和描述界面显示角色贴图。"
+         to_translation( "在角色创建的场景、职业、背景、属性、特性、技能和描述界面显示角色贴图。"
                          "可用 z、Z 缩放，按 c 显示或隐藏职业服装。" ),
          true, COPT_CURSES_HIDE
        );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2168,6 +2168,12 @@ void options_manager::add_options_graphics()
          true, COPT_CURSES_HIDE
        );
 
+    add( "USE_CHARACTER_PREVIEW", "graphics", to_translation( "角色创建贴图预览" ),
+         to_translation( "在角色创建的职业、特性和描述界面显示角色贴图。"
+                         "可用 z、Z 缩放，按 c 显示或隐藏职业服装。" ),
+         true, COPT_CURSES_HIDE
+       );
+
     add( "TILES", "graphics", to_translation( "Choose tileset" ),
          to_translation( "Choose the tileset you want to use." ),
          build_tilesets_list(), "MshockXottoplus", COPT_CURSES_HIDE
@@ -2189,6 +2195,7 @@ void options_manager::add_options_graphics()
        ); // populate the options dynamically
 
     get_option( "TILES" ).setPrerequisite( "USE_TILES" );
+    get_option( "USE_CHARACTER_PREVIEW" ).setPrerequisite( "USE_TILES" );
     get_option( "USE_DISTANT_TILES" ).setPrerequisite( "USE_TILES" );
     get_option( "DISTANT_TILES" ).setPrerequisite( "USE_DISTANT_TILES" );
     get_option( "SWAP_ZOOM" ).setPrerequisite( "USE_DISTANT_TILES" );


### PR DESCRIPTION
## 改动内容

参考 CBN 的角色创建贴图预览实现，在微风角色创建界面中加入可选的角色贴图预览：

- 在场景、职业、背景、属性、特性、技能和描述页面显示当前角色外观。
- 预览会随性别、外貌特征、职业装备和生化插件等选择实时更新。
- 增加角色预览选项及快捷操作，可缩放预览并切换服装显示。
- 缩小默认预览尺寸，统一描述页面与其他页面的预览位置，减少对文字区域的占用。

## 修复与兼容

- 修复特性页面预览对象的作用域问题。
- 修复部分职业生化插件在生成预览角色时产生的报错。
- 统一各角色创建页面的预览尺寸和布局行为。
- 保留 `main` 中现有的公历角色创建界面支持。
- 不启用图块或关闭角色预览选项时，继续使用原有界面流程。

## 验证

- 已在个人仓库测试分支完成 Windows MSVC 编译。
- 已进行游戏内角色创建测试，场景、职业、背景、属性、特性、技能和描述页面显示正常。
- 已验证职业装备、生化插件、预览缩放、服装切换和描述页布局。
- `git diff --check` 通过，PR 仅包含角色预览相关的 5 个文件。