### PR TITLE
修复安卓版本号同步

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,7 +274,33 @@ jobs:
             -Poverride_versionCode="${UPSTREAM_BUILD_NUMBER}" \
             assembleRelease
 
-          mv ./app/build/outputs/apk/stable/release/*.apk "../${OUTPUT_FILE}"
+          APK_PATH="$(find ./app/build/outputs/apk/stable/release -maxdepth 1 -type f -name '*.apk' -print -quit)"
+          if [[ -z "${APK_PATH}" ]]; then
+            echo "Android APK was not generated." >&2
+            exit 1
+          fi
+
+          AAPT="$(find "${ANDROID_SDK_ROOT}/build-tools" -type f -name aapt -print | sort -V | tail -n 1)"
+          if [[ -z "${AAPT}" ]]; then
+            echo "Unable to locate aapt for APK version verification." >&2
+            exit 1
+          fi
+
+          APK_BADGING="$("${AAPT}" dump badging "${APK_PATH}")"
+          APK_VERSION_NAME="$(sed -n "s/^package:.*versionName='\([^']*\)'.*/\1/p" <<<"${APK_BADGING}")"
+          APK_VERSION_CODE="$(sed -n "s/^package:.*versionCode='\([^']*\)'.*/\1/p" <<<"${APK_BADGING}")"
+
+          if [[ "${APK_VERSION_NAME}" != "${BREEZE_VERSION}" ]]; then
+            echo "APK versionName mismatch: expected ${BREEZE_VERSION}, got ${APK_VERSION_NAME}." >&2
+            exit 1
+          fi
+          if [[ "${APK_VERSION_CODE}" != "${UPSTREAM_BUILD_NUMBER}" ]]; then
+            echo "APK versionCode mismatch: expected ${UPSTREAM_BUILD_NUMBER}, got ${APK_VERSION_CODE}." >&2
+            exit 1
+          fi
+
+          echo "Verified APK versionName=${APK_VERSION_NAME}, versionCode=${APK_VERSION_CODE}."
+          mv "${APK_PATH}" "../${OUTPUT_FILE}"
 
       - name: 保存构建文件到Actions
         uses: actions/upload-artifact@v4

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -69,7 +69,7 @@ if (localProperties.getProperty('deps') != null) {
     deps = localProperties.getProperty("deps")
 }
 
-def override_version = getProperty("override_version")
+def override_version = getProperty("override_version") ?: ""
 if (localProperties.getProperty('override_version') != null) {
     override_version = localProperties.getProperty("override_version")
 }
