### PR TITLE
确保难民中心与固定派系据点全世界唯一

### DIFF
--- a/data/json/overmap/overmap_special/alien.json
+++ b/data/json/overmap/overmap_special/alien.json
@@ -104,6 +104,6 @@
     "city_sizes": [ 1, 12 ],
     "//": "Occurrences should drop a lot once we have some breadcrumbs leading to the base, but until then this is going to be the only way to get CBMs.",
     "occurrences": [ 1, 12 ],
-    "flags": [ "UNIQUE", "EXODII" ]
+    "flags": [ "GLOBALLY_UNIQUE", "EXODII" ]
   }
 ]

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -3345,7 +3345,7 @@
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 75, 100 ],
     "priority": 1,
-    "flags": [ "UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
+    "flags": [ "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -581,7 +581,7 @@
     "city_distance": [ 25, -1 ],
     "occurrences": [ 50, 100 ],
     "//": "Inflated chance, effective rate ~40%",
-    "flags": [ "CLASSIC", "WILDERNESS", "UNIQUE", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "WILDERNESS", "GLOBALLY_UNIQUE", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",
@@ -1268,7 +1268,7 @@
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 4, 12 ],
     "occurrences": [ 50, 100 ],
-    "flags": [ "CLASSIC", "LAKE", "UNIQUE", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "LAKE", "GLOBALLY_UNIQUE", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",
@@ -3605,7 +3605,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
     "occurrences": [ 30, 100 ],
-    "flags": [ "UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
+    "flags": [ "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",
@@ -3624,7 +3624,7 @@
     "locations": [ "land" ],
     "city_distance": [ 8, 30 ],
     "occurrences": [ 30, 70 ],
-    "flags": [ "CLASSIC", "UNIQUE", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "GLOBALLY_UNIQUE", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",
@@ -4607,7 +4607,7 @@
     "city_sizes": [ 1, 16 ],
     "occurrences": [ 33, 100 ],
     "rotate": false,
-    "flags": [ "UNIQUE", "SAFE_AT_WORLDGEN" ]
+    "flags": [ "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN" ]
   },
   {
     "type": "overmap_special",
@@ -7143,7 +7143,7 @@
     "occurrences": [ 35, 100 ],
     "//": "Inflated chance, effective rate ~19% (n=726)",
     "connections": [ { "point": [ -1, 15, 0 ], "terrain": "road" } ],
-    "flags": [ "FARM", "UNIQUE", "SAFE_AT_WORLDGEN" ]
+    "flags": [ "FARM", "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN" ]
   },
   {
     "id": "airliner_crashed",
@@ -7795,8 +7795,8 @@
     "locations": [ "forest" ],
     "city_distance": [ 5, 10 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 0, 1 ],
-    "flags": [ "CLASSIC", "WILDERNESS" ]
+    "occurrences": [ 30, 100 ],
+    "flags": [ "CLASSIC", "MAN_MADE", "GLOBALLY_UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -7806,8 +7806,8 @@
     "locations": [ "field" ],
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 1, -1 ],
-    "occurrences": [ 0, 1 ],
-    "flags": [ "CLASSIC" ]
+    "occurrences": [ 30, 100 ],
+    "flags": [ "CLASSIC", "MAN_MADE", "GLOBALLY_UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -7837,8 +7837,8 @@
     "locations": [ "forest" ],
     "city_distance": [ 5, 60 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "WILDERNESS" ]
+    "occurrences": [ 60, 100 ],
+    "flags": [ "CLASSIC", "MAN_MADE", "GLOBALLY_UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -7847,8 +7847,8 @@
     "locations": [ "field" ],
     "city_distance": [ 3, 10 ],
     "city_sizes": [ 8, -1 ],
-    "occurrences": [ 0, 1 ],
-    "flags": [ "CLASSIC", "URBAN" ]
+    "occurrences": [ 30, 100 ],
+    "flags": [ "CLASSIC", "URBAN", "MAN_MADE", "GLOBALLY_UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -7895,7 +7895,7 @@
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 1, 12 ],
     "occurrences": [ 5, 100 ],
-    "flags": [ "CLASSIC", "UNIQUE", "WILDERNESS" ]
+    "flags": [ "CLASSIC", "GLOBALLY_UNIQUE", "WILDERNESS" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
## 改动内容

- 将难民中心、塔科马牧场、伊舍伍德农场、流亡族基地、拉宾小屋、北欧福音派、岛屿监狱、孤立工匠住所、荒野地堡商店等固定据点改为全世界唯一。
- 将 Exodii 基地改为全世界唯一。
- 补回化学家据点、废料商据点、有人居住的伐木场和流浪者营地，并对齐当前 CDDA/CCB 的生成概率及 MAN_MADE、GLOBALLY_UNIQUE 标志。
- Hub 01 与新英格兰教会原本已经全局唯一，不产生无意义改动。

## 范围控制

- 米戈营地仍保持每张大地图唯一，不改为全世界唯一。
- 阿皮斯生成项保持微风原始配置。
- 格洛斯卡普狩猎小屋与螺旋矿井不纳入固定派系据点范围。
- 已经生成的重复地点不会被删除；应使用新世界或未生成区域验证。

## 验证

- 相关 JSON 文件均完整解析通过。
- 逐项检查目标据点的 occurrences 与 flags。
- git diff --check 通过。
- 合并后将与侧边栏改动一起执行 Windows MSVC 与 Android 综合测试。