### PR TITLE
让马成为更好的人类伙伴

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -185,6 +185,12 @@
   },
   {
     "type": "effect_type",
+    "id": "combat_mount_trained",
+    "name": [ "战马训练" ],
+    "desc": [ "这匹坐骑经过了战斗训练，不会再因附近的敌人受惊。" ]
+  },
+  {
+    "type": "effect_type",
     "id": "paid",
     "name": [ "Paid" ],
     "desc": [ "AI tag used for paid critters.  This is a bug if you have it." ]

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -851,6 +851,16 @@
     "based_on": "speed"
   },
   {
+    "id": "ACT_TRAIN_COMBAT_MOUNT",
+    "type": "activity_type",
+    "activity_level": "LIGHT_EXERCISE",
+    "verb": "训练战马",
+    "rooted": true,
+    "based_on": "time",
+    "suspendable": false,
+    "no_resume": true
+  },
+  {
     "id": "ACT_PLAY_WITH_PET",
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -155,6 +155,7 @@ static const activity_id ACT_STUDY_SPELL( "ACT_STUDY_SPELL" );
 static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
 static const activity_id ACT_TOOLMOD_ADD( "ACT_TOOLMOD_ADD" );
 static const activity_id ACT_TRAIN( "ACT_TRAIN" );
+static const activity_id ACT_TRAIN_COMBAT_MOUNT( "ACT_TRAIN_COMBAT_MOUNT" );
 static const activity_id ACT_TRAIN_TEACHER( "ACT_TRAIN_TEACHER" );
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 static const activity_id ACT_TREE_COMMUNION( "ACT_TREE_COMMUNION" );
@@ -174,10 +175,12 @@ static const ammotype ammo_battery( "battery" );
 static const bionic_id bio_painkiller( "bio_painkiller" );
 
 static const efftype_id effect_blind( "blind" );
+static const efftype_id effect_combat_mount_trained( "combat_mount_trained" );
 static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_pet( "pet" );
 static const efftype_id effect_sleep( "sleep" );
+static const efftype_id effect_tied( "tied" );
 static const efftype_id effect_under_operation( "under_operation" );
 
 static const harvest_drop_type_id harvest_drop_blood( "blood" );
@@ -196,6 +199,8 @@ static const json_character_flag json_flag_PSYCHOPATH( "PSYCHOPATH" );
 static const json_character_flag json_flag_SAPIOVORE( "SAPIOVORE" );
 
 static const mongroup_id GROUP_FISH( "GROUP_FISH" );
+
+static const mtype_id mon_horse( "mon_horse" );
 
 static const quality_id qual_BUTCHER( "BUTCHER" );
 static const quality_id qual_CUT_FINE( "CUT_FINE" );
@@ -287,6 +292,7 @@ activity_handlers::finish_functions = {
     { ACT_START_FIRE, start_fire_finish },
     { ACT_GENERIC_GAME, generic_game_finish },
     { ACT_TRAIN, train_finish },
+    { ACT_TRAIN_COMBAT_MOUNT, train_combat_mount_finish },
     { ACT_TRAIN_TEACHER, teach_finish },
     { ACT_PLANT_SEED, plant_seed_finish },
     { ACT_VEHICLE, vehicle_finish },
@@ -1778,6 +1784,36 @@ static bool magic_train( player_activity *act, Character *you )
         return true;
     }
     return false;
+}
+
+void activity_handlers::train_combat_mount_finish( player_activity *act, Character *you )
+{
+    if( act->monsters.empty() ) {
+        debugmsg( "No horse assigned in ACT_TRAIN_COMBAT_MOUNT" );
+        act->set_to_null();
+        return;
+    }
+
+    shared_ptr_fast<monster> horse = act->monsters.front().lock();
+    act->monsters.clear();
+    const std::string horse_name = act->str_values.empty() ? _( "这匹马" ) : act->str_values.front();
+
+    if( !horse || horse->type->id != mon_horse || !horse->has_effect( effect_pet ) ||
+        !horse->has_effect( effect_tied ) || rl_dist( you->pos(), horse->pos() ) > 1 ) {
+        you->add_msg_if_player( m_warning, _( "训练中断了，那匹马已经不在身边或没有拴好。" ) );
+        act->set_to_null();
+        return;
+    }
+    if( you->get_skill_level( skill_survival ) < 3 ) {
+        you->add_msg_if_player( m_warning, _( "你的生存技能不足以完成战马训练。" ) );
+        act->set_to_null();
+        return;
+    }
+
+    horse->add_effect( effect_combat_mount_trained, 1_turns, true );
+    you->add_msg_if_player( m_good, _( "经过反复训练，%s已经能在怪物面前保持镇定。" ),
+                            horse_name );
+    act->set_to_null();
 }
 
 void activity_handlers::teach_finish( player_activity *act, Character *you )

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -228,6 +228,7 @@ void study_spell_finish( player_activity *act, Character *you );
 void teach_finish( player_activity *act, Character *you );
 void toolmod_add_finish( player_activity *act, Character *you );
 void train_finish( player_activity *act, Character *you );