@@ -77,6 +77,68 @@ if (localProperties.getProperty('override_version') != null) {
 def version_header_path = getProperty("version_header_path")
 if (localProperties.getProperty('version_header_path') != null) {
     version_header_path = localProperties.getProperty("version_header_path")
+}
+
+def projectRoot = './../..'
+def versionHeaderFile = new File(rootProject.projectDir, version_header_path)
+
+def normalizeBreezeVersion = { String value ->
+    def normalized = value.trim().replaceFirst(/(?i)^cdda-breeze[- ]?/, "")
+    if (normalized.isEmpty()) {
+        return ""
+    }
+    return "CDDA-Breeze-${normalized}"
+}
+
+def readVersionFromGit = {
+    def output = new ByteArrayOutputStream()
+    def errors = new ByteArrayOutputStream()
+    try {
+        def result = exec {
+            workingDir projectRoot
+            commandLine 'git', 'describe', '--tags', '--always', '--dirty',
+                '--match', 'cdda-breeze-*',
+                '--match', 'CDDA-Breeze-*',
+                '--match', '[0-9A-Z]*.[0-9A-Z]*'
+            standardOutput output
+            errorOutput errors
+            ignoreExitValue true
+        }
+        if (result.exitValue == 0) {
+            return output.toString('UTF-8').trim()
+        }
+    } catch (Exception ignored) {
+        // Source archives may not contain Git metadata.
+    }
+    return ""
+}
+
+def readVersionFromHeader = {
+    if (!versionHeaderFile.isFile()) {
+        return ""
+    }
+    def matcher = versionHeaderFile.getText('UTF-8') =~ /#define\s+VERSION\s+"([^"]+)"/
+    return matcher.find() ? matcher.group(1).trim() : ""
+}
+
+def resolved_version = override_version.trim()
+if (resolved_version.isEmpty()) {
+    resolved_version = (System.getenv("BREEZE_VERSION") ?: "").trim()
+}
+if (resolved_version.isEmpty()) {
+    resolved_version = readVersionFromGit()
+}
+if (resolved_version.isEmpty()) {
+    resolved_version = readVersionFromHeader()
+}
+resolved_version = normalizeBreezeVersion(resolved_version)
+if (resolved_version.isEmpty()) {
+    throw new GradleException("Unable to determine the Breeze version. Pass -Poverride_version=CDDA-Breeze-<version>.")
+}
+
+def android_version_name = resolved_version.replaceFirst(/^CDDA-Breeze[- ]?/, "")
+if (android_version_name.isEmpty()) {
+    throw new GradleException("Android versionName cannot be empty")
 }
 
 def override_compileSdkVersion = getProperty("override_compileSdkVersion").toInteger()
@@ -109,12 +171,10 @@ if (localProperties.getProperty('override_versionCode') != null) {
     override_versionCode = localProperties.getProperty('override_versionCode').toInteger()
 }
 
-def android_version_name = override_version.replaceFirst(/^CDDA-Breeze[- ]?/, "")
-
 println("Using [              njobs]: $njobs")
 println("Using [           localize]: $localize")
 println("Using [               deps]: $deps")
-println("Using [   override_version]: $override_version")
+println("Using [   resolved_version]: $resolved_version")
 println("Using [version_header_path]: $version_header_path")
 println("Using [  compileSdkVersion]: $override_compileSdkVersion")
 println("Using [      minSdkVersion]: $override_minSdkVersion")
@@ -135,15 +195,11 @@ if (!file(deps).exists()) {
     throw new GradleException("Dependencies file does not exist:" + deps)
 }
 
-if (!override_version.isEmpty()) {
-    if (version_header_path.isEmpty()) {
-        throw new GradleException("`version_header_path` cannot be empty when `override_version` is not empty")
-    } else {
-        println("Overriding version number to $override_version using path $version_header_path")
-    }
+if (version_header_path.isEmpty()) {
+    throw new GradleException("`version_header_path` cannot be empty")
+} else {
+    println("Writing version number $resolved_version using path $version_header_path")
 }
-
-def projectRoot = './../..'
 def assetsDir = 'src/main/assets'
 def assetsDirWindows = 'src/main/assetsWinHost'
 
@@ -181,28 +237,13 @@ task makeLocalization(type: Exec) {
 }
 
 task generateVersionHeader() {
-    // this taks imitates `make version` while respecting version_header_path
-    if (override_version.isEmpty()) {
-        println("Generating version number to $version_header_path")
-        def output = new ByteArrayOutputStream()
-        exec {
-            workingDir projectRoot
-            commandLine 'git', 'describe', '--tags', '--always', '--dirty', '--match', '"[0-9A-Z]*.[0-9A-Z]*"'
-            standardOutput output
-        }
-        override_version = output.toString()
-        override_version = override_version.split()[0] // strip whitespaces
-    } else {
-        println("Overriding version number to $override_version")
-    }
-
-    def define = "// NOLINT(cata-header-guard)\n#define VERSION \"$override_version\"\n"
-    def versionHeader = new File("$version_header_path")
-    if (!versionHeader.exists() || versionHeader.text != define) {
-        versionHeader.text = define
+    // Keep the header synchronized during Gradle configuration, before native tasks are scheduled.
+    def define = "// NOLINT(cata-header-guard)\n#define VERSION \"$resolved_version\"\n"
+    versionHeaderFile.parentFile?.mkdirs()
+    if (!versionHeaderFile.exists() || versionHeaderFile.getText('UTF-8') != define) {
+        versionHeaderFile.setText(define, 'UTF-8')
     }
 }
-
 task createWindowsJunctionLinks() {
     onlyIf {
         OperatingSystem.current() == OperatingSystem.WINDOWS

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,6 @@
      com.gamemaker.game
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    android:versionCode="1"
-    android:versionName="1.0"
     android:installLocation="auto">
 
     <!-- OpenGL ES 2.0 -->

--- a/android/app/src/main/java/com/cleverraven/cataclysmdda/SplashScreen.java
+++ b/android/app/src/main/java/com/cleverraven/cataclysmdda/SplashScreen.java
@@ -40,11 +40,17 @@ public class SplashScreen extends Activity {
     public CharSequence[] mSettingsNames;
     public boolean[] mSettingsValues = { false, true, false };
 
-    private String getVersionName() {
+    private String getInstallVersionKey() {
         try {
             Context context = getApplicationContext();
             PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-            return pInfo.versionName;
+            long versionCode;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                versionCode = pInfo.getLongVersionCode();
+            } else {
+                versionCode = pInfo.versionCode;
+            }
+            return pInfo.versionName + ":" + versionCode;
         } catch (Exception e) {
             e.printStackTrace();
             return "error";
@@ -126,7 +132,7 @@ public class SplashScreen extends Activity {
         Log.e(TAG, "onCreate()");
         accessibilityServicesAlert.dismiss();
         // Start the game if already installed, otherwise start installing...
-        if (getVersionName().equals(PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("installed", ""))) {
+        if (getInstallVersionKey().equals(PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString("installed", ""))) {
             // Show an alert box if the game crashed last time
             String externalFilesDir = getExternalFilesDir(null).getPath();
             File crashAlertPrompt = new File(externalFilesDir + "/config/crash.log.prompt");
@@ -326,7 +332,7 @@ public class SplashScreen extends Activity {
             }
 
             // Remember which version the installed data is
-            PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit().putString("installed", getVersionName()).commit();
+            PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit().putString("installed", getInstallVersionKey()).commit();
 
             publishProgress(++installedFiles);
             Log.d(TAG, "Total number of files copied: " + installedFiles);

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -44,9 +44,11 @@ abi_x86_64=false
 # You can override this from the command line by passing "-Pdeps=#"
 deps=./deps.zip
 
-# This property controls which override version number to use
+# This property controls which override version number to use.
 # You can override this from the command line by passing "-Poverride_version=#"
-override_version=CDDA-Breeze-12.0
+# Leave it empty so normal Git builds derive the version from the current tag/commit.
+# Source archives without Git metadata fall back to src/version.h.
+override_version=
 
 # This property controls path where overridden version number header should be generated
 # You can override this from the command line by passing "-Pversion_header_path=#"


### PR DESCRIPTION
﻿## 问题

安卓发布包的文件名和发布版本已经更新，但 APK 包内与游戏界面使用的版本号仍可能来自旧的固定值，导致游戏内显示没有同步到最新微风版本。

## 修复

- 删除 `AndroidManifest.xml` 中固定的 `versionName=1.0` 和 `versionCode=1`，改由 Gradle 写入。
- 取消 `android/gradle.properties` 中固定的 `CDDA-Breeze-12.0` 默认版本。
- Gradle 统一解析版本来源，并将同一个版本写入 APK `versionName` 与 `src/version.h`。
- 安装资源版本标记同时包含 `versionName` 和 `versionCode`，避免相同显示版本但构建号变化时跳过资源释放。
- 发布工作流在上传 APK 前使用 `aapt dump badging` 校验 APK 内实际 `versionName/versionCode`，不一致时直接失败。

## 验证

- `git diff --check` 通过。
- 已检查本次涉及的发布/安卓版本文件中没有残留 `CDDA-Breeze-12.0`、Manifest 固定 `1.0/1` 或旧仓库名。
- 本地尝试运行 Gradle 配置检查，但当前机器 Java 为 OpenJDK 25，Gradle 7.5 在配置阶段报 `Unsupported class file major version 69`，因此未在本地完成 Android 构建。
