### PR TITLE
修复飞艇自动驾驶无法寻路

### DIFF
--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -919,7 +919,7 @@ void vehicle::autodrive_controller::precompute_data()
         // initialize car and driver properties
         data.land_ok = driven_veh.valid_wheel_config();
         data.water_ok = driven_veh.can_float();
-        data.air_ok = driven_veh.has_sufficient_rotorlift();
+        data.air_ok = driven_veh.has_sufficient_rotorlift() || driven_veh.is_airship();
         data.max_speed_tps = std::min( MAX_SPEED_TPS, driven_veh.safe_velocity() / VMIPH_PER_TPS );
         data.acceleration.resize( data.max_speed_tps );
         for( int speed_tps = 0; speed_tps < data.max_speed_tps; speed_tps++ ) {


### PR DESCRIPTION
## 改动内容

修复飞艇在空中启用自动驾驶时立即提示“无法看清前方道路”并中止的问题：

- 自动驾驶初始化空中通行能力时，同时识别旋翼升力与飞艇气囊升力。
- 让具备足够气囊升力的飞艇能够将开放空气视为可通行区域并正常参与 A* 寻路。
- 保留现有旋翼机寻路、视野检查、障碍判断和安全速度逻辑。
- 不修改车辆 JSON、存档格式、按键或界面。

## 原因

飞艇通过 `is_airship()` 和气囊升力判定飞行能力，但自动驾驶的 `air_ok` 只检查 `has_sufficient_rotorlift()`。因此飞艇会被寻路器当作不能飞行的载具，所有开放空气都被标记为障碍，最终触发通用的“无法看清前方道路”提示。

## 验证

- `git diff --check` 通过，PR 仅修改 `src/vehicle_autodrive.cpp`。
- 已核对开放空气与未记忆空气格的寻路分支，飞艇现在与旋翼机一样被识别为可在空中通行。
- 本地单文件编译受仓库基线第三方 FlatBuffers 与 GCC 16 / Clang 22 的兼容问题阻断，错误发生在 `src/third-party/flatbuffers/stl_emulation.h`，先于本次改动代码。
