### PR TITLE
添加侧边栏短日期时间与全局隐藏星期选项

### DIFF
--- a/data/json/ui/date.json
+++ b/data/json/ui/date.json
@@ -11,5 +11,18 @@
     "type": "widget",
     "copy-from": "date_desc_label",
     "flags": [ "W_LABEL_NONE" ]
+  },
+  {
+    "id": "date_desc_short_label",
+    "type": "widget",
+    "label": "Date",
+    "style": "text",
+    "var": "date_text_short"
+  },
+  {
+    "id": "date_desc_short_no_label",
+    "type": "widget",
+    "copy-from": "date_desc_short_label",
+    "flags": [ "W_LABEL_NONE" ]
   }
 ]

--- a/data/json/ui/sidebar-legacy-classic.json
+++ b/data/json/ui/sidebar-legacy-classic.json
@@ -162,7 +162,7 @@
     "label": "Date/Time",
     "style": "layout",
     "arrange": "columns",
-    "widgets": [ "date_desc_short_label", "time_desc_short_label" ],
+    "widgets": [ "date_desc_label", "time_desc_short_label" ],
     "flags": [ "W_LABEL_NONE" ]
   },
   {

--- a/data/json/ui/sidebar-legacy-classic.json
+++ b/data/json/ui/sidebar-legacy-classic.json
@@ -162,7 +162,7 @@
     "label": "Date/Time",
     "style": "layout",
     "arrange": "columns",
-    "widgets": [ "date_desc_label", "time_desc_label" ],
+    "widgets": [ "date_desc_short_label", "time_desc_short_label" ],
     "flags": [ "W_LABEL_NONE" ]
   },
   {

--- a/data/json/ui/sidebar-legacy-compact.json
+++ b/data/json/ui/sidebar-legacy-compact.json
@@ -162,7 +162,7 @@
     "style": "layout",
     "label": "Time",
     "arrange": "columns",
-    "widgets": [ "date_desc_short_no_label", "time_desc_short_no_label" ]
+    "widgets": [ "date_desc_no_label", "time_desc_short_no_label" ]
   },
   {
     "id": "lcom_needs_left_layout",

--- a/data/json/ui/sidebar-legacy-compact.json
+++ b/data/json/ui/sidebar-legacy-compact.json
@@ -162,7 +162,7 @@
     "style": "layout",
     "label": "Time",
     "arrange": "columns",
-    "widgets": [ "date_desc_no_label", "time_desc_no_label" ]
+    "widgets": [ "date_desc_short_no_label", "time_desc_short_no_label" ]
   },
   {
     "id": "lcom_needs_left_layout",

--- a/data/json/ui/time.json
+++ b/data/json/ui/time.json
@@ -31,6 +31,19 @@
     "flags": [ "W_LABEL_NONE" ]
   },
   {
+    "id": "time_desc_short_label",
+    "type": "widget",
+    "label": "Time",
+    "style": "text",
+    "var": "time_text_short"
+  },
+  {
+    "id": "time_desc_short_no_label",
+    "type": "widget",
+    "copy-from": "time_desc_short_label",
+    "flags": [ "W_LABEL_NONE" ]
+  },
+  {
     "id": "sundial_label_text",
     "type": "widget",
     "style": "text",

--- a/doc/WIDGETS.md
+++ b/doc/WIDGETS.md
@@ -1058,8 +1058,8 @@ Some vars refer to text descriptors. These must use style "text". Examples:
 | `bp_outer_armor_text`    | Item name and damage bars of armor/clothing worn on the given "bodypart"
 | `compass_legend_text`    | (_multiline_) A list of creatures visible by the player, corresponding to compass symbols
 | `compass_text`           | A compass direction (ex: NE), displaying visible creatures in that direction
-| `date_text`              | Current date, including weekday when calendar months are enabled
-| `date_text_short`        | Compact current date without weekday, intended for narrow sidebars
+| `date_text`              | Current sidebar date; includes the weekday unless the player enables "Hide weekday" in sidebar options
+| `date_text_short`        | Compatibility alias for `date_text`; it follows the same sidebar weekday setting
 | `env_temp_text`          | Environment temperature, if thermometer is available
 | `mood_text`              | Avatar mood represented as an emoticon face
 | `move_mode_letter`       | Movement mode - "W": walking, "R": running, "C": crouching, "P": prone

--- a/doc/WIDGETS.md
+++ b/doc/WIDGETS.md
@@ -1058,7 +1058,8 @@ Some vars refer to text descriptors. These must use style "text". Examples:
 | `bp_outer_armor_text`    | Item name and damage bars of armor/clothing worn on the given "bodypart"
 | `compass_legend_text`    | (_multiline_) A list of creatures visible by the player, corresponding to compass symbols
 | `compass_text`           | A compass direction (ex: NE), displaying visible creatures in that direction
-| `date_text`              | Current day within season, like "Summer, day 15"
+| `date_text`              | Current date, including weekday when calendar months are enabled
+| `date_text_short`        | Compact current date without weekday, intended for narrow sidebars
 | `env_temp_text`          | Environment temperature, if thermometer is available
 | `mood_text`              | Avatar mood represented as an emoticon face
 | `move_mode_letter`       | Movement mode - "W": walking, "R": running, "C": crouching, "P": prone
@@ -1073,6 +1074,7 @@ Some vars refer to text descriptors. These must use style "text". Examples:
 | `style_text`             | Name of current martial arts style
 | `sundial_text`           | Current position of the Sun/Moon in the sky
 | `time_text`              | Current time - exact if clock is available, approximate otherwise
+| `time_text_short`        | Compact current time without AM/PM and with seconds when exact; same approximate fallback as `time_text`
 | `veh_azimuth_text`       | Heading of vehicle in degrees
 | `veh_cruise_text`        | Target and actual cruising velocity, positive or negative
 | `veh_fuel_text`          | Percentage of fuel remaining for current vehicle engine

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -274,6 +274,20 @@ std::string display::date_string()
                           month_day.second );
 }
 
