### PR TITLE
修复安卓内部版本号同步

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,12 @@ jobs:
             '${{ github.workspace }}/android/a.keystore' > keystore.properties
 
           chmod +x gradlew
+
+          # Do not let an old native object or a prebuilt libmain.so survive
+          # into a release whose Android versionName has already changed.
+          rm -rf app/.cxx app/build/intermediates/cxx app/build/intermediates/merged_native_libs app/build/intermediates/stripped_native_libs
+          find app/libs -type f -name 'libmain.so' -delete 2>/dev/null || true
+
           ./gradlew --no-daemon \
             -Pj="$(nproc)" \
             -Pabi_arm_32=false \
@@ -299,7 +305,37 @@ jobs:
             exit 1
           fi
 
-          echo "Verified APK versionName=${APK_VERSION_NAME}, versionCode=${APK_VERSION_CODE}."
+          EXPECTED_NATIVE_VERSION="CDDA-Breeze-${BREEZE_VERSION}"
+          NATIVE_CHECK_DIR="$(mktemp -d)"
+          trap 'rm -rf "${NATIVE_CHECK_DIR}"' EXIT
+
+          unzip -q "${APK_PATH}" 'lib/*/libmain.so' -d "${NATIVE_CHECK_DIR}"
+          mapfile -t MAIN_LIBRARIES < <(
+            find "${NATIVE_CHECK_DIR}/lib" -type f -name 'libmain.so' -print
+          )
+
+          if [[ "${#MAIN_LIBRARIES[@]}" -eq 0 ]]; then
+            echo "APK does not contain libmain.so." >&2
+            exit 1
+          fi
+
+          for MAIN_LIBRARY in "${MAIN_LIBRARIES[@]}"; do
+            NATIVE_VERSION_STRINGS="$(
+              strings -a "${MAIN_LIBRARY}" |
+                grep -E '^CDDA-Breeze[- ][0-9]' |
+                sort -u || true
+            )"
+
+            if ! grep -Fqx "${EXPECTED_NATIVE_VERSION}" <<<"${NATIVE_VERSION_STRINGS}"; then
+              echo "Native version mismatch in ${MAIN_LIBRARY}." >&2
+              echo "Expected: ${EXPECTED_NATIVE_VERSION}" >&2
+              echo "Found native version strings:" >&2
+              printf '%s\n' "${NATIVE_VERSION_STRINGS:-<none>}" >&2
+              exit 1
+            fi
+          done
+
+          echo "Verified APK versionName=${APK_VERSION_NAME}, versionCode=${APK_VERSION_CODE}, nativeVersion=${EXPECTED_NATIVE_VERSION}."
           mv "${APK_PATH}" "../${OUTPUT_FILE}"
 
       - name: 保存构建文件到Actions

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -207,7 +207,11 @@ task unzipDeps(type: Copy) {
     println("Using dependencies file: $deps")
     def zipFile = new File("$deps")
     def outputDir = new File('.')
-    from zipTree(zipFile)
+    from(zipTree(zipFile)) {
+        // libmain.so is the game executable and must always be rebuilt from
+        // the current source tree. Never allow deps.zip to provide an old copy.
+        exclude '**/libmain.so'
+    }
     into outputDir
 }
 
@@ -338,7 +342,9 @@ android {
 
         externalNativeBuild {
             ndkBuild {
-                arguments "APP_PLATFORM=$override_ndkBuildAppPlatform", "-j$njobs"
+                arguments "APP_PLATFORM=$override_ndkBuildAppPlatform",
+                          "-j$njobs",
+                          "BREEZE_VERSION=$resolved_version"
             }
         }
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/android/app/jni/src/Android.mk
+++ b/android/app/jni/src/Android.mk
@@ -18,6 +18,12 @@ LOCAL_LDLIBS := -lGLESv1_CM -lGLESv2 -llog -lz
 
 LOCAL_CFLAGS += -DTILES=1 -DSDL_SOUND=1 -DBACKTRACE=1 -DLOCALIZE=1 -Wextra -Wall -fsigned-char
 
+# Pass the Gradle-resolved release version directly into the native compiler.
+# This prevents APK versionName and libmain.so from using different versions.
+ifneq ($(strip $(BREEZE_VERSION)),)
+    LOCAL_CPPFLAGS += -DBREEZE_ANDROID_VERSION="$(BREEZE_VERSION)"
+endif
+
 LOCAL_LDFLAGS += $(LOCAL_CFLAGS)
 
 ifeq ($(OS),Windows_NT)

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,6 +1,10 @@
 #include "get_version.h" // IWYU pragma: associated
 
-#if (defined(_WIN32) || defined(MINGW)) && !defined(GIT_VERSION) && !defined(CROSS_LINUX) && !defined(_MSC_VER)
+#if defined(BREEZE_ANDROID_VERSION)
+
+#define VERSION BREEZE_ANDROID_VERSION
+
+#elif (defined(_WIN32) || defined(MINGW)) && !defined(GIT_VERSION) && !defined(CROSS_LINUX) && !defined(_MSC_VER)
 
 #ifndef VERSION
 #define VERSION "CDDA-Breeze 12.0"


### PR DESCRIPTION
﻿## 问题

这版继续修复安卓内部版本号不同步的问题。上一版已经把 APK 外壳的 `versionName/versionCode` 同步好了，但 `libmain.so` 里的游戏内部版本仍可能停在旧值，导致主菜单显示和包内版本不一致。

## 修复

- Gradle 解析到的同一个版本号会同时传给 Android 外壳和原生编译。
- `deps.zip` 解压时不再带出旧的 `libmain.so`。
- `version.cpp` 在 Android 构建时优先使用来自 Gradle 的版本宏。
- 发布工作流在打包前清理旧的原生中间产物，并在产物里反查 `libmain.so` 的内部版本字符串。

## 验证

- `git diff --check` 通过。
- 已确认本次涉及文件没有残留旧的固定版本号逻辑。
- 本地推送已成功，分支已到达 `breeze-upstream`。