+void train_combat_mount_finish( player_activity *act, Character *you );
 void vehicle_finish( player_activity *act, Character *you );
 void vibe_finish( player_activity *act, Character *you );
 void view_recipe_finish( player_activity *act, Character *you );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -254,6 +254,7 @@ static const efftype_id effect_recently_coughed( "recently_coughed" );
 static const efftype_id effect_recover( "recover" );
 static const efftype_id effect_ridden( "ridden" );
 static const efftype_id effect_riding( "riding" );
+static const efftype_id effect_combat_mount_trained( "combat_mount_trained" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_slept_through_alarm( "slept_through_alarm" );
 static const efftype_id effect_stunned( "stunned" );
@@ -1496,12 +1497,20 @@ void Character::mount_creature( monster &z )
         // mech night-vision counts as optics for overmap sight range.
         g->update_overmap_seen();
     }
+
+    // Animal mounts start at a steady trot.  Galloping remains an explicit player choice,
+    // while mechs keep their existing power-management behavior.
+    if( get_steed_type() == steed_type::ANIMAL ) {
+        set_movement_mode( move_mode_walk );
+    }
+
     mod_moves( -100 );
 }
 
 bool Character::check_mount_will_move( const tripoint &dest_loc )
 {
-    if( !is_mounted() ) {
+    if( !is_mounted() || ( mounted_creature &&
+                             mounted_creature->has_effect( effect_combat_mount_trained ) ) ) {
         return true;
     }
     if( mounted_creature && mounted_creature->type->has_fear_trigger( mon_trigger::HOSTILE_CLOSE ) ) {
@@ -1522,7 +1531,8 @@ bool Character::check_mount_will_move( const tripoint &dest_loc )
 
 bool Character::check_mount_is_spooked()
 {
-    if( !is_mounted() ) {
+    if( !is_mounted() || ( mounted_creature &&
+                             mounted_creature->has_effect( effect_combat_mount_trained ) ) ) {
         return false;
     }
     // chance to spook per monster nearby:

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10234,12 +10234,18 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint &dest_loc ) co
 
 bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool furniture_move )
 {
+    // 为减少反复上下马的操作，允许坐骑通过可通行的窗户。其他狭窄通道仍按体型限制，
+    // 避免马匹钻过通风口、裂缝等并非门窗的地形。
+    const bool mounted_window_passage = u.is_mounted() &&
+                                        m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_WINDOW,
+                                                dest_loc ) &&
+                                        m.passable_ter_furn( dest_loc );
     if( m.has_flag_ter( ter_furn_flag::TFLAG_SMALL_PASSAGE, dest_loc ) ) {
         if( u.get_size() > creature_size::medium ) {
             add_msg( m_warning, _( "You can't fit there." ) );
             return false; // character too large to fit through a tight passage
         }
-        if( u.is_mounted() ) {
+        if( u.is_mounted() && !mounted_window_passage ) {
             monster *mount = u.mounted_creature.get();
             if( mount->get_size() > creature_size::medium ) {
                 add_msg( m_warning, _( "Your mount can't fit there." ) );
@@ -10391,18 +10397,52 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
     const int previous_moves = u.moves;
     if( u.is_mounted() ) {
         auto *crit = u.mounted_creature.get();
-        if( !crit->has_flag( MF_RIDEABLE_MECH ) &&
-            ( m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, dest_loc ) ||
-              m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_BARRICADABLE_DOOR, dest_loc ) ||
-              m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_OPENCLOSE_INSIDE, dest_loc ) ||
-              m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_BARRICADABLE_DOOR_DAMAGED, dest_loc ) ||
-              m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_BARRICADABLE_DOOR_REINFORCED, dest_loc ) ) ) {
+        // 打开的木门仍保留门类标记，打开的窗户则带有 MOUNTABLE 与 OPENCLOSE_INSIDE。
+        // 只放行门和可通行窗户，栅栏、柜台、路障等障碍仍不能骑乘越过。
+        const bool mounted_doorway =
+            m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_DOOR, dest_loc ) ||
+            m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_BARRICADABLE_DOOR, dest_loc ) ||
+            m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_BARRICADABLE_DOOR_DAMAGED, dest_loc ) ||
+            m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_BARRICADABLE_DOOR_REINFORCED, dest_loc );
+        const bool blocked_mounted_obstacle =
+            m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, dest_loc ) &&
+            !mounted_window_passage;
+        const bool blocked_inside_openable =
+            m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_OPENCLOSE_INSIDE, dest_loc ) &&
+            !mounted_window_passage;
+        if( !crit->has_flag( MF_RIDEABLE_MECH ) && !mounted_doorway &&
+            ( blocked_mounted_obstacle || blocked_inside_openable ) ) {
             add_msg( m_warning, _( "You cannot pass obstacles whilst mounted." ) );
             return false;
         }