+std::string display::date_string_short()
+{
+    if( calendar::year_length() != 364_days || !get_option<bool>( "SHOW_MONTHS" ) ) {
+        const std::string season = calendar::name_season( season_of_year( calendar::turn ) );
+        const int day_num = day_of_season<int>( calendar::turn ) + 1;
+        //~ 1 is the season, 2 is the day of the season
+        return string_format( _( "%1$s day %2$d" ), season, day_num );
+    }
+
+    const std::pair<month, int> month_day = month_and_day( calendar::turn );
+    //~ 1 is the month, 2 is the day of the month
+    return string_format( _( "%1$s %2$d" ), to_string( month_day.first ), month_day.second );
+}
+
 std::string display::time_string( const Character &u )
 {
     // Return exact time if character has a watch, or approximate time if can see the sky
@@ -285,6 +299,29 @@ std::string display::time_string( const Character &u )
         // NOLINTNEXTLINE(cata-text-style): the question mark does not end a sentence
         return _( "???" );
     }
+}
+
+std::string display::time_string_short( const Character &u )
+{
+    if( !u.has_watch() ) {
+        if( is_creature_outside( u ) ) {
+            return display::time_approx();
+        }
+        // NOLINTNEXTLINE(cata-text-style): the question mark does not end a sentence
+        return _( "???" );
+    }
+
+    const int hour = hour_of_day<int>( calendar::turn );
+    const int minute = minute_of_hour<int>( calendar::turn );
+    const int second = to_seconds<int>( time_past_midnight( calendar::turn ) ) % 60;
+    const std::string format_type = get_option<std::string>( "24_HOUR" );
+
+    if( format_type == "military" ) {
+        return string_format( "%02d%02d.%02d", hour, minute, second );
+    }
+
+    //~ hour:minute:second (compact time display without AM/PM)
+    return string_format( _( "%02d:%02d:%02d" ), hour, minute, second );
 }
 
 std::string display::sundial_time_text_color( const Character &u, int width )

--- a/src/display.h
+++ b/src/display.h
@@ -85,14 +85,18 @@ namespace display
 std::string get_moon();
 // Current moon phase as ascii-art, ex. "(   )", "(  ))"
 std::string get_moon_graphic();
-// Current date, in terms of day within season, ex. "Summer, day 17"
+// Current date, including weekday when calendar months are enabled
 std::string date_string();
+// Compact current date without weekday, for narrow sidebars
+std::string date_string_short();
 // Approximate time of day on the given turn, ex. "Early morning", "Around dusk"
 std::string time_approx( const time_point &turn );
 // Current approximate time of day, ex. "Early morning", "Around dusk"
 std::string time_approx();
 // Exact time if character has a watch, approx time if aboveground, "???" if unknown/underground
 std::string time_string( const Character &u );
