### PR TITLE
自动驾驶采用 CBN 式高速路径规划

### DIFF
--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -147,10 +147,7 @@ static constexpr int TURNING_INCREMENT = 15;
 static constexpr int NUM_ORIENTATIONS = 360 / TURNING_INCREMENT;
 // min and max speed in tiles/s
 static constexpr int MIN_SPEED_TPS = 1;
-// 常规寻路保持低速，确保弯道、城市道路和狭窄区域稳定。
-static constexpr int MAX_CAUTIOUS_SPEED_TPS = 3;
-// 当已计算路径直到下一过图块都不需要转向时，允许高速直行。
-static constexpr int MAX_GREEDY_SPEED_TPS = 10;
+static constexpr int MAX_SPEED_TPS = 9;
 static constexpr int VMIPH_PER_TPS = static_cast<int>( vehicles::vmiph_per_tile );
 
 /**
@@ -301,10 +298,8 @@ struct auto_navigation_data {
     bool land_ok;
     bool water_ok;
     bool air_ok;
-    // the maximum speed to consider driving at when using A*, in tiles/s
-    int max_cautious_speed_tps = 0;
-    // the maximum speed to consider when following a verified straight path, in tiles/s
-    int max_greedy_speed_tps = 0;
+    // the maximum speed to consider driving at, in tiles/s
+    int max_speed_tps;
     // max acceleration
     std::vector<int> acceleration;
     // max amount of steering actions per turn
@@ -385,7 +380,6 @@ class vehicle::autodrive_controller
         const vehicle &driven_veh;
         const Character &driver;
         auto_navigation_data data;
-        bool in_greedy_mode = false;
 
         void compute_coordinates();
         bool check_drivable(const tripoint_bub_ms& pt) const;
@@ -396,7 +390,6 @@ class vehicle::autodrive_controller
         void compute_valid_positions();
         void compute_goal_zone();
         void precompute_data();
-        bool check_greedy_mode() const;
         scored_address compute_node_score( const node_address &addr, const navigation_node &node ) const;
         void compute_next_nodes( const node_address &addr, const navigation_node &node,
                                  int target_speed_tps,
@@ -927,11 +920,9 @@ void vehicle::autodrive_controller::precompute_data()
         data.land_ok = driven_veh.valid_wheel_config();
         data.water_ok = driven_veh.can_float();
         data.air_ok = driven_veh.has_sufficient_rotorlift();
-        const int safe_speed_tps = driven_veh.safe_velocity() / VMIPH_PER_TPS;
-        data.max_cautious_speed_tps = std::min( MAX_CAUTIOUS_SPEED_TPS, safe_speed_tps );
-        data.max_greedy_speed_tps = std::min( MAX_GREEDY_SPEED_TPS, safe_speed_tps );
-        data.acceleration.resize( data.max_cautious_speed_tps );
-        for( int speed_tps = 0; speed_tps < data.max_cautious_speed_tps; speed_tps++ ) {
+        data.max_speed_tps = std::min( MAX_SPEED_TPS, driven_veh.safe_velocity() / VMIPH_PER_TPS );
+        data.acceleration.resize( data.max_speed_tps );
+        for( int speed_tps = 0; speed_tps < data.max_speed_tps; speed_tps++ ) {
             data.acceleration[speed_tps] = driven_veh.acceleration( true, speed_tps * VMIPH_PER_TPS );
         }
         // TODO: compute from driver's skill and speed stat
@@ -948,7 +939,6 @@ void vehicle::autodrive_controller::precompute_data()
         compute_valid_positions();
         compute_goal_zone();
         data.path.clear();
-        in_greedy_mode = false;
     }
 }
 
@@ -1013,7 +1003,7 @@ const
     int next_speed = target_speed;
     int num_tiles_to_move = std::abs( target_speed_tps );
     if( target_speed_tps > 1 && node.speed < target_speed ) {
-        const int cur_tps = std::min( std::max( node.speed / VMIPH_PER_TPS, 0 ), data.max_cautious_speed_tps - 1 );
+        const int cur_tps = std::min( std::max( node.speed / VMIPH_PER_TPS, 0 ), data.max_speed_tps - 1 );
         next_speed = std::min( std::max<int>( node.speed, 0 ) + data.acceleration[cur_tps], target_speed );
         num_tiles_to_move = next_speed / VMIPH_PER_TPS;
     }
@@ -1138,14 +1128,8 @@ void vehicle::autodrive_controller::check_safe_speed()
     // However, sometimes the vehicle's safe speed may drop (e.g. amphibious vehicle entering
     // water), so this extra check is needed to adjust our max speed.
     int safe_speed_tps = driven_veh.safe_velocity() / VMIPH_PER_TPS;
-    if( data.max_cautious_speed_tps > safe_speed_tps ) {
-        data.max_cautious_speed_tps = safe_speed_tps;
-    }
-    if( data.max_greedy_speed_tps > safe_speed_tps ) {
-        data.max_greedy_speed_tps = safe_speed_tps;
-    }
-    if( data.max_greedy_speed_tps <= data.max_cautious_speed_tps ) {
-        in_greedy_mode = false;
+    if( data.max_speed_tps > safe_speed_tps ) {
+        data.max_speed_tps = safe_speed_tps;
     }
 }
 
@@ -1219,87 +1203,31 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
 
 void vehicle::autodrive_controller::reduce_speed()
 {
-    data.max_cautious_speed_tps = MIN_SPEED_TPS;
-    in_greedy_mode = false;
-}
-
-bool vehicle::autodrive_controller::check_greedy_mode() const
-{
-    // 飞行中的载具沿用原有自动驾驶速度和避障方式。
-    if( driven_veh.is_rotorcraft() && driven_veh.is_flying_in_air() ) {
-        return false;
-    }
-    // 接近目的地时保持低速，避免冲过终点。
-    if( driver.omt_path.size() <= 2 ) {
-        return false;
-    }
-    if( data.max_greedy_speed_tps <= data.max_cautious_speed_tps ) {
-        return false;
-    }
-    // 只有直到下一过图块的整段路径都无需转向，才允许高速直行。
-    for( const navigation_step &step : data.path ) {
-        if( step.steering_dir != to_orientation( driven_veh.turn_dir ) ) {
-            return false;
-        }
-    }
-    return !data.path.empty();
+    data.max_speed_tps = MIN_SPEED_TPS;
 }
 
 std::optional<navigation_step> vehicle::autodrive_controller::compute_next_step()
 {
     precompute_data();
     const tripoint_abs_ms veh_pos = driven_veh.global_square_location();
-    const bool had_cached_path = !data.path.empty();
-    const bool two_steps = data.path.size() > 2;
-    const navigation_step first_step = two_steps ? data.path.back() : navigation_step();
-    const navigation_step second_step = two_steps ? data.path.at( data.path.size() - 2 ) :
-                                        navigation_step();
-    bool maintain_speed = false;
-    // If vehicle did not move as far as planned and direction is the same
-    // then it is still accelerating. If the vehicle moved more than expected
-    // then we likely underestimated the acceleration when planning the path.
-    // If either of these happen, we should maintain speed but compute a new path.
-    if( !in_greedy_mode ) {
-        if( two_steps &&
-            square_dist( first_step.pos.xy().raw(), second_step.pos.xy().raw() ) !=
-            square_dist( first_step.pos.xy().raw(), veh_pos.xy().raw() ) &&
-            first_step.steering_dir == second_step.steering_dir ) {
-            maintain_speed = true;
-            data.path.clear();
-        } else {
-            while( !data.path.empty() && data.path.back().pos != veh_pos ) {
-                data.path.pop_back();
-            }
-        }
-        if( !data.path.empty() &&
-            data.path.back().target_speed_tps > data.max_cautious_speed_tps ) {
-            data.path.clear();
-            maintain_speed = false;
-        }
+
+    while( !data.path.empty() && data.path.back().pos != veh_pos ) {
+        data.path.pop_back();
+    }
+    if( !data.path.empty() && data.path.back().target_speed_tps > data.max_speed_tps ) {
+        data.path.clear();
     }
     if( data.path.empty() ) {
-        // if we're just starting out or we've gone off-course use the lowest speed
-        if( ( had_cached_path && !maintain_speed ) || driven_veh.velocity == 0 ) {
-            data.max_cautious_speed_tps = MIN_SPEED_TPS;
-        }
-        auto new_path = compute_path( data.max_cautious_speed_tps );
-        while( !new_path && data.max_cautious_speed_tps > MIN_SPEED_TPS ) {
-            // high speed didn't work, try a lower speed
-            data.max_cautious_speed_tps /= 2;
-            new_path = compute_path( data.max_cautious_speed_tps );
+        auto new_path = compute_path( data.max_speed_tps );
+        while( !new_path && data.max_speed_tps > MIN_SPEED_TPS ) {
+            // high speed did not work, try a lower speed
+            data.max_speed_tps /= 2;
+            new_path = compute_path( data.max_speed_tps );
         }
         if( !new_path ) {
             return std::nullopt;
         }
         data.path.swap( *new_path );
-        in_greedy_mode = check_greedy_mode();
-    }
-    if( in_greedy_mode ) {
-        navigation_step greedy_step;
-        greedy_step.pos = driven_veh.global_square_location();
-        greedy_step.steering_dir = to_orientation( driven_veh.turn_dir );
-        greedy_step.target_speed_tps = data.max_greedy_speed_tps;
-        return greedy_step;
     }
     return data.path.back();
 }

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -147,7 +147,10 @@ static constexpr int TURNING_INCREMENT = 15;
 static constexpr int NUM_ORIENTATIONS = 360 / TURNING_INCREMENT;
 // min and max speed in tiles/s
 static constexpr int MIN_SPEED_TPS = 1;
-static constexpr int MAX_SPEED_TPS = 3;
+// 常规寻路保持低速，确保弯道、城市道路和狭窄区域稳定。
+static constexpr int MAX_CAUTIOUS_SPEED_TPS = 3;
+// 当已计算路径直到下一过图块都不需要转向时，允许高速直行。
+static constexpr int MAX_GREEDY_SPEED_TPS = 10;
 static constexpr int VMIPH_PER_TPS = static_cast<int>( vehicles::vmiph_per_tile );
 
 /**
@@ -298,8 +301,10 @@ struct auto_navigation_data {
     bool land_ok;
     bool water_ok;
     bool air_ok;
-    // the maximum speed to consider driving at, in tiles/s
-    int max_speed_tps;
+    // the maximum speed to consider driving at when using A*, in tiles/s
+    int max_cautious_speed_tps = 0;
+    // the maximum speed to consider when following a verified straight path, in tiles/s
+    int max_greedy_speed_tps = 0;
     // max acceleration
     std::vector<int> acceleration;
     // max amount of steering actions per turn
@@ -380,6 +385,7 @@ class vehicle::autodrive_controller
         const vehicle &driven_veh;
         const Character &driver;
         auto_navigation_data data;
+        bool in_greedy_mode = false;
 
         void compute_coordinates();
         bool check_drivable(const tripoint_bub_ms& pt) const;
@@ -390,6 +396,7 @@ class vehicle::autodrive_controller
         void compute_valid_positions();
         void compute_goal_zone();
         void precompute_data();
+        bool check_greedy_mode() const;
         scored_address compute_node_score( const node_address &addr, const navigation_node &node ) const;
         void compute_next_nodes( const node_address &addr, const navigation_node &node,
                                  int target_speed_tps,
@@ -920,9 +927,11 @@ void vehicle::autodrive_controller::precompute_data()
         data.land_ok = driven_veh.valid_wheel_config();
         data.water_ok = driven_veh.can_float();
         data.air_ok = driven_veh.has_sufficient_rotorlift();
-        data.max_speed_tps = std::min( MAX_SPEED_TPS, driven_veh.safe_velocity() / VMIPH_PER_TPS );
-        data.acceleration.resize( data.max_speed_tps );
-        for( int speed_tps = 0; speed_tps < data.max_speed_tps; speed_tps++ ) {
+        const int safe_speed_tps = driven_veh.safe_velocity() / VMIPH_PER_TPS;
+        data.max_cautious_speed_tps = std::min( MAX_CAUTIOUS_SPEED_TPS, safe_speed_tps );
+        data.max_greedy_speed_tps = std::min( MAX_GREEDY_SPEED_TPS, safe_speed_tps );
+        data.acceleration.resize( data.max_cautious_speed_tps );
+        for( int speed_tps = 0; speed_tps < data.max_cautious_speed_tps; speed_tps++ ) {
             data.acceleration[speed_tps] = driven_veh.acceleration( true, speed_tps * VMIPH_PER_TPS );
         }
         // TODO: compute from driver's skill and speed stat
@@ -939,6 +948,7 @@ void vehicle::autodrive_controller::precompute_data()
         compute_valid_positions();
         compute_goal_zone();
         data.path.clear();
+        in_greedy_mode = false;
     }
 }
 
@@ -1003,7 +1013,7 @@ const
     int next_speed = target_speed;
     int num_tiles_to_move = std::abs( target_speed_tps );
     if( target_speed_tps > 1 && node.speed < target_speed ) {
-        const int cur_tps = std::min( std::max( node.speed / VMIPH_PER_TPS, 0 ), data.max_speed_tps - 1 );
+        const int cur_tps = std::min( std::max( node.speed / VMIPH_PER_TPS, 0 ), data.max_cautious_speed_tps - 1 );
         next_speed = std::min( std::max<int>( node.speed, 0 ) + data.acceleration[cur_tps], target_speed );
         num_tiles_to_move = next_speed / VMIPH_PER_TPS;
     }
@@ -1128,8 +1138,14 @@ void vehicle::autodrive_controller::check_safe_speed()
     // However, sometimes the vehicle's safe speed may drop (e.g. amphibious vehicle entering
     // water), so this extra check is needed to adjust our max speed.
     int safe_speed_tps = driven_veh.safe_velocity() / VMIPH_PER_TPS;
-    if( data.max_speed_tps > safe_speed_tps ) {
-        data.max_speed_tps = safe_speed_tps;
+    if( data.max_cautious_speed_tps > safe_speed_tps ) {
+        data.max_cautious_speed_tps = safe_speed_tps;
+    }
+    if( data.max_greedy_speed_tps > safe_speed_tps ) {
+        data.max_greedy_speed_tps = safe_speed_tps;
+    }
+    if( data.max_greedy_speed_tps <= data.max_cautious_speed_tps ) {
+        in_greedy_mode = false;
     }
 }
 
@@ -1203,7 +1219,30 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
 
 void vehicle::autodrive_controller::reduce_speed()
 {
-    data.max_speed_tps = MIN_SPEED_TPS;
+    data.max_cautious_speed_tps = MIN_SPEED_TPS;
+    in_greedy_mode = false;
+}
+
+bool vehicle::autodrive_controller::check_greedy_mode() const
+{
+    // 飞行中的载具沿用原有自动驾驶速度和避障方式。
+    if( driven_veh.is_rotorcraft() && driven_veh.is_flying_in_air() ) {
+        return false;
+    }
+    // 接近目的地时保持低速，避免冲过终点。
+    if( driver.omt_path.size() <= 2 ) {
+        return false;
+    }
+    if( data.max_greedy_speed_tps <= data.max_cautious_speed_tps ) {
+        return false;
+    }
+    // 只有直到下一过图块的整段路径都无需转向，才允许高速直行。
+    for( const navigation_step &step : data.path ) {
+        if( step.steering_dir != to_orientation( driven_veh.turn_dir ) ) {
+            return false;
+        }
+    }
+    return !data.path.empty();
 }
 
 std::optional<navigation_step> vehicle::autodrive_controller::compute_next_step()
@@ -1220,36 +1259,47 @@ std::optional<navigation_step> vehicle::autodrive_controller::compute_next_step(
     // then it is still accelerating. If the vehicle moved more than expected
     // then we likely underestimated the acceleration when planning the path.
     // If either of these happen, we should maintain speed but compute a new path.
-    if (two_steps && square_dist(first_step.pos.xy().raw(), second_step.pos.xy().raw()) !=
-        square_dist( first_step.pos.xy().raw(), veh_pos.xy().raw() ) &&
-        first_step.steering_dir == second_step.steering_dir ) {
-        data.path.pop_back();
-        maintain_speed = true;
-        data.path.clear();
-    } else {
-        while( !data.path.empty() && data.path.back().pos != veh_pos ) {
-            data.path.pop_back();
+    if( !in_greedy_mode ) {
+        if( two_steps &&
+            square_dist( first_step.pos.xy().raw(), second_step.pos.xy().raw() ) !=
+            square_dist( first_step.pos.xy().raw(), veh_pos.xy().raw() ) &&
+            first_step.steering_dir == second_step.steering_dir ) {
+            maintain_speed = true;
+            data.path.clear();
+        } else {
+            while( !data.path.empty() && data.path.back().pos != veh_pos ) {
+                data.path.pop_back();
+            }
         }
-    }
-    if( !data.path.empty() && data.path.back().target_speed_tps > data.max_speed_tps ) {
-        data.path.clear();
-        maintain_speed = false;
+        if( !data.path.empty() &&
+            data.path.back().target_speed_tps > data.max_cautious_speed_tps ) {
+            data.path.clear();
+            maintain_speed = false;
+        }
     }
     if( data.path.empty() ) {
         // if we're just starting out or we've gone off-course use the lowest speed
         if( ( had_cached_path && !maintain_speed ) || driven_veh.velocity == 0 ) {
-            data.max_speed_tps = MIN_SPEED_TPS;
+            data.max_cautious_speed_tps = MIN_SPEED_TPS;
         }
-        auto new_path = compute_path( data.max_speed_tps );
-        while( !new_path && data.max_speed_tps > MIN_SPEED_TPS ) {
+        auto new_path = compute_path( data.max_cautious_speed_tps );
+        while( !new_path && data.max_cautious_speed_tps > MIN_SPEED_TPS ) {
             // high speed didn't work, try a lower speed
-            data.max_speed_tps /= 2;
-            new_path = compute_path( data.max_speed_tps );
+            data.max_cautious_speed_tps /= 2;
+            new_path = compute_path( data.max_cautious_speed_tps );
         }
         if( !new_path ) {
             return std::nullopt;
         }
         data.path.swap( *new_path );
+        in_greedy_mode = check_greedy_mode();
+    }
+    if( in_greedy_mode ) {
+        navigation_step greedy_step;
+        greedy_step.pos = driven_veh.global_square_location();
+        greedy_step.steering_dir = to_orientation( driven_veh.turn_dir );
+        greedy_step.target_speed_tps = data.max_greedy_speed_tps;
+        return greedy_step;
     }
     return data.path.back();
 }


### PR DESCRIPTION
## 改动内容

微风现有自动驾驶的规划速度上限较低，车辆即使具有足够动力和安全速度，在普通道路上也难以维持合理巡航速度。

本提交参考 Cataclysm: Bright Nights 的实现，将自动驾驶最高规划速度统一调整为每秒 9 格，约 58 公里/小时，并让该速度直接参与普通 A* 寻路：

- 直路、缓弯和多数道路可以更稳定地维持高速。
- 高速路径不可行时，依次按 9、4、2、1 格/秒降低规划速度并重新寻路。
- 保留车辆自身安全速度限制，不强制超过车辆性能。
- 保留碰撞检测、视野检查、障碍减速和紧急停止逻辑。
- 不修改车辆 JSON、存档格式、按键或界面。

## 验证

- Windows Tiles x64 MSVC 构建成功。
- Android arm64 构建成功。
- Windows 与 Android 测试附件均上传成功。
- 已进行游戏内自动驾驶测试，基本运行正常。
- `git diff --check` 通过，PR 仅修改 `src/vehicle_autodrive.cpp`。

测试运行：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/29995186169