-        const double base_moves = u.run_cost( mcost, diag ) * 100.0 / crit->get_speed();
-        const double encumb_moves = u.get_weight() / 4800.0_gram;
-        u.moves -= static_cast<int>( std::ceil( base_moves + encumb_moves ) );
+        double base_moves;
+        if( crit->has_flag( MF_RIDEABLE_MECH ) ) {
+            base_moves = u.run_cost( mcost, diag ) * 100.0 / crit->get_speed();
+        } else {
+            // 动物坐骑不再提高角色行动速度，步态只调整每格移动消耗。
+            double gait_cost_mult = 1.0;
+            switch( u.current_movement_mode()->type() ) {
+                case move_mode_type::RUNNING:
+                    gait_cost_mult = 0.25;  // 疾驰：平地 25 点
+                    break;
+                case move_mode_type::WALKING:
+                    gait_cost_mult = 0.30;  // 快步：平地 30 点
+                    break;
+                case move_mode_type::CROUCHING:
+                    gait_cost_mult = 0.50;  // 慢行：平地 50 点
+                    break;
+                case move_mode_type::PRONE:
+                    gait_cost_mult = 1.0;   // 缓步：平地 100 点
+                    break;
+            }
+            base_moves = u.run_cost( mcost, diag ) * gait_cost_mult;
+        }
+        // 动物坐骑在上马时已经检查承载能力，不再按骑手重量逐格重复收费。
+        // 动力装甲和机甲仍保留原有重量附加消耗。
+        if( crit->has_flag( MF_RIDEABLE_MECH ) ) {
+            base_moves += u.get_weight() / 4800.0_gram;
+        }
+        u.moves -= static_cast<int>( std::ceil( base_moves ) );
         crit->use_mech_power( u.current_movement_mode()->mech_power_use() );
     } else {
         u.moves -= u.run_cost( mcost, diag );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -784,6 +784,28 @@ static void pldrive(point d)
     return pldrive(tripoint(d, 0));
 }
 
