### PR TITLE
修复地图生成前置地形空值判断编译失败

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4890,7 +4890,7 @@ void mapgen_function_json::generate( mapgendata &md )
         // submap generation and later leaves an uninitialized map grid.  Treat a
         // null recorded predecessor exactly like a missing predecessor and use
         // the JSON fallback instead.
-        if( md.has_predecessor() && md.last_predecessor() != ot_null ) {
+        if( md.has_predecessor() && !md.last_predecessor().id().is_null() ) {
             mapgendata predecessor_md( md, md.last_predecessor() );
             predecessor_md.pop_last_predecessor();
             do_predecessor_mapgen( predecessor_md );


### PR DESCRIPTION
## 问题

最新 main 的 Windows MSVC 与 Android arm64 构建均在 src/mapgen.cpp 失败：该文件引用了仅在 overmap.cpp 内部可见的静态变量 ot_null。

## 修复

- 改用 oter_id 的公开字符串 ID 接口判断空前置地形。
- 保留高速公路多层地图生成的空前置地形回退逻辑。
- 仅修改一行，不改变正常前置地图生成流程。

## 验证

- git diff --check 通过。
- 将在合入 main 后重新运行 Windows & Android Test。