### PR TITLE
修复安卓原生版本号字符串化

### DIFF
--- a/android/app/jni/src/Android.mk
+++ b/android/app/jni/src/Android.mk
@@ -21,7 +21,7 @@ LOCAL_CFLAGS += -DTILES=1 -DSDL_SOUND=1 -DBACKTRACE=1 -DLOCALIZE=1 -Wextra -Wall
 # Pass the Gradle-resolved release version directly into the native compiler.
 # This prevents APK versionName and libmain.so from using different versions.
 ifneq ($(strip $(BREEZE_VERSION)),)
-    LOCAL_CPPFLAGS += -DBREEZE_ANDROID_VERSION="$(BREEZE_VERSION)"
+    LOCAL_CPPFLAGS += -DBREEZE_ANDROID_VERSION=$(BREEZE_VERSION)
 endif
 
 LOCAL_LDFLAGS += $(LOCAL_CFLAGS)

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -2,7 +2,9 @@
 
 #if defined(BREEZE_ANDROID_VERSION)
 
-#define VERSION BREEZE_ANDROID_VERSION
+#define STRINGIFY_IMPL(x) #x
+#define STRINGIFY(x) STRINGIFY_IMPL(x)
+#define VERSION STRINGIFY(BREEZE_ANDROID_VERSION)
 
 #elif (defined(_WIN32) || defined(MINGW)) && !defined(GIT_VERSION) && !defined(CROSS_LINUX) && !defined(_MSC_VER)
 


### PR DESCRIPTION
﻿## 问题

Android 编译在 `src/version.cpp` 处失败，因为 `BREEZE_ANDROID_VERSION` 传进来的是裸版本 token，`VERSION` 直接展开后被当成标识符而不是字符串。

## 修复

- `Android.mk` 继续把 Gradle 解析出的版本传给原生编译，但不再手动包引号。
- `src/version.cpp` 改为在 Android 分支里把 `BREEZE_ANDROID_VERSION` 字符串化，再返回给版本接口。
- 这样既保住了 Android 应用界面/包内版本号的同步逻辑，也修掉了原生编译报错。

## 验证

- `git diff --check` 通过。
- 已确认补丁仅涉及 Android 原生版本宏这一层，不碰外层版本同步逻辑。