+static bool is_mounted_passage_openable( map &here, const tripoint &p )
+{
+    // 车门仍按载具交互处理。地形与家具只要当前状态或开关后的状态属于门窗，
+    // 就允许骑乘时操作，从而同时识别关闭和已经打开的门窗。
+    if( here.veh_at( p ) ) {
+        return false;
+    }
+
+    const ter_t &ter = here.ter( p ).obj();
+    const furn_t &furn = here.furn( p ).obj();
+    const auto is_passage = []( const map_data_common_t &data ) {
+        return data.has_flag( ter_furn_flag::TFLAG_DOOR ) ||
+               data.has_flag( ter_furn_flag::TFLAG_WINDOW );
+    };
+
+    return is_passage( ter ) || is_passage( furn ) ||
+           ( ter.open && is_passage( ter.open.obj() ) ) ||
+           ( ter.close && is_passage( ter.close.obj() ) ) ||
+           ( furn.open && is_passage( furn.open.obj() ) ) ||
+           ( furn.close && is_passage( furn.close.obj() ) );
+}
+
 static void open()
 {
     avatar& player_character = get_avatar();
@@ -796,6 +818,11 @@ static void open()
     }
     const tripoint openp = *openp_;
     map& here = get_map();
+
+    if( player_character.is_mounted() && !is_mounted_passage_openable( here, openp ) ) {
+        add_msg( m_info, _( "骑乘时只能开门或开窗。" ) );
+        return;
+    }
 
     player_character.moves -= 100;
 