+// Compact exact time without AM/PM, retaining seconds and the same fallback behavior as time_string
+std::string time_string_short( const Character &u );
 // Sundial representing the current time of day
 std::string sundial_text_color( const Character &u, int width = 0 );
 // Sundial representing the current time of day, exact time if player has a watch, "???" if unknown/underground

--- a/src/panels.cpp
+++ b/src/panels.cpp
@@ -434,6 +434,11 @@ std::string panel_manager::get_current_layout_id() const
     return current_layout_id;
 }
 
+bool panel_manager::get_hide_weekday() const
+{
+    return hide_weekday;
+}
+
 int panel_manager::get_width_right() const
 {
     if( get_option<std::string>( "SIDEBAR_POSITION" ) == "left" ) {
@@ -488,6 +493,7 @@ void panel_manager::serialize( JsonOut &json )
     json.start_object();
 
     json.member( "current_layout_id", current_layout_id );
+    json.member( "hide_weekday", hide_weekday );
     json.member( "layouts" );
 
     json.start_array();
@@ -524,6 +530,7 @@ void panel_manager::deserialize( const JsonArray &ja )
     JsonObject joLayouts = ja.get_object( 0 );
 
     current_layout_id = joLayouts.get_string( "current_layout_id" );
+    hide_weekday = joLayouts.get_bool( "hide_weekday", false );
     if( layouts.find( current_layout_id ) == layouts.end() ) {
         // Layout id updated between loads.
         // Shouldn't happen unless custom sidebar id's were modified or removed.
@@ -594,9 +601,14 @@ static void draw_border_win( catacurses::window &w, const std::vector<int> &colu
 
 static void draw_left_win( catacurses::window &w, const std::map<size_t, size_t> &row_indices,
                            const std::vector<window_panel> &panels, size_t source_index, size_t current_row,
-                           size_t source_row, bool cur_col, bool swapping, int width, int height, int start )
+                           size_t source_row, bool cur_col, bool swapping, bool hide_weekday,
+                           int width, int height, int start )
 {
     werase( w );
+    if( start == 0 ) {
+        mvwprintz( w, point( 3, 0 ), hide_weekday ? c_white : c_dark_gray,
+                   _( "Hide weekday" ) );
+    }
     for( std::pair<size_t, size_t> row_indx : row_indices ) {
         if( row_indx.first < static_cast<size_t>( start ) ) {
             continue;
@@ -628,7 +640,7 @@ static void draw_left_win( catacurses::window &w, const std::map<size_t, size_t>
     scrollbar()
     .offset_x( width - 1 )
     .offset_y( 0 )
-    .content_size( row_indices.size() )
+    .content_size( row_indices.size() + 1 )
     .viewport_pos( start )
     .viewport_size( height )
     .apply( w );
@@ -672,11 +684,17 @@ static void draw_center_win( catacurses::window &w, int col_width, const input_c
     mvwprintz( w, point( 1, 5 ), c_white, _( "Exit" ) );
 
     if( left_panel ) {
-        const widget_id current_widget = panels[row_indices.at( current_row )].get_widget();
-        for( const widget &wgt : widget::get_all() ) {
-            if( wgt.getId() == current_widget ) {
-                fold_and_print( w, point( 1, 7 ), col_width - 2, c_white, _( wgt._description ) );
-                break;
+        if( current_row == 0 ) {
+            fold_and_print( w, point( 1, 7 ), col_width - 2, c_white,
+                            _( "Hide the weekday in every sidebar date to save horizontal space.  "
+                               "Disable this option to show the full date." ) );
+        } else {
+            const widget_id current_widget = panels[row_indices.at( current_row )].get_widget();
+            for( const widget &wgt : widget::get_all() ) {
+                if( wgt.getId() == current_widget ) {
+                    fold_and_print( w, point( 1, 7 ), col_width - 2, c_white, _( wgt._description ) );
+                    break;
+                }
             }
         }
     } else {
@@ -742,7 +760,7 @@ void panel_manager::show_adm()
         draw_right_win( w_right, layouts, current_layout_id, current_row, current_col == 2 );
         auto &panels = get_current_layout().panels();
         draw_left_win( w_left, row_indices, panels, source_index, current_row, source_row, current_col == 0,
-                       swapping, column_widths[0], popup_height - 2, start );
+                       swapping, hide_weekday, column_widths[0], popup_height - 2, start );
 
         widget *sidebar = nullptr;
         if( current_col == 0 ) {
@@ -767,7 +785,7 @@ void panel_manager::show_adm()
                 widget::finalize_inherited_fields_recursive( get_current_sidebar()->getId(),
                         get_current_sidebar()->_separator, get_current_sidebar()->_padding );
             }
-            for( size_t i = 0, row = 0; i < panels.size(); i++ ) {
+            for( size_t i = 0, row = 1; i < panels.size(); i++ ) {
                 if( panels[i].render() ) {
                     row_indices.emplace( row, i );
                     row++;
@@ -775,7 +793,7 @@ void panel_manager::show_adm()
             }
         }
 
-        const size_t num_rows = current_col == 0 ? row_indices.size() : layouts.size();
+        const size_t num_rows = current_col == 0 ? row_indices.size() + 1 : layouts.size();
         current_row = clamp<size_t>( current_row, 0, num_rows - 1 );
         if( current_row < start ) {
             start = current_row > popup_height - 3 ? current_row - ( popup_height - 3 ) : 0;
@@ -785,7 +803,8 @@ void panel_manager::show_adm()
 
         const std::string action = ctxt.handle_input();
         if( action == "UP" ) {
-            if( current_row > 0 ) {
+            const size_t first_row = current_col == 0 && swapping ? 1 : 0;
+            if( current_row > first_row ) {
                 current_row -= 1;
                 if( current_row < start ) {
                     start = current_row;
@@ -797,16 +816,17 @@ void panel_manager::show_adm()
                 }
             }
         } else if( action == "DOWN" ) {
+            const size_t first_row = current_col == 0 && swapping ? 1 : 0;
             if( current_row + 1 < num_rows ) {
                 current_row += 1;
                 if( current_row > start + popup_height - 3 ) {
                     start = current_row - ( popup_height - 3 );
                 }
             } else {
-                current_row = 0;
-                start = 0;
+                current_row = first_row;
+                start = first_row;
             }
-        } else if( action == "MOVE_PANEL" && current_col == 0 ) {
+        } else if( action == "MOVE_PANEL" && current_col == 0 && current_row > 0 ) {
             swapping = !swapping;
             if( swapping ) {
                 // source window from the swap
@@ -846,7 +866,12 @@ void panel_manager::show_adm()
                 current_col = 0;
             }
         } else if( !swapping && action == "TOGGLE_PANEL" && current_col == 0 ) {
-            panels[row_indices[current_row]].toggle = !panels[row_indices[current_row]].toggle;
+            if( current_row == 0 ) {
+                hide_weekday = !hide_weekday;
+            } else {
+                panels[row_indices.at( current_row )].toggle =
+                    !panels[row_indices.at( current_row )].toggle;
+            }
             g->invalidate_main_ui_adaptor();
         } else if( action == "QUIT" ) {
             exit = true;

--- a/src/panels.h
+++ b/src/panels.h
@@ -138,6 +138,7 @@ class panel_manager
         widget *get_current_sidebar();
         widget *get_sidebar( const std::string &name );
         std::string get_current_layout_id() const;
+        bool get_hide_weekday() const;
         int get_width_right() const;
         int get_width_left() const;
 
@@ -157,6 +158,7 @@ class panel_manager
         int width_right = 0; // NOLINT(cata-serialize)
         int width_left = 0; // NOLINT(cata-serialize)
         std::string current_layout_id;
+        bool hide_weekday = false;
         std::map<std::string, panel_layout> layouts;
 
         friend widget;

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -143,6 +143,8 @@ std::string enum_to_string<widget_var>( widget_var data )
             return "carry_weight_text";
         case widget_var::date_text:
             return "date_text";
+        case widget_var::date_text_short:
+            return "date_text_short";
         case widget_var::env_temp_text:
             return "env_temp_text";
         case widget_var::mood_text:
@@ -173,6 +175,8 @@ std::string enum_to_string<widget_var>( widget_var data )
             return "sundial_time_text";
         case widget_var::time_text:
             return "time_text";
+        case widget_var::time_text_short:
+            return "time_text_short";
         case widget_var::veh_azimuth_text:
             return "veh_azimuth_text";
         case widget_var::veh_cruise_text:
@@ -1008,6 +1012,7 @@ bool widget::uses_text_function() const
         case widget_var::compass_text:
         case widget_var::compass_legend_text:
         case widget_var::date_text:
+        case widget_var::date_text_short:
         case widget_var::env_temp_text:
         case widget_var::mood_text:
         case widget_var::move_count_mode_text:
@@ -1023,6 +1028,7 @@ bool widget::uses_text_function() const
         case widget_var::sundial_text:
         case widget_var::sundial_time_text:
         case widget_var::time_text:
+        case widget_var::time_text_short:
         case widget_var::veh_azimuth_text:
         case widget_var::veh_cruise_text:
         case widget_var::veh_fuel_text:
@@ -1111,6 +1117,9 @@ std::string widget::color_text_function_string( const avatar &ava, unsigned int 
         case widget_var::date_text:
             desc.first = display::date_string();
             break;
+        case widget_var::date_text_short:
+            desc.first = display::date_string_short();
+            break;
         case widget_var::env_temp_text:
             desc.first = display::get_temp( ava );
             break;
@@ -1158,6 +1167,9 @@ std::string widget::color_text_function_string( const avatar &ava, unsigned int 
             break;
         case widget_var::time_text:
             desc.first = display::time_string( ava );
+            break;
+        case widget_var::time_text_short:
+            desc.first = display::time_string_short( ava );
             break;
         case widget_var::veh_azimuth_text:
             desc.first = display::vehicle_azimuth_text( ava );

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -8,6 +8,7 @@
 #include "json.h"
 #include "output.h"
 #include "overmapbuffer.h"
+#include "panels.h"
 
 const static flag_id json_flag_W_DISABLED_BY_DEFAULT( "W_DISABLED_BY_DEFAULT" );
 const static flag_id json_flag_W_DISABLED_WHEN_EMPTY( "W_DISABLED_WHEN_EMPTY" );
@@ -1115,10 +1116,9 @@ std::string widget::color_text_function_string( const avatar &ava, unsigned int 
             desc = display::carry_weight_text_color( ava );
             break;
         case widget_var::date_text:
-            desc.first = display::date_string();
-            break;
         case widget_var::date_text_short:
-            desc.first = display::date_string_short();
+            desc.first = panel_manager::get_manager().get_hide_weekday() ?
+                         display::date_string_short() : display::date_string();
             break;
         case widget_var::env_temp_text:
             desc.first = display::get_temp( ava );

--- a/src/widget.h
+++ b/src/widget.h
@@ -55,7 +55,8 @@ enum class widget_var : int {
     carry_weight_text,   // Weight carried, relative to capacity, in %
     compass_text,   // Compass / visible threats by cardinal direction
     compass_legend_text, // Names of visible creatures that appear on the compass
-    date_text,      // Current date, in terms of day within season
+    date_text,      // Current date, including weekday when available
+    date_text_short, // Compact current date without weekday
     env_temp_text,  // Environment temperature, if character has thermometer
     mood_text,      // Mood as a text emote, color string
     move_count_mode_text, // Movement counter and mode letter like "50(R)", color string
@@ -71,6 +72,7 @@ enum class widget_var : int {
     sundial_text,   // Sundial representing the time of day
     sundial_time_text,   // Current time - exact if character has a watch, sundial otherwise
     time_text,      // Current time - exact if character has a watch, approximate otherwise
+    time_text_short, // Compact current time without AM/PM, retaining seconds when exact
     veh_azimuth_text, // Azimuth or heading in degrees, string
     veh_cruise_text, // Current/target cruising speed in vehicle, color string
     veh_fuel_text,  // Current/total fuel for active vehicle engine, color string


### PR DESCRIPTION
## 改动内容

- 新增短日期与短时间侧边栏变量，短时间在有手表时保留秒数。
- 经典与紧凑旧侧边栏使用更紧凑的时间显示。
- 在侧边栏选项界面增加“隐藏星期”全局开关。
- 开关关闭时显示完整公历日期，开启时所有侧边栏日期隐藏星期；设置会写入现有面板配置并兼容旧配置。
- 保留无手表时的近似时间或未知时间回退行为。

## 代码检查

- 侧边栏选项使用独立第 0 行，面板移动与切换只访问真实面板行。
- 空面板布局仍保留选项行，避免行数下溢。
- 保存与加载默认值保持向后兼容。
- 两个 UI JSON 文件完整解析通过，中文翻译与变量引用链检查通过。
- git diff --check 通过。

## 测试安排

合并后将与固定派系据点唯一性改动一起从最终 main 执行 Windows MSVC 与 Android 综合测试。本 PR 不触发正式 Release。