### PR TITLE
改进大地图高层透视与渐进色显示

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2742,9 +2742,11 @@ bool cata_tiles::draw_sprite_at(
     const SDL_RendererFlip flip ) {
         int result = sprite_tex->render_copy_ex( renderer, &destination, angle, nullptr, flip );
         if( z_overlay_tex ) {
-            // CBN uses a much gentler tint on the overmap than on the local map.
+            // Keep CBN's gentler 12-alpha-per-level overmap curve, but do not
+            // stop progressing after the seventh lower level.  CBN caps this
+            // overlay at 192, while the local-map curve remains capped at 160.
             const int alpha = drawing_overmap_transparency
-                              ? std::min( 96, 24 + ( z_overlay_depth - 1 ) * 12 )
+                              ? std::min( 192, 24 + ( z_overlay_depth - 1 ) * 12 )
                               : std::min( 160, 56 + ( z_overlay_depth - 1 ) * 32 );
             z_overlay_tex->set_alpha_mod( alpha );
             const int overlay_result =

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1,4 +1,4 @@
-#include "cata_tiles.h"
+﻿#include "cata_tiles.h"
 #include "particle_effect_manager.h"
 
 #include <algorithm>
@@ -284,6 +284,7 @@ void tileset::clear()
     shadow_tile_values.clear();
     night_tile_values.clear();
     overexposed_tile_values.clear();
+    z_overlay_values.clear();
     memory_tile_values.clear();
     duplicate_ids.clear();
     tile_ids.clear();
@@ -493,11 +494,12 @@ void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_P
 
     /** perform color filter conversion here */
     using tiles_pixel_color_entry = std::tuple<std::vector<texture>*, std::string>;
-    std::array<tiles_pixel_color_entry, 5> tile_values_data = {{
+    std::array<tiles_pixel_color_entry, 6> tile_values_data = {{
             { std::make_tuple( &ts.tile_values, "color_pixel_none" ) },
             { std::make_tuple( &ts.shadow_tile_values, "color_pixel_grayscale" ) },
             { std::make_tuple( &ts.night_tile_values, "color_pixel_nightvision" ) },
             { std::make_tuple( &ts.overexposed_tile_values, "color_pixel_overexposed" ) },
+            { std::make_tuple( &ts.z_overlay_values, "color_pixel_zoverlay" ) },
             { std::make_tuple( &ts.memory_tile_values, tilecontext->memory_map_mode ) }
         }
     };
@@ -595,6 +597,7 @@ void tileset_cache::loader::load_tileset( const cata_path &img_path, const bool 
     extend_vector_by( ts.shadow_tile_values, expected_tilecount );
     extend_vector_by( ts.night_tile_values, expected_tilecount );
     extend_vector_by( ts.overexposed_tile_values, expected_tilecount );
+    extend_vector_by( ts.z_overlay_values, expected_tilecount );
     extend_vector_by( ts.memory_tile_values, expected_tilecount );
 
     for( const SDL_Rect sub_rect : output_range ) {
@@ -1179,6 +1182,13 @@ tile_type &tileset_cache::loader::load_tile( const JsonObject &entry, const std:
     load_tile_spritelists( entry, curr_subtile.fg, "fg" );
     load_tile_spritelists( entry, curr_subtile.bg, "bg" );
 
+    // CBN marks these explicitly in tileset JSON.  Breeze also infers the common
+    // open-air/roof cases so existing tilesets benefit without a huge JSON rewrite.
+    const bool inferred_om_transparency =
+        id == "open_air" || id.find( "roof" ) != std::string::npos;
+    curr_subtile.has_om_transparency =
+        entry.get_bool( "has_om_transparency", inferred_om_transparency );
+
     return ts.create_tile_type( id, std::move( curr_subtile ) );
 }
 
@@ -1400,9 +1410,10 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
     creature_tracker &creatures = get_creature_tracker();
     phmap::btree_map<int, std::vector<tile_render_info>> draw_points;
-    // Limit draw depth to vertical vision setting
-    // Disable multi z-level display on isometric tilesets until height_3d issues resolved
-    const int max_draw_depth = is_isometric() ? 0 : fov_3d_z_range;
+    // Always draw at least the first visible level below the player.  The existing
+    // vertical-vision option still controls whether more distant levels are included.
+    // Disable multi z-level display on isometric tilesets until height_3d issues resolved.
+    const int max_draw_depth = is_isometric() ? 0 : std::max( 1, fov_3d_z_range );
     for( int row = min_row; row < max_row; row ++ ) {
         draw_points[row].reserve(max_col);
         for( int col = min_col; col < max_col; col ++ ) {
@@ -1661,6 +1672,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             // Start drawing from the bottom-most z-level
             int cur_zlevel = -OVERMAP_DEPTH;
             do {
+                z_overlay_depth = std::max( 0, center.z - cur_zlevel );
                 //int cur_height_3d = ( cur_zlevel - center.z ) * height_3d_mult;
             // For each row
                 for (int row = min_row; row < max_row; row++) {
@@ -1683,6 +1695,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 }
                 cur_zlevel += 1;
             } while (cur_zlevel <= center.z);
+            z_overlay_depth = 0;
         }
 
         // display number of monsters to spawn in mapgen preview
@@ -2628,6 +2641,15 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
         }
     }
 
+    // Transparent overmap sprites are composited bottom-to-top.  Once the lower
+    // tile has been drawn, omit this tile's opaque background and keep its roof/edge foreground.
+    if( category == TILE_CATEGORY::OVERMAP_TERRAIN &&
+        overmap_transparency_foreground_only && display_tile.has_om_transparency ) {
+        draw_sprite_at( display_tile, display_tile.fg, screen_pos, loc_rand, true, rota, ll,
+                        nv_color_active, retract, height_3d, offset );
+        return true;
+    }
+
     //draw it!
     draw_tile_at( display_tile, screen_pos, loc_rand, rota, ll,
                   nv_color_active, retract, height_3d, offset );
@@ -2695,6 +2717,11 @@ bool cata_tiles::draw_sprite_at(
         }
     }
 
+    const texture *z_overlay_tex = nullptr;
+    if( z_overlay_depth > 0 ) {
+        z_overlay_tex = tileset_ptr->get_z_overlay( sprite_index );
+    }
+
     int width = 0;
     int height = 0;
     std::tie( width, height ) = sprite_tex->dimension();
@@ -2713,19 +2740,34 @@ bool cata_tiles::draw_sprite_at(
     destination.w = width * tile_width * tile.pixelscale / tileset_ptr->get_tile_width();
     destination.h = height * tile_height * tile.pixelscale / tileset_ptr->get_tile_height();
 
+    const auto render_with_z_overlay = [&]( const double angle,
+    const SDL_RendererFlip flip ) {
+        int result = sprite_tex->render_copy_ex( renderer, &destination, angle, nullptr, flip );
+        if( z_overlay_tex ) {
+            // First lower floor stays readable; deeper floors become progressively bluer.
+            const int alpha = std::min( 160, 56 + ( z_overlay_depth - 1 ) * 32 );
+            z_overlay_tex->set_alpha_mod( alpha );
+            const int overlay_result =
+                z_overlay_tex->render_copy_ex( renderer, &destination, angle, nullptr, flip );
+            z_overlay_tex->set_alpha_mod( 255 );
+            if( result == 0 ) {
+                result = overlay_result;
+            }
+        }
+        return result;
+    };
+
     if( rotate_sprite ) {
         if( rota == -1 ) {
             // flip horizontally
-            ret = sprite_tex->render_copy_ex(
-                      renderer, &destination, 0, nullptr,
-                      static_cast<SDL_RendererFlip>( SDL_FLIP_HORIZONTAL ) );
+            ret = render_with_z_overlay(
+                      0, static_cast<SDL_RendererFlip>( SDL_FLIP_HORIZONTAL ) );
         } else {
             switch( rota % 4 ) {
                 default:
                 case 0:
                     // unrotated (and 180, with just two sprites)
-                    ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
-                                                      SDL_FLIP_NONE );
+                    ret = render_with_z_overlay( 0, SDL_FLIP_NONE );
                     break;
                 case 1:
                     // 90 degrees (and 270, with just two sprites)
@@ -2738,23 +2780,19 @@ bool cata_tiles::draw_sprite_at(
 #endif
                     if( !is_isometric() ) {
                         // never rotate isometric tiles
-                        ret = sprite_tex->render_copy_ex( renderer, &destination, -90, nullptr,
-                                                          SDL_FLIP_NONE );
+                        ret = render_with_z_overlay( -90, SDL_FLIP_NONE );
                     } else {
-                        ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
-                                                          SDL_FLIP_NONE );
+                        ret = render_with_z_overlay( 0, SDL_FLIP_NONE );
                     }
                     break;
                 case 2:
                     // 180 degrees, implemented with flips instead of rotation
                     if( !is_isometric() ) {
                         // never flip isometric tiles vertically
-                        ret = sprite_tex->render_copy_ex(
-                                  renderer, &destination, 0, nullptr,
-                                  static_cast<SDL_RendererFlip>( SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL ) );
+                        ret = render_with_z_overlay(
+                                  0, static_cast<SDL_RendererFlip>( SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL ) );
                     } else {
-                        ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
-                                                          SDL_FLIP_NONE );
+                        ret = render_with_z_overlay( 0, SDL_FLIP_NONE );
                     }
                     break;
                 case 3:
@@ -2768,18 +2806,16 @@ bool cata_tiles::draw_sprite_at(
 #endif
                     if( !is_isometric() ) {
                         // never rotate isometric tiles
-                        ret = sprite_tex->render_copy_ex( renderer, &destination, 90, nullptr,
-                                                          SDL_FLIP_NONE );
+                        ret = render_with_z_overlay( 90, SDL_FLIP_NONE );
                     } else {
-                        ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
-                                                          SDL_FLIP_NONE );
+                        ret = render_with_z_overlay( 0, SDL_FLIP_NONE );
                     }
                     break;
             }
         }
     } else {
         // don't rotate, same as case 0 above
-        ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr, SDL_FLIP_NONE );
+        ret = render_with_z_overlay( 0, SDL_FLIP_NONE );
     }
 
     printErrorIf( ret != 0, "SDL_RenderCopyEx() failed" );
@@ -2927,9 +2963,10 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
     // first memorize the actual terrain
     const ter_id &t = here.ter( p );
     const std::string& tname = t.id().str();
-    // Non-isometric legacy mode does not draw fog sprites
-    if (!is_isometric() && fov_3d_z_range == 0 && tname == "t_open_air") {
-        return false;
+    // Open air is a transparent window onto the already-rendered lower z-level.
+    // Drawing a fog/fallback sprite here would cover the new cyan lower-level view.
+    if( !is_isometric() && tname == "t_open_air" ) {
+        return true;
     }
     if( t && !invisible[0] ) {
         int subtile = 0;
@@ -5284,5 +5321,4 @@ std::vector<options_manager::id_and_option> cata_tiles::build_display_list()
 
     return display_names.empty() ? default_display_names : display_names;
 }
-
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1182,12 +1182,10 @@ tile_type &tileset_cache::loader::load_tile( const JsonObject &entry, const std:
     load_tile_spritelists( entry, curr_subtile.fg, "fg" );
     load_tile_spritelists( entry, curr_subtile.bg, "bg" );
 
-    // CBN marks these explicitly in tileset JSON.  Breeze also infers the common
-    // open-air/roof cases so existing tilesets benefit without a huge JSON rewrite.
-    const bool inferred_om_transparency =
-        id == "open_air" || id.find( "roof" ) != std::string::npos;
+    // Match CBN's contract exactly: overmap transparency is opt-in tileset metadata.
+    // Inferring it from names such as "*roof*" misclassifies opaque or oversized sprites.
     curr_subtile.has_om_transparency =
-        entry.get_bool( "has_om_transparency", inferred_om_transparency );
+        entry.get_bool( "has_om_transparency", false );
 
     return ts.create_tile_type( id, std::move( curr_subtile ) );
 }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1,4 +1,4 @@
-﻿#include "cata_tiles.h"
+#include "cata_tiles.h"
 #include "particle_effect_manager.h"
 
 #include <algorithm>
@@ -2744,8 +2744,10 @@ bool cata_tiles::draw_sprite_at(
     const SDL_RendererFlip flip ) {
         int result = sprite_tex->render_copy_ex( renderer, &destination, angle, nullptr, flip );
         if( z_overlay_tex ) {
-            // First lower floor stays readable; deeper floors become progressively bluer.
-            const int alpha = std::min( 160, 56 + ( z_overlay_depth - 1 ) * 32 );
+            // CBN uses a much gentler tint on the overmap than on the local map.
+            const int alpha = drawing_overmap_transparency
+                              ? std::min( 96, 24 + ( z_overlay_depth - 1 ) * 12 )
+                              : std::min( 160, 56 + ( z_overlay_depth - 1 ) * 32 );
             z_overlay_tex->set_alpha_mod( alpha );
             const int overlay_result =
                 z_overlay_tex->render_copy_ex( renderer, &destination, angle, nullptr, flip );
@@ -5321,4 +5323,3 @@ std::vector<options_manager::id_and_option> cata_tiles::build_display_list()
 
     return display_names.empty() ? default_display_names : display_names;
 }
-

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -43,6 +43,8 @@ struct tile_type {
     bool multitile = false;
     bool rotates = false;
     bool animated = false;
+    // Overmap tiles with transparent foreground pixels reveal lower z-levels.
+    bool has_om_transparency = false;
     int height_3d = 0;
     point offset = point_zero;
     point offset_retracted = point_zero;
@@ -119,6 +121,10 @@ class texture
             return SDL_RenderCopyEx( renderer.get(), sdl_texture_ptr.get(), &srcrect, dstrect, angle, center,
                                      flip );
         }
+
+        int set_alpha_mod( int alpha ) const {
+            return SDL_SetTextureAlphaMod( sdl_texture_ptr.get(), static_cast<Uint8>( alpha ) );
+        }
 };
 
 class layer_variant
@@ -155,6 +161,7 @@ class tileset
         std::vector<texture> shadow_tile_values;
         std::vector<texture> night_tile_values;
         std::vector<texture> overexposed_tile_values;
+        std::vector<texture> z_overlay_values;
         std::vector<texture> memory_tile_values;
 
         std::unordered_set<std::string> duplicate_ids;
@@ -215,6 +222,9 @@ class tileset
         }
         const texture *get_memory_tile( const size_t index ) const {
             return get_if_available( index, memory_tile_values );
+        }
+        const texture *get_z_overlay( const size_t index ) const {
+            return get_if_available( index, z_overlay_values );
         }
 
         const std::unordered_set<std::string> &get_duplicate_ids() const {
@@ -674,6 +684,9 @@ class cata_tiles
     private:
         std::string get_omt_id_rotation_and_subtile(
             const tripoint_abs_omt &omp, int &rota, int &subtile );
+        void draw_om_tile_recursively( const tripoint_abs_omt &omp, const std::string &id,
+                                       int rotation, int subtile, int base_z_offset,
+                                       bool has_debug_vision );
     protected:
         template <typename maptype>
         void tile_loading_report_map( const maptype &tiletypemap, TILE_CATEGORY category,
@@ -782,6 +795,11 @@ class cata_tiles
          * Allows usage of night vision tilesets during sprite rendering.
          */
         bool nv_goggles_activated = false;
+
+        // Depth of the z-level currently being rendered.  Zero means the viewed level.
+        int z_overlay_depth = 0;
+        // Transparent overmap tiles draw only their foreground after the lower tile.
+        bool overmap_transparency_foreground_only = false;
 
         pimpl<pixel_minimap> minimap;
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -800,9 +800,10 @@ class cata_tiles
         int z_overlay_depth = 0;
         // Transparent overmap tiles draw only their foreground after the lower tile.
         bool overmap_transparency_foreground_only = false;
+        // Uses the gentler CBN overmap alpha curve instead of the local-map curve.
+        bool drawing_overmap_transparency = false;
 
         pimpl<pixel_minimap> minimap;
-
         // List all layers for a single z-level
         const std::array<decltype(&cata_tiles::draw_furniture), 12> drawing_layers = { {
                 &cata_tiles::draw_terrain, &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap, &cata_tiles::draw_part_con,

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -284,8 +284,12 @@ static void draw_city_labels( const catacurses::window &w, const tripoint_abs_om
 
     const point screen_center_pos( win_x_max / 2, win_y_max / 2 );
 
+    // Above ground, labels follow the same z=0 layer used by the aviation map.
+    const tripoint_abs_omt label_center =
+        center.z() > 0 ? tripoint_abs_omt( center.xy(), 0 ) : center;
+
     for( const city_reference &element : overmap_buffer.get_cities_near(
-             project_to<coords::sm>( center ), sm_radius ) ) {
+             project_to<coords::sm>( label_center ), sm_radius ) ) {
         const point_abs_omt city_pos =
             project_to<coords::omt>( element.abs_sm_pos.xy() );
         const point_rel_omt screen_pos( city_pos - center.xy() + screen_center_pos );
@@ -309,8 +313,8 @@ static void draw_city_labels( const catacurses::window &w, const tripoint_abs_om
             continue;   // right under the cursor.
         }
 
-        if( !overmap_buffer.seen( tripoint_abs_omt( city_pos, center.z() ) ) ) {
-            continue;   // haven't seen it.
+        if( !overmap_buffer.seen( tripoint_abs_omt( city_pos, label_center.z() ) ) ) {
+            continue;   // haven't seen it on the displayed ground layer.
         }
 
         mvwprintz( w, point( text_x_min, text_y ), i_yellow, element.city->name );
@@ -325,8 +329,12 @@ static void draw_camp_labels( const catacurses::window &w, const tripoint_abs_om
 
     const point screen_center_pos( win_x_max / 2, win_y_max / 2 );
 
+    // Ordinary camps are ground features and use the projected ground layer.
+    const tripoint_abs_omt label_center =
+        center.z() > 0 ? tripoint_abs_omt( center.xy(), 0 ) : center;
+
     for( const camp_reference &element : overmap_buffer.get_camps_near(
-             project_to<coords::sm>( center ), sm_radius ) ) {
+             project_to<coords::sm>( label_center ), sm_radius ) ) {
         const point_abs_omt camp_pos( element.camp->camp_omt_pos().xy() );
         const point screen_pos( ( camp_pos - center.xy() ).raw() + screen_center_pos );
         const std::string camp_name = element.camp->camp_name().empty() ?
@@ -349,8 +357,8 @@ static void draw_camp_labels( const catacurses::window &w, const tripoint_abs_om
             continue;   // right under the cursor.
         }
 
-        if( !overmap_buffer.seen( tripoint_abs_omt( camp_pos, center.z() ) ) ) {
-            continue;   // haven't seen it.
+        if( !overmap_buffer.seen( tripoint_abs_omt( camp_pos, label_center.z() ) ) ) {
+            continue;   // haven't seen it on the displayed ground layer.
         }
 
         mvwprintz( w, point( text_x_min, text_y ), i_yellow, camp_name );
@@ -364,8 +372,12 @@ static void draw_faction_camp_labels( const catacurses::window &w,
     const int win_y_max = getmaxy( w );
     const point screen_center_pos( win_x_max / 2, win_y_max / 2 );
 
+    // Faction camps follow the same z=0 projection when viewed from the air.
+    const tripoint_abs_omt label_center =
+        center.z() > 0 ? tripoint_abs_omt( center.xy(), 0 ) : center;
+
     for( const faction_camp_reference &element : overmap_buffer.get_faction_camps_near(
-             center, win_x_max / 2 + 1, win_y_max / 2 + 1 ) ) {
+             label_center, win_x_max / 2 + 1, win_y_max / 2 + 1 ) ) {
         const point screen_pos( ( element.abs_omt_pos.xy() - center.xy() ).raw() +
                                 screen_center_pos );
         const int text_width = utf8_width( element.name, true );

--- a/src/sdl_utils.cpp
+++ b/src/sdl_utils.cpp
@@ -19,6 +19,7 @@ static color_pixel_function_map builtin_color_pixel_functions = {
     { "color_pixel_grayscale", color_pixel_grayscale },
     { "color_pixel_nightvision", color_pixel_nightvision },
     { "color_pixel_overexposed", color_pixel_overexposed },
+    { "color_pixel_zoverlay", color_pixel_z_overlay },
 };
 
 color_pixel_function_pointer get_color_pixel_function( const std::string &name )

--- a/src/sdl_utils.h
+++ b/src/sdl_utils.h
@@ -69,6 +69,12 @@ inline SDL_Color color_pixel_custom( const SDL_Color &color )
     return color_pixel_mixer( color, get_option<float>( "MEMORY_GAMMA" ), dark, light );
 }
 
+// CBN-style pale-cyan texture used to distinguish lower z-levels.
+inline SDL_Color color_pixel_z_overlay( const SDL_Color &color )
+{
+    return { 128, 255, 255, color.a };
+}
+
 SDL_Color curses_color_to_SDL( const nc_color &color );
 
 ///@throws std::exception upon errors.

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1131,18 +1131,12 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             const int previous_overlay_depth = z_overlay_depth;
             const bool previous_overmap_render = drawing_overmap_transparency;
             if( !viewing_weather && omp.z() > 0 ) {
-                // The custom z-overlay texture path is stable for the first two visual
-                // depths.  Treat all higher aviation levels as the second fade step;
-                // the actual viewed height is still kept by center_abs_omt.
-                z_overlay_depth = std::min( omp.z(), 2 );
+                z_overlay_depth = omp.z();
                 drawing_overmap_transparency = true;
             }
 
-            // The sprite is ground terrain, but it is being displayed in the current
-            // overmap cell.  Keep the current z coordinate for rendering and overlays;
-            // only the terrain ID/rotation/subtile come from z=0.
             draw_from_id_string( terrain_id, TILE_CATEGORY::OVERMAP_TERRAIN,
-                                 "overmap_terrain", omp.raw(),
+                                 "overmap_terrain", terrain_omp.raw(),
                                  terrain_subtile, terrain_rotation, terrain_ll,
                                  false, height_3d );
 
@@ -1329,34 +1323,23 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             draw_string( *font, renderer, geometry, name, draw_pos, 11 );
         };
 
-        // Above ground, labels follow the same z=0 layer as the aviation map.
-        // Underground and z=0 continue using the current layer.
-        const tripoint_abs_omt label_center =
-            center_abs_omt.z() > 0
-            ? tripoint_abs_omt( center_abs_omt.xy(), 0 )
-            : center_abs_omt;
-
         // the tiles on the overmap are overmap tiles, so we need to use
         // coordinate conversions to make sure we're in the right place.
         const int radius = project_to<coords::sm>( tripoint_abs_omt( std::max( max_col, max_row ),
                            0, 0 ) ).x() / 2;
 
         for( const city_reference &city : overmap_buffer.get_cities_near(
-                 project_to<coords::sm>( label_center ), radius ) ) {
-            const tripoint_abs_omt city_ground = project_to<coords::omt>( city.abs_sm_pos );
-            const tripoint_abs_omt city_screen( city_ground.xy(), center_abs_omt.z() );
-            if( overmap_buffer.seen( city_ground ) &&
-                overmap_area.contains( city_screen.raw() ) ) {
+                 project_to<coords::sm>( center_abs_omt ), radius ) ) {
+            const tripoint_abs_omt city_center = project_to<coords::omt>( city.abs_sm_pos );
+            if( overmap_buffer.seen( city_center ) && overmap_area.contains( city_center.raw() ) ) {
                 label_bg( city.abs_sm_pos, city.city->name );
             }
         }
 
         for( const camp_reference &camp : overmap_buffer.get_camps_near(
-                 project_to<coords::sm>( label_center ), radius ) ) {
-            const tripoint_abs_omt camp_ground = project_to<coords::omt>( camp.abs_sm_pos );
-            const tripoint_abs_omt camp_screen( camp_ground.xy(), center_abs_omt.z() );
-            if( overmap_buffer.seen( camp_ground ) &&
-                overmap_area.contains( camp_screen.raw() ) ) {
+                 project_to<coords::sm>( center_abs_omt ), radius ) ) {
+            const tripoint_abs_omt camp_center = project_to<coords::omt>( camp.abs_sm_pos );
+            if( overmap_buffer.seen( camp_center ) && overmap_area.contains( camp_center.raw() ) ) {
                 const std::string camp_name = camp.camp->camp_name().empty() ?
                                               _( "Faction Camp" ) : camp.camp->camp_name();
                 label_bg( camp.abs_sm_pos, camp_name );
@@ -1364,10 +1347,9 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         }
 
         for( const faction_camp_reference &camp : overmap_buffer.get_faction_camps_near(
-                 label_center, max_col / 2 + 1, max_row / 2 + 1 ) ) {
-            const tripoint_abs_omt camp_screen( camp.abs_omt_pos.xy(), center_abs_omt.z() );
+                 center_abs_omt, max_col / 2 + 1, max_row / 2 + 1 ) ) {
             if( overmap_buffer.seen( camp.abs_omt_pos ) &&
-                overmap_area.contains( camp_screen.raw() ) ) {
+                overmap_area.contains( camp.abs_omt_pos.raw() ) ) {
                 label_bg( project_to<coords::sm>( camp.abs_omt_pos ), camp.name );
             }
         }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1100,48 +1100,51 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                 mx = overmap_buffer.extra( omp );
             }
 
-            // CBN does not redraw the current open_air sprite after drawing the lower tile.
-            // Instead it follows any consecutive open_air chain down to the first real terrain.
-            // Some legacy tilesets also use roof sprites that need to borrow the lower level.
-            std::string draw_id = id;
-            int draw_rotation = rotation;
-            int draw_subtile = subtile;
-            int z_offset = 0;
-            tripoint_abs_omt draw_omp = omp;
-            while( draw_id == "open_air" && draw_omp.z() > -OVERMAP_DEPTH ) {
-                const tripoint_abs_omt lower_omp = draw_omp + tripoint( 0, 0, -1 );
-                const bool lower_see = has_debug_vision || overmap_buffer.seen( lower_omp );
-                if( !lower_see ) {
-                    break;
-                }
-                ++z_offset;
-                draw_omp = lower_omp;
-                draw_id = get_omt_id_rotation_and_subtile( draw_omp, draw_rotation, draw_subtile );
-            }
-            while( overmap_tile_copies_lower_level( draw_id ) &&
-                   draw_omp.z() > -OVERMAP_DEPTH ) {
-                const tripoint_abs_omt lower_omp = draw_omp + tripoint( 0, 0, -1 );
-                const bool lower_see = has_debug_vision || overmap_buffer.seen( lower_omp );
-                if( !lower_see ) {
-                    break;
-                }
+            // Above ground, use the overmap as an aviation chart: always project the
+            // known z=0 terrain instead of drawing sparse roof/upper-floor OMTs.
+            // Underground and z=0 retain their original behavior.
+            tripoint_abs_omt terrain_omp = omp;
+            std::string terrain_id = id;
+            int terrain_rotation = rotation;
+            int terrain_subtile = subtile;
+            lit_level terrain_ll =
+                overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
 
-                int lower_rotation = 0;
-                int lower_subtile = -1;
-                const std::string lower_id = get_omt_id_rotation_and_subtile(
-                                                 lower_omp, lower_rotation, lower_subtile );
-                if( !find_tile_looks_like( lower_id, TILE_CATEGORY::OVERMAP_TERRAIN, "" ) ) {
-                    break;
-                }
+            if( !viewing_weather && omp.z() > 0 ) {
+                terrain_omp = tripoint_abs_omt( omp.xy(), 0 );
+                const bool ground_seen =
+                    has_debug_vision || overmap_buffer.seen( terrain_omp );
 
-                ++z_offset;
-                draw_omp = lower_omp;
-                draw_id = lower_id;
-                draw_rotation = lower_rotation;
-                draw_subtile = lower_subtile;
+                if( ground_seen ) {
+                    terrain_id = get_omt_id_rotation_and_subtile(
+                                     terrain_omp, terrain_rotation, terrain_subtile );
+                    terrain_ll = overmap_buffer.is_explored( terrain_omp )
+                                 ? lit_level::LOW : lit_level::LIT;
+                } else {
+                    terrain_id = "unknown_terrain";
+                    terrain_rotation = 0;
+                    terrain_subtile = -1;
+                    terrain_ll = lit_level::LIT;
+                }
             }
-            draw_om_tile_recursively( draw_omp, draw_id, draw_rotation, draw_subtile,
-                                      z_offset, has_debug_vision );
+
+            const int previous_overlay_depth = z_overlay_depth;
+            const bool previous_overmap_render = drawing_overmap_transparency;
+            if( !viewing_weather && omp.z() > 0 ) {
+                z_overlay_depth = omp.z();
+                drawing_overmap_transparency = true;
+            }
+
+            draw_from_id_string( terrain_id, TILE_CATEGORY::OVERMAP_TERRAIN,
+                                 "overmap_terrain", terrain_omp.raw(),
+                                 terrain_subtile, terrain_rotation, terrain_ll,
+                                 false, height_3d );
+
+            z_overlay_depth = previous_overlay_depth;
+            drawing_overmap_transparency = previous_overmap_render;
+
+            // Notes, missions, vehicles and other overlays still belong to the currently
+            // viewed z-level and are drawn at full opacity over the projected ground map.
             const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
             if( !mx.is_empty() && mx->autonote ) {
                 draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp.raw(),

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -927,8 +927,33 @@ void cata_tiles::draw_om_tile_recursively( const tripoint_abs_omt &omp,
         const std::string &id, const int rotation, const int subtile,
         const int base_z_offset, const bool has_debug_vision )
 {
+    std::string draw_id = id;
+    int draw_rotation = rotation;
+    int draw_subtile = subtile;
+
+    // open_air is not a roof sprite.  It is a transparent hole and must never be
+    // drawn back over the lower level.  When the lower level is unknown, render
+    // unknown terrain instead of exposing it or showing a tileset-specific air icon.
+    if( id == "open_air" ) {
+        if( omp.z() > -OVERMAP_DEPTH ) {
+            const tripoint_abs_omt lower_omp = omp + tripoint( 0, 0, -1 );
+            if( has_debug_vision || overmap_buffer.seen( lower_omp ) ) {
+                int lower_rotation = 0;
+                int lower_subtile = -1;
+                const std::string lower_id =
+                    get_omt_id_rotation_and_subtile( lower_omp, lower_rotation, lower_subtile );
+                draw_om_tile_recursively( lower_omp, lower_id, lower_rotation, lower_subtile,
+                                          base_z_offset + 1, has_debug_vision );
+                return;
+            }
+        }
+        draw_id = "unknown_terrain";
+        draw_rotation = 0;
+        draw_subtile = -1;
+    }
+
     std::optional<tile_lookup_res> tile =
-        find_tile_looks_like( id, TILE_CATEGORY::OVERMAP_TERRAIN, "" );
+        find_tile_looks_like( draw_id, TILE_CATEGORY::OVERMAP_TERRAIN, "" );
     const bool transparent = tile && tile->tile().has_om_transparency;
 
     bool drew_lower = false;
@@ -955,8 +980,8 @@ void cata_tiles::draw_om_tile_recursively( const tripoint_abs_omt &omp,
     const lit_level ll =
         overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
     int discarded_height = 0;
-    draw_from_id_string( id, TILE_CATEGORY::OVERMAP_TERRAIN, "overmap_terrain",
-                         omp.raw(), subtile, rotation, ll, false, discarded_height );
+    draw_from_id_string( draw_id, TILE_CATEGORY::OVERMAP_TERRAIN, "overmap_terrain",
+                         omp.raw(), draw_subtile, draw_rotation, ll, false, discarded_height );
 
     z_overlay_depth = previous_overlay_depth;
     overmap_transparency_foreground_only = previous_foreground_only;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1131,12 +1131,18 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             const int previous_overlay_depth = z_overlay_depth;
             const bool previous_overmap_render = drawing_overmap_transparency;
             if( !viewing_weather && omp.z() > 0 ) {
-                z_overlay_depth = omp.z();
+                // The custom z-overlay texture path is stable for the first two visual
+                // depths.  Treat all higher aviation levels as the second fade step;
+                // the actual viewed height is still kept by center_abs_omt.
+                z_overlay_depth = std::min( omp.z(), 2 );
                 drawing_overmap_transparency = true;
             }
 
+            // The sprite is ground terrain, but it is being displayed in the current
+            // overmap cell.  Keep the current z coordinate for rendering and overlays;
+            // only the terrain ID/rotation/subtile come from z=0.
             draw_from_id_string( terrain_id, TILE_CATEGORY::OVERMAP_TERRAIN,
-                                 "overmap_terrain", terrain_omp.raw(),
+                                 "overmap_terrain", omp.raw(),
                                  terrain_subtile, terrain_rotation, terrain_ll,
                                  false, height_3d );
 
@@ -1323,23 +1329,34 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             draw_string( *font, renderer, geometry, name, draw_pos, 11 );
         };
 
+        // Above ground, labels follow the same z=0 layer as the aviation map.
+        // Underground and z=0 continue using the current layer.
+        const tripoint_abs_omt label_center =
+            center_abs_omt.z() > 0
+            ? tripoint_abs_omt( center_abs_omt.xy(), 0 )
+            : center_abs_omt;
+
         // the tiles on the overmap are overmap tiles, so we need to use
         // coordinate conversions to make sure we're in the right place.
         const int radius = project_to<coords::sm>( tripoint_abs_omt( std::max( max_col, max_row ),
                            0, 0 ) ).x() / 2;
 
         for( const city_reference &city : overmap_buffer.get_cities_near(
-                 project_to<coords::sm>( center_abs_omt ), radius ) ) {
-            const tripoint_abs_omt city_center = project_to<coords::omt>( city.abs_sm_pos );
-            if( overmap_buffer.seen( city_center ) && overmap_area.contains( city_center.raw() ) ) {
+                 project_to<coords::sm>( label_center ), radius ) ) {
+            const tripoint_abs_omt city_ground = project_to<coords::omt>( city.abs_sm_pos );
+            const tripoint_abs_omt city_screen( city_ground.xy(), center_abs_omt.z() );
+            if( overmap_buffer.seen( city_ground ) &&
+                overmap_area.contains( city_screen.raw() ) ) {
                 label_bg( city.abs_sm_pos, city.city->name );
             }
         }
 
         for( const camp_reference &camp : overmap_buffer.get_camps_near(
-                 project_to<coords::sm>( center_abs_omt ), radius ) ) {
-            const tripoint_abs_omt camp_center = project_to<coords::omt>( camp.abs_sm_pos );
-            if( overmap_buffer.seen( camp_center ) && overmap_area.contains( camp_center.raw() ) ) {
+                 project_to<coords::sm>( label_center ), radius ) ) {
+            const tripoint_abs_omt camp_ground = project_to<coords::omt>( camp.abs_sm_pos );
+            const tripoint_abs_omt camp_screen( camp_ground.xy(), center_abs_omt.z() );
+            if( overmap_buffer.seen( camp_ground ) &&
+                overmap_area.contains( camp_screen.raw() ) ) {
                 const std::string camp_name = camp.camp->camp_name().empty() ?
                                               _( "Faction Camp" ) : camp.camp->camp_name();
                 label_bg( camp.abs_sm_pos, camp_name );
@@ -1347,9 +1364,10 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         }
 
         for( const faction_camp_reference &camp : overmap_buffer.get_faction_camps_near(
-                 center_abs_omt, max_col / 2 + 1, max_row / 2 + 1 ) ) {
+                 label_center, max_col / 2 + 1, max_row / 2 + 1 ) ) {
+            const tripoint_abs_omt camp_screen( camp.abs_omt_pos.xy(), center_abs_omt.z() );
             if( overmap_buffer.seen( camp.abs_omt_pos ) &&
-                overmap_area.contains( camp.abs_omt_pos.raw() ) ) {
+                overmap_area.contains( camp_screen.raw() ) ) {
                 label_bg( project_to<coords::sm>( camp.abs_omt_pos ), camp.name );
             }
         }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -923,6 +923,43 @@ std::string cata_tiles::get_omt_id_rotation_and_subtile(
     return ot_type_id.id().str();
 }
 
+void cata_tiles::draw_om_tile_recursively( const tripoint_abs_omt &omp,
+        const std::string &id, const int rotation, const int subtile,
+        const int base_z_offset, const bool has_debug_vision )
+{
+    std::optional<tile_lookup_res> tile =
+        find_tile_looks_like( id, TILE_CATEGORY::OVERMAP_TERRAIN, "" );
+    const bool transparent = tile && tile->tile().has_om_transparency;
+
+    bool drew_lower = false;
+    if( transparent && omp.z() > -OVERMAP_DEPTH ) {
+        const tripoint_abs_omt lower_omp = omp + tripoint( 0, 0, -1 );
+        if( has_debug_vision || overmap_buffer.seen( lower_omp ) ) {
+            int lower_rotation = 0;
+            int lower_subtile = -1;
+            const std::string lower_id =
+                get_omt_id_rotation_and_subtile( lower_omp, lower_rotation, lower_subtile );
+            draw_om_tile_recursively( lower_omp, lower_id, lower_rotation, lower_subtile,
+                                      base_z_offset + 1, has_debug_vision );
+            drew_lower = true;
+        }
+    }
+
+    const int previous_overlay_depth = z_overlay_depth;
+    const bool previous_foreground_only = overmap_transparency_foreground_only;
+    z_overlay_depth = base_z_offset;
+    overmap_transparency_foreground_only = transparent && drew_lower;
+
+    const lit_level ll =
+        overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
+    int discarded_height = 0;
+    draw_from_id_string( id, TILE_CATEGORY::OVERMAP_TERRAIN, "overmap_terrain",
+                         omp.raw(), subtile, rotation, ll, false, discarded_height );
+
+    z_overlay_depth = previous_overlay_depth;
+    overmap_transparency_foreground_only = previous_foreground_only;
+}
+
 static point draw_string( Font &font,
                           const SDL_Renderer_Ptr &renderer,
                           const GeometryRenderer_Ptr &geometry,
@@ -1028,10 +1065,10 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                 mx = overmap_buffer.extra( omp );
             }
 
+            // Draw transparent/open-air overmap tiles bottom-to-top, with the same
+            // pale-cyan depth cue used by the local map.
+            draw_om_tile_recursively( omp, id, rotation, subtile, 0, has_debug_vision );
             const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
-            // light level is now used for choosing between grayscale filter and normal lit tiles.
-            draw_from_id_string( id, TILE_CATEGORY::OVERMAP_TERRAIN, "overmap_terrain", omp.raw(),
-                                 subtile, rotation, ll, false, height_3d );
             if( !mx.is_empty() && mx->autonote ) {
                 draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp.raw(),
                                      0, 0, ll, false );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -947,8 +947,10 @@ void cata_tiles::draw_om_tile_recursively( const tripoint_abs_omt &omp,
 
     const int previous_overlay_depth = z_overlay_depth;
     const bool previous_foreground_only = overmap_transparency_foreground_only;
+    const bool previous_overmap_render = drawing_overmap_transparency;
     z_overlay_depth = base_z_offset;
     overmap_transparency_foreground_only = transparent && drew_lower;
+    drawing_overmap_transparency = true;
 
     const lit_level ll =
         overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
@@ -958,6 +960,7 @@ void cata_tiles::draw_om_tile_recursively( const tripoint_abs_omt &omp,
 
     z_overlay_depth = previous_overlay_depth;
     overmap_transparency_foreground_only = previous_foreground_only;
+    drawing_overmap_transparency = previous_overmap_render;
 }
 
 static point draw_string( Font &font,
@@ -1065,9 +1068,21 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                 mx = overmap_buffer.extra( omp );
             }
 
-            // Draw transparent/open-air overmap tiles bottom-to-top, with the same
-            // pale-cyan depth cue used by the local map.
-            draw_om_tile_recursively( omp, id, rotation, subtile, 0, has_debug_vision );
+            // CBN does not redraw the current open_air sprite after drawing the lower tile.
+            // Instead it follows any consecutive open_air chain down to the first real terrain.
+            int z_offset = 0;
+            tripoint_abs_omt draw_omp = omp;
+            while( id == "open_air" && draw_omp.z() > -OVERMAP_DEPTH ) {
+                const tripoint_abs_omt lower_omp = draw_omp + tripoint( 0, 0, -1 );
+                const bool lower_see = has_debug_vision || overmap_buffer.seen( lower_omp );
+                if( !lower_see ) {
+                    break;
+                }
+                ++z_offset;
+                draw_omp = lower_omp;
+                id = get_omt_id_rotation_and_subtile( draw_omp, rotation, subtile );
+            }
+            draw_om_tile_recursively( draw_omp, id, rotation, subtile, z_offset, has_debug_vision );
             const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
             if( !mx.is_empty() && mx->autonote ) {
                 draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp.raw(),

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1,4 +1,4 @@
-#include "cursesdef.h" // IWYU pragma: associated
+﻿#include "cursesdef.h" // IWYU pragma: associated
 #include "sdltiles.h" // IWYU pragma: associated
 
 #include "cuboid_rectangle.h"
@@ -922,6 +922,13 @@ std::string cata_tiles::get_omt_id_rotation_and_subtile(
 
     return ot_type_id.id().str();
 }
+// Legacy overmap tilesets often have no dedicated transparent roof foreground.
+// Treat a roof as a proxy for the already-known level below.
+static bool overmap_tile_copies_lower_level( const std::string &id )
+{
+    return id == "roof" || id.find( "_roof" ) != std::string::npos ||
+           id.rfind( "roof_", 0 ) == 0;
+}
 
 void cata_tiles::draw_om_tile_recursively( const tripoint_abs_omt &omp,
         const std::string &id, const int rotation, const int subtile,
@@ -1095,9 +1102,13 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
             // CBN does not redraw the current open_air sprite after drawing the lower tile.
             // Instead it follows any consecutive open_air chain down to the first real terrain.
+            // Some legacy tilesets also use roof sprites that need to borrow the lower level.
+            std::string draw_id = id;
+            int draw_rotation = rotation;
+            int draw_subtile = subtile;
             int z_offset = 0;
             tripoint_abs_omt draw_omp = omp;
-            while( id == "open_air" && draw_omp.z() > -OVERMAP_DEPTH ) {
+            while( draw_id == "open_air" && draw_omp.z() > -OVERMAP_DEPTH ) {
                 const tripoint_abs_omt lower_omp = draw_omp + tripoint( 0, 0, -1 );
                 const bool lower_see = has_debug_vision || overmap_buffer.seen( lower_omp );
                 if( !lower_see ) {
@@ -1105,9 +1116,32 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                 }
                 ++z_offset;
                 draw_omp = lower_omp;
-                id = get_omt_id_rotation_and_subtile( draw_omp, rotation, subtile );
+                draw_id = get_omt_id_rotation_and_subtile( draw_omp, draw_rotation, draw_subtile );
             }
-            draw_om_tile_recursively( draw_omp, id, rotation, subtile, z_offset, has_debug_vision );
+            while( overmap_tile_copies_lower_level( draw_id ) &&
+                   draw_omp.z() > -OVERMAP_DEPTH ) {
+                const tripoint_abs_omt lower_omp = draw_omp + tripoint( 0, 0, -1 );
+                const bool lower_see = has_debug_vision || overmap_buffer.seen( lower_omp );
+                if( !lower_see ) {
+                    break;
+                }
+
+                int lower_rotation = 0;
+                int lower_subtile = -1;
+                const std::string lower_id = get_omt_id_rotation_and_subtile(
+                                                 lower_omp, lower_rotation, lower_subtile );
+                if( !find_tile_looks_like( lower_id, TILE_CATEGORY::OVERMAP_TERRAIN, "" ) ) {
+                    break;
+                }
+
+                ++z_offset;
+                draw_omp = lower_omp;
+                draw_id = lower_id;
+                draw_rotation = lower_rotation;
+                draw_subtile = lower_subtile;
+            }
+            draw_om_tile_recursively( draw_omp, draw_id, draw_rotation, draw_subtile,
+                                      z_offset, has_debug_vision );
             const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
             if( !mx.is_empty() && mx->autonote ) {
                 draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp.raw(),


### PR DESCRIPTION
## 改动内容

- 移植并修复 CBN 式高层透明、大地图透视、下层复制和地面投影模式。
- 完善高层城市名与派系营地名的显示。
- 将大地图向下观察的渐进叠色上限从 96 提高到 192，使第 8 层之后仍继续逐层加深；局部地图上限保持 160。

## 验证

- 已通过 `git diff --check`。
- 本次按集中测试策略暂未触发 MSVC/Android 工作流，待后续功能合入 `develop` 后统一运行。