### PR TITLE
修复现实地图高层透视渐进色过早封顶

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2742,12 +2742,13 @@ bool cata_tiles::draw_sprite_at(
     const SDL_RendererFlip flip ) {
         int result = sprite_tex->render_copy_ex( renderer, &destination, angle, nullptr, flip );
         if( z_overlay_tex ) {
-            // Keep CBN's gentler 12-alpha-per-level overmap curve, but do not
-            // stop progressing after the seventh lower level.  CBN caps this
-            // overlay at 192, while the local-map curve remains capped at 160.
+            // Keep the gentler overmap curve capped at 192.  On the local map,
+            // retain the existing 56-alpha first lower level but spread the
+            // progression across all ten above-ground z-levels, so high floors
+            // do not collapse to the same blue tint after only four levels.
             const int alpha = drawing_overmap_transparency
                               ? std::min( 192, 24 + ( z_overlay_depth - 1 ) * 12 )
-                              : std::min( 160, 56 + ( z_overlay_depth - 1 ) * 32 );
+                              : std::min( 240, 56 + ( z_overlay_depth - 1 ) * 20 );
             z_overlay_tex->set_alpha_mod( alpha );
             const int overlay_result =
                 z_overlay_tex->render_copy_ex( renderer, &destination, angle, nullptr, flip );


### PR DESCRIPTION
## 修复内容

- 保留已验证的大地图渐进叠色曲线：上限 192、每层递增 12。
- 将现实地图曲线改为首层 56、每层递增 20、上限 240，使第 5 至第 10 个向下观察层级持续加深，而不是过早固定为同一种蓝色。

## 验证

- 已通过补丁预检与 `git diff --check`。
- 按集中测试安排，本 PR 不启动 MSVC/Android 工作流。