### PR TITLE
修复高速弯道导航与驾驶稳定性

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4884,7 +4884,13 @@ void mapgen_function_json::generate( mapgendata &md )
         mapgendata predecessor_md( md, predecessor_mapgen );
         do_predecessor_mapgen( predecessor_md );
     } else if( expects_predecessor() ) {
-        if( md.has_predecessor() ) {
+        // Some multi-z overmap specials can record a null predecessor when a
+        // raised highway piece replaces an as-yet unmaterialized OMT.  Passing
+        // that null terrain into get_mapgen_id() yields an empty key, aborts the
+        // submap generation and later leaves an uninitialized map grid.  Treat a
+        // null recorded predecessor exactly like a missing predecessor and use
+        // the JSON fallback instead.
+        if( md.has_predecessor() && md.last_predecessor() != ot_null ) {
             mapgendata predecessor_md( md, md.last_predecessor() );
             predecessor_md.pop_last_predecessor();
             do_predecessor_mapgen( predecessor_md );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -33,6 +33,7 @@
 #include "overmap.h"
 #include "overmap_connection.h"
 #include "overmap_types.h"
+#include "output.h"
 #include "path_info.h"
 #include "point.h"
 #include "rng.h"
@@ -47,7 +48,6 @@ static const oter_type_str_id oter_type_bridge( "bridge" );
 static const oter_type_str_id oter_type_bridge_road( "bridge_road" );
 static const oter_type_str_id oter_type_bridgehead_ground( "bridgehead_ground" );
 static const oter_type_str_id oter_type_bridgehead_ramp( "bridgehead_ramp" );
-static const oter_type_str_id oter_type_highway_road( "hw_road" );
 static const oter_type_str_id oter_type_highway_road_bridge( "hw_road_bridge" );
 static const oter_type_str_id oter_type_deep_rock( "deep_rock" );
 static const oter_type_str_id oter_type_empty_rock( "empty_rock" );
@@ -1039,6 +1039,57 @@ static bool is_ramp( const tripoint_abs_omt &omt_pos )
     return false;
 }
 
+static bool highway_oter_connects_toward( const oter_id &oter,
+        const om_direction::type toward )
+{
+    if( !oter->is_highway() || !oter->is_road() ) {
+        return true;
+    }
+
+    if( oter->is_linear() ) {
+        return static_cast<bool>( oter->get_line() & ( 1 << static_cast<int>( toward ) ) );
+    }
+
+    // Rotated box-drawing symbols describe the useful edge connections for
+    // highway straights, bends, tees and four-way pieces.  Using the displayed
+    // symbol here is more accurate than relying only on get_dir(): a bend has a
+    // single special rotation, but physically connects two perpendicular edges.
+    const uint32_t sym = oter->get_uint32_symbol();
+    switch( sym ) {
+        case LINE_XOXO_UNICODE: // north/south
+            return toward == om_direction::type::north || toward == om_direction::type::south;
+        case LINE_OXOX_UNICODE: // east/west
+            return toward == om_direction::type::east || toward == om_direction::type::west;
+        case LINE_OXXO_UNICODE: // east/south (upper-left corner)
+            return toward == om_direction::type::east || toward == om_direction::type::south;
+        case LINE_OOXX_UNICODE: // west/south (upper-right corner)
+            return toward == om_direction::type::west || toward == om_direction::type::south;
+        case LINE_XXOO_UNICODE: // east/north (lower-left corner)
+            return toward == om_direction::type::east || toward == om_direction::type::north;
+        case LINE_XOOX_UNICODE: // west/north (lower-right corner)
+            return toward == om_direction::type::west || toward == om_direction::type::north;
+        case LINE_XXXO_UNICODE: // north/east/south
+            return toward != om_direction::type::west;
+        case LINE_XOXX_UNICODE: // north/west/south
+            return toward != om_direction::type::east;
+        case LINE_OXXX_UNICODE: // east/west/south
+            return toward != om_direction::type::north;
+        case LINE_XXOX_UNICODE: // east/west/north
+            return toward != om_direction::type::south;
+        case LINE_XXXX_UNICODE:
+            return true;
+        default:
+            break;
+    }
+
+    // Slanted and large interchange pieces use non-box symbols.  Keep those
+    // available, while ordinary rotatable highway tiles still use their axis.
+    if( oter->is_highway_special() ) {
+        return true;
+    }
+    return !oter->is_rotatable() || om_direction::are_parallel( oter->get_dir(), toward );
+}
+
 static bool overmap_transition_allowed( const tripoint_abs_omt &from,
                                         const tripoint_abs_omt &to )
 {
@@ -1048,11 +1099,8 @@ static bool overmap_transition_allowed( const tripoint_abs_omt &from,
 
     const oter_id &from_oter = overmap_buffer.ter_existing( from );
     const oter_id &to_oter = overmap_buffer.ter_existing( to );
-    const auto simple_highway_lane = []( const oter_id & oter ) {
-        return oter->get_type_id() == oter_type_highway_road && oter->is_rotatable();
-    };
-
-    if( !simple_highway_lane( from_oter ) || !simple_highway_lane( to_oter ) ) {
+    if( !from_oter->is_highway() || !from_oter->is_road() ||
+        !to_oter->is_highway() || !to_oter->is_road() ) {
         return true;
     }
 
@@ -1071,14 +1119,11 @@ static bool overmap_transition_allowed( const tripoint_abs_omt &from,
         return true;
     }
 
-    // Two side-by-side highway OMTs with parallel road directions are separated
-    // by a median barrier.  Do not let the overmap route jump laterally between
-    // them.  When the directions differ we are at a legitimate highway bend and
-    // the transition must remain available.
-    if( !om_direction::are_parallel( from_oter->get_dir(), to_oter->get_dir() ) ) {
-        return true;
-    }
-    return om_direction::are_parallel( from_oter->get_dir(), move_dir );
+    // Require both OMTs to expose a road edge toward one another.  This keeps
+    // routes on the current carriageway, but still permits real corners and
+    // interchange pieces instead of treating every bend like a median jump.
+    return highway_oter_connects_toward( from_oter, move_dir ) &&
+           highway_oter_connects_toward( to_oter, om_direction::opposite( move_dir ) );
 }
 
 std::vector<tripoint_abs_omt> overmapbuffer::get_travel_path(

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -705,6 +705,24 @@ bool vehicle::autodrive_controller::check_drivable(const tripoint_bub_ms& pt) co
         return &ovp->vehicle() == &driven_veh;
     }
 
+    // Keep a one-tile clearance around other vehicles.  Exact-part collision
+    // checks are too optimistic for a turning multi-tile vehicle and can let a
+    // corner, mirror or rear section clip parked traffic even when the pivot path
+    // itself is clear.  The wide highway carriageways normally provide enough
+    // room to route around this buffer; on a narrow blocked road autodrive will
+    // stop rather than scrape through.
+    for( int dx = -1; dx <= 1; ++dx ) {
+        for( int dy = -1; dy <= 1; ++dy ) {
+            if( dx == 0 && dy == 0 ) {
+                continue;
+            }
+            const optional_vpart_position nearby = here.veh_at( pt + tripoint( dx, dy, 0 ) );
+            if( nearby && &nearby->vehicle() != &driven_veh ) {
+                return false;
+            }
+        }
+    }
+
     const tripoint_abs_ms pt_abs( here.getabs( pt ) );
     const tripoint_abs_omt pt_omt = project_to<coords::omt>( pt_abs );
     // only check visibility for the current OMT, we'll check other OMTs when

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2217,7 +2217,11 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
                                                "the power of the impact!" ),
                                             _( "<npcname> is hurled from the %s's seat by "
                                                "the power of the impact!" ), veh.name );
-                unboard_vehicle( part_pos );
+                // Use the exact occupied part captured before collision damage.
+                // Looking the seat up again by coordinates can select a different
+                // boardable part (or none after the seat breaks), leaving a stale
+                // passenger flag and producing "passenger not found" debug errors.
+                unboard_vehicle( vpart_reference( veh, ps ), psg );
             } else {
                 add_msg_if_player_sees( part_pos, m_bad,
                                         _( "The %s is hurled from %s's by the power of the impact!" ),


### PR DESCRIPTION
## 改动内容

- 高速弯道、三岔与十字路段按大地图地形实际连接边进行路径判断，避免路线在弯道处横跳中央隔离带或选错相邻车道。
- 自动驾驶为其他车辆增加一格规划缓冲，减少车头、车尾、后视镜与转弯外侧擦撞停放车辆的情况。
- 碰撞将乘员甩出座位时，使用碰撞循环已确认的座位部件和乘员引用下车，避免 passenger not found 调试错误。
- 多层地图遇到空前置地形记录时使用 JSON 声明的 fallback predecessor，避免空 mapgen key 与未初始化子地图。
- 清理路径判断替换后不再使用的 hw_road 静态常量。

## 行为说明

- 自动驾驶会更保守：道路空间不足时可能停车，而不是贴近其他车辆强行通过。
- 已经因空前置地图写坏的区域不会自动修复，需要在新世界或尚未生成区域验证。
- 本 PR 不包含不死人贴图、高速贴图别名或贴图 ID 清单改动。

## 验证

- 只修改 src/mapgen.cpp、src/overmapbuffer.cpp、src/vehicle_autodrive.cpp 与 src/vehicle_move.cpp。
- 地形旋转符号、前置地图 fallback、车辆部件引用和坐标接口均已核对。
- 补丁标记检查与 git diff --check 通过。
- 合并后从最终 main 运行 Windows MSVC 与 Android 综合测试。