@@ -872,10 +899,16 @@ static void open()
 
 static void close()
 {
-    if (const std::optional<tripoint> pnt = choose_adjacent_highlight(_("Close where?"),
-        pgettext("no door, gate, etc.", "There is nothing that can be closed nearby."),
-        ACTION_CLOSE, false)) {
-        doors::close_door(get_map(), get_player_character(), *pnt);
+    if( const std::optional<tripoint> pnt = choose_adjacent_highlight( _( "Close where?" ),
+            pgettext( "no door, gate, etc.", "There is nothing that can be closed nearby." ),
+            ACTION_CLOSE, false ) ) {
+        map &here = get_map();
+        avatar &player_character = get_avatar();
+        if( player_character.is_mounted() && !is_mounted_passage_openable( here, *pnt ) ) {
+            add_msg( m_info, _( "骑乘时只能关门或关窗。" ) );
+            return;
+        }
+        doors::close_door( here, player_character, *pnt );
     }
 }
 
@@ -2092,9 +2125,25 @@ static void open_movement_mode_menu()
 
     for (size_t i = 0; i < modes.size(); ++i) {
         const move_mode_id& curr = modes[i];
+        std::string mode_name = curr->name();
+        if( player_character.get_steed_type() == steed_type::ANIMAL ) {
+            switch( curr->type() ) {
+                case move_mode_type::RUNNING:
+                    mode_name = _( "疾驰，基础消耗25" );
+                    break;
+                case move_mode_type::WALKING:
+                    mode_name = _( "快步，基础消耗30" );
+                    break;
+                case move_mode_type::CROUCHING:
+                    mode_name = _( "慢行，基础消耗50" );
+                    break;
+                case move_mode_type::PRONE:
+                    mode_name = _( "缓步，基础消耗100" );
+                    break;
+            }
+        }
         as_m.entries.emplace_back(static_cast<int>(i), player_character.can_switch_to(curr),
-            curr->letter(),
-            curr->name());
+            curr->letter(), mode_name);
     }
     as_m.entries.emplace_back(cycle,
         player_character.can_switch_to(player_character.current_movement_mode()->cycle()),
@@ -2820,9 +2869,6 @@ bool game::do_regular_action(action_id& act, avatar& player_character,
         if (in_shell) {
             add_msg(m_info, _("You can't open things while you're in your shell."));
         }
-        else if (player_character.is_mounted()) {
-            add_msg(m_info, _("You can't open things while you're riding."));
-        }
         else if (u.has_effect(effect_incorporeal)) {
             add_msg(m_info, _("You lack the substance to affect anything."));
         }
@@ -2838,14 +2884,13 @@ bool game::do_regular_action(action_id& act, avatar& player_character,
         else if (player_character.has_effect(effect_incorporeal)) {
             add_msg(m_info, _("You lack the substance to affect anything."));
         }
-        else if (player_character.is_mounted()) {
-            auto* mon = player_character.mounted_creature.get();
-            if (!mon->has_flag(MF_RIDEABLE_MECH)) {
-                add_msg(m_info, _("You can't close things while you're riding."));
-            }
-        }
         else if (mouse_target) {
-            doors::close_door(m, player_character, *mouse_target);
+            if( player_character.is_mounted() &&
+                !is_mounted_passage_openable( m, *mouse_target ) ) {
+                add_msg( m_info, _( "骑乘时只能关门或关窗。" ) );
+            } else {
+                doors::close_door( m, player_character, *mouse_target );
+            }
         }
         else {
             close();

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1620,11 +1620,25 @@ std::optional<int> iuse::petfood( Character *p, item *it, bool, const tripoint &
         if( petfood.feed.empty() ) {
             p->add_msg_if_player( m_good, _( "The %1$s is your pet now!" ), mon->get_name() );
         } else {
-            p->add_msg_if_player( m_good, petfood.feed, mon->get_name() );
+            // JSON 中的物种专属驯养文本此前被直接输出，绕过了翻译系统。
+            const std::string localized_feed = _( petfood.feed );
+            const std::string generic_feed = _( "The %1$s is your pet now!" );
+            if( localized_feed == petfood.feed &&
+                generic_feed != "The %1$s is your pet now!" ) {
+                // 当前语言缺少专属译文时，退回已本地化的通用提示，避免夹杂英文。
+                p->add_msg_if_player( m_good, generic_feed, mon->get_name() );
+            } else {
+                p->add_msg_if_player( m_good, localized_feed, mon->get_name() );
+            }
         }
 
         mon->friendly = -1;
         mon->add_effect( effect_pet, 1_turns, true );
+        // 非狗动物在被驯服前可能仍保留着接近或逃离玩家的旧目标。
+        // 驯服成功时立即清除；需要带走时使用绳子牵引。
+        if( !mon->is_pet_follow() ) {
+            mon->unset_dest();
+        }
         p->consume_charges( *it, 1 );
         return std::nullopt;
     }

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -43,6 +43,9 @@
 #include "overmapbuffer.h"
 #include "units_utility.h"
 
+static const activity_id ACT_TRAIN_COMBAT_MOUNT( "ACT_TRAIN_COMBAT_MOUNT" );
+
+static const efftype_id effect_combat_mount_trained( "combat_mount_trained" );
 static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_harnessed( "harnessed" );
 static const efftype_id effect_has_bag( "has_bag" );
@@ -65,6 +68,8 @@ static const flag_id json_flag_AUTONOMOUS_CONTROL("AUTONOMOUS_CONTROL");
 
 static const itype_id itype_cash_card( "cash_card" );
 static const itype_id itype_id_military( "id_military" );
+
+static const mtype_id mon_horse( "mon_horse" );
 
 static const quality_id qual_SHEAR( "SHEAR" );
 
@@ -695,6 +700,7 @@ bool monexamine::pet_menu( monster &z )
         pay,
         attach_saddle,
         remove_saddle,
+        train_combat_mount,
         mount,
         tie,
         untie,
@@ -782,15 +788,13 @@ bool monexamine::pet_menu( monster &z )
     
     }
 
-    if (!z.has_flag(MF_RIDEABLE_MECH) && !z.has_effect(effect_has_bag)) {
-        amenu.addentry(attach_bag, true, 'b', "给 % s 安装容器", pet_name);
+    if( !z.has_flag( MF_RIDEABLE_MECH ) && !z.has_effect( effect_has_bag ) ) {
+        amenu.addentry( attach_bag, true, 'b', _( "给%s安装容器" ), pet_name );
     }
 
-    if (z.has_effect(effect_has_bag)) {
-        amenu.addentry(交换物品, true, 'E', _("交换物品"));
-    }
-    else {
-        amenu.addentry(交换物品, false, 'E', _("交换物品"));
+    // 只有宠物实际安装了容器时才显示物品管理，避免菜单里长期出现无意义的灰色选项。
+    if( z.has_effect( effect_has_bag ) ) {
+        amenu.addentry( 交换物品, true, 'E', _( "管理容器内物品" ) );
     }
 
     if( z.has_effect( effect_harnessed ) ) {
@@ -854,6 +858,16 @@ bool monexamine::pet_menu( monster &z )
     }
     if( z.has_flag( MF_PET_MOUNTABLE ) && z.has_effect( effect_monster_saddled ) ) {
         amenu.addentry( remove_saddle, true, 'h', _( "Remove tack from %s" ), pet_name );
+    }
+    // 训练完成后不再保留灰色菜单项；战马状态仍会永久保存。
+    if( z.type->id == mon_horse && !z.has_effect( effect_combat_mount_trained ) ) {
+        if( player_character.get_skill_level( skill_survival ) < 3 ) {
+            amenu.addentry( train_combat_mount, false, 'W', _( "训练为战马，需要生存技能3" ) );
+        } else if( !z.has_effect( effect_tied ) ) {
+            amenu.addentry( train_combat_mount, false, 'W', _( "训练为战马，需要先将马拴好" ) );
+        } else {
+            amenu.addentry( train_combat_mount, true, 'W', _( "训练为战马，一小时" ) );
+        }
     }
     if( z.has_flag( MF_PAY_BOT ) ) {
         amenu.addentry( pay, true, 'f', _( "Manage your friendship with %s" ), pet_name );
@@ -968,6 +982,12 @@ bool monexamine::pet_menu( monster &z )
             break;
         case remove_saddle:
             remove_saddle_from( z );
+            break;
+        case train_combat_mount:
+            player_character.assign_activity( ACT_TRAIN_COMBAT_MOUNT, to_moves<int>( 1_hours ) );
+            player_character.activity.monsters.push_back( g->shared_from( z ) );
+            player_character.activity.str_values.push_back( pet_name );
+            add_msg( m_info, _( "你开始训练%s适应怪物的嘶吼与骚动。" ), pet_name );
             break;
         case mount:
             mount_pet( z );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -412,6 +412,13 @@ void monster::plan()
     bool swarms = has_flag( MF_SWARMS );
     monster_attitude mood = attitude();
     Character &player_character = get_player_character();
+    // Clear only a stale destination aimed directly at the player.  Do not erase
+    // combat, fleeing, patrol or ordinary roaming destinations.
+    const bool pet_without_auto_follow = is_pet() && !is_pet_follow() &&
+                                         !has_effect( effect_led_by_leash );
+    if( pet_without_auto_follow && get_dest() == player_character.get_location() ) {
+        unset_dest();
+    }
     flood_fill_zone(*this);
     // If we can see the player, move toward them or flee.
     if( friendly == 0 && seen_levels.test( player_character.pos().z + OVERMAP_DEPTH ) &&
@@ -769,12 +776,12 @@ void monster::plan()
     } else if( friendly > 0 && one_in( 3 ) ) {
         // Grow restless with no targets
         friendly--;
-    } else if (has_effect(effect_pet) && sees(player_character) &&
-        (get_location().z() == player_character.get_location().z() ||
-            get_location().z() == get_dest().z())) {
-        // Simpleminded animals are too dumb to follow the player.
+    } else if( is_pet_follow() && sees( player_character ) &&
+               ( get_location().z() == player_character.get_location().z() ||
+                 get_location().z() == get_dest().z() ) ) {
+        // Dog-type pets follow their owner automatically.
         // To use stairs smoothly, if the destination is on a different Z-level, move there first.
-        set_dest(player_character.get_location());
+        set_dest( player_character.get_location() );
     }
 }
 
@@ -967,7 +974,7 @@ void monster::move()
     }
     bool was_controlled_by_friendly_monster_controller = has_value("was_controlled_by_friendly_monster_controller");
     
-    if ((has_effect(effect_pet)&&!has_flag(MF_PET_WONT_FOLLOW)) || (friendly != 0 && has_effect(effect_led_by_leash))) {
+    if( is_pet_follow() || ( friendly != 0 && has_effect( effect_led_by_leash ) ) ) {
         const int dist = rl_dist(get_location(), get_dest());
         if ((dist <= 1 || (dist <= 2 && !has_effect(effect_led_by_leash) &&
             sees(player_character))) &&
@@ -1028,7 +1035,9 @@ void monster::move()
             }
         }
     }
-    if( !moved && has_flag( MF_SMELLS ) ) {
+    if( !moved && has_flag( MF_SMELLS ) &&
+        !( is_pet() && !is_pet_follow() &&
+           !has_effect( effect_led_by_leash ) ) ) {
         // No sight... or our plans are invalid (e.g. moving through a transparent, but
         //  solid, square of terrain).  Fall back to smell if we have it.
         

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -135,6 +135,7 @@ static const material_id material_veggy("veggy");
 static const mfaction_str_id monfaction_acid_ant("acid_ant");
 static const mfaction_str_id monfaction_ant("ant");
 static const mfaction_str_id monfaction_bee("bee");
+static const mfaction_str_id monfaction_dog("dog");
 static const mfaction_str_id monfaction_nether_player_hate("nether_player_hate");
 static const mfaction_str_id monfaction_wasp("wasp");
 
@@ -1481,6 +1482,19 @@ bool monster::made_of_any(const std::set<material_id>& ms) const
 bool monster::shearable() const
 {
     return type->shearing.valid();
+}
+
+bool monster::is_pet() const
+{
+    return friendly == -1 && has_effect( effect_pet );
+}
+
+bool monster::is_pet_follow() const
+{
+    // Only animals whose original monster faction is the dog faction follow
+    // automatically.  Other tamed animals must be led with a leash.
+    return is_pet() && type->default_faction == monfaction_dog &&
+           !has_flag( MF_PET_WONT_FOLLOW );
 }
 
 bool monster::made_of(phase_id p) const

--- a/src/monster.h
+++ b/src/monster.h
@@ -178,6 +178,11 @@ class monster : public Creature
 
         bool shearable() const;
 
+        // Permanent pets are marked by both friendly == -1 and the pet effect.
+        bool is_pet() const;
+        // Only dog-type pets follow automatically; other animals require a leash.
+        bool is_pet_follow() const;
+
         bool avoid_trap( const tripoint &pos, const trap &tr ) const override;
 
         void serialize( JsonOut &json ) const;


### PR DESCRIPTION
﻿## 改动内容

- 让骑乘时候的行动菜单真正生效，骑乘分为四档行动消耗，分为100 50 30 25。
- 骑乘时允许通过门和可通行窗户，但仍保留对其他狭窄通道的限制。
- 增加战马训练流程，让马在怪物环境下不再害怕，需要生存等级达到三级，花费时间为一个小时。
- 补齐部分驯养本地化内容。

## 测试

- `git diff --check`
- `JSON` 解析检查通过
- `Windows & Android Test #30269426699` 成功
