### PR TITLE
修复高层大地图的城市与派系营地标签显示

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -284,12 +284,8 @@ static void draw_city_labels( const catacurses::window &w, const tripoint_abs_om
 
     const point screen_center_pos( win_x_max / 2, win_y_max / 2 );
 
-    // Above ground, labels follow the same z=0 layer used by the aviation map.
-    const tripoint_abs_omt label_center =
-        center.z() > 0 ? tripoint_abs_omt( center.xy(), 0 ) : center;
-
     for( const city_reference &element : overmap_buffer.get_cities_near(
-             project_to<coords::sm>( label_center ), sm_radius ) ) {
+             project_to<coords::sm>( center ), sm_radius ) ) {
         const point_abs_omt city_pos =
             project_to<coords::omt>( element.abs_sm_pos.xy() );
         const point_rel_omt screen_pos( city_pos - center.xy() + screen_center_pos );
@@ -313,8 +309,8 @@ static void draw_city_labels( const catacurses::window &w, const tripoint_abs_om
             continue;   // right under the cursor.
         }
 
-        if( !overmap_buffer.seen( tripoint_abs_omt( city_pos, label_center.z() ) ) ) {
-            continue;   // haven't seen it on the displayed ground layer.
+        if( !overmap_buffer.seen( tripoint_abs_omt( city_pos, center.z() ) ) ) {
+            continue;   // haven't seen it.
         }
 
         mvwprintz( w, point( text_x_min, text_y ), i_yellow, element.city->name );
@@ -329,12 +325,8 @@ static void draw_camp_labels( const catacurses::window &w, const tripoint_abs_om
 
     const point screen_center_pos( win_x_max / 2, win_y_max / 2 );
 
-    // Ordinary camps are ground features and use the projected ground layer.
-    const tripoint_abs_omt label_center =
-        center.z() > 0 ? tripoint_abs_omt( center.xy(), 0 ) : center;
-
     for( const camp_reference &element : overmap_buffer.get_camps_near(
-             project_to<coords::sm>( label_center ), sm_radius ) ) {
+             project_to<coords::sm>( center ), sm_radius ) ) {
         const point_abs_omt camp_pos( element.camp->camp_omt_pos().xy() );
         const point screen_pos( ( camp_pos - center.xy() ).raw() + screen_center_pos );
         const std::string camp_name = element.camp->camp_name().empty() ?
@@ -357,8 +349,8 @@ static void draw_camp_labels( const catacurses::window &w, const tripoint_abs_om
             continue;   // right under the cursor.
         }
 
-        if( !overmap_buffer.seen( tripoint_abs_omt( camp_pos, label_center.z() ) ) ) {
-            continue;   // haven't seen it on the displayed ground layer.
+        if( !overmap_buffer.seen( tripoint_abs_omt( camp_pos, center.z() ) ) ) {
+            continue;   // haven't seen it.
         }
 
         mvwprintz( w, point( text_x_min, text_y ), i_yellow, camp_name );
@@ -372,12 +364,8 @@ static void draw_faction_camp_labels( const catacurses::window &w,
     const int win_y_max = getmaxy( w );
     const point screen_center_pos( win_x_max / 2, win_y_max / 2 );
 
-    // Faction camps follow the same z=0 projection when viewed from the air.
-    const tripoint_abs_omt label_center =
-        center.z() > 0 ? tripoint_abs_omt( center.xy(), 0 ) : center;
-
     for( const faction_camp_reference &element : overmap_buffer.get_faction_camps_near(
-             label_center, win_x_max / 2 + 1, win_y_max / 2 + 1 ) ) {
+             center, win_x_max / 2 + 1, win_y_max / 2 + 1 ) ) {
         const point screen_pos( ( element.abs_omt_pos.xy() - center.xy() ).raw() +
                                 screen_center_pos );
         const int text_width = utf8_width( element.name, true );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1300,6 +1300,13 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     }
 
     if( !viewing_weather && uistate.overmap_show_city_labels ) {
+        // Above ground, terrain is projected from z=0.  Query labels from the
+        // same layer and compare only their screen-plane coordinates.
+        const tripoint_abs_omt label_center = center_abs_omt.z() > 0 ?
+                                               tripoint_abs_omt( center_abs_omt.xy(), 0 ) : center_abs_omt;
+        const auto label_in_view = [&]( const tripoint_abs_omt & label_pos ) {
+            return overmap_area.contains( tripoint( label_pos.raw().xy(), center_abs_omt.z() ) );
+        };
 
         const auto abs_sm_to_draw_label = [&]( const tripoint_abs_sm & city_pos, const int label_length ) {
             const tripoint tile_draw_pos = global_omt_to_draw_position( project_to<coords::omt>
@@ -1329,17 +1336,17 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                            0, 0 ) ).x() / 2;
 
         for( const city_reference &city : overmap_buffer.get_cities_near(
-                 project_to<coords::sm>( center_abs_omt ), radius ) ) {
+                 project_to<coords::sm>( label_center ), radius ) ) {
             const tripoint_abs_omt city_center = project_to<coords::omt>( city.abs_sm_pos );
-            if( overmap_buffer.seen( city_center ) && overmap_area.contains( city_center.raw() ) ) {
+            if( overmap_buffer.seen( city_center ) && label_in_view( city_center ) ) {
                 label_bg( city.abs_sm_pos, city.city->name );
             }
         }
 
         for( const camp_reference &camp : overmap_buffer.get_camps_near(
-                 project_to<coords::sm>( center_abs_omt ), radius ) ) {
+                 project_to<coords::sm>( label_center ), radius ) ) {
             const tripoint_abs_omt camp_center = project_to<coords::omt>( camp.abs_sm_pos );
-            if( overmap_buffer.seen( camp_center ) && overmap_area.contains( camp_center.raw() ) ) {
+            if( overmap_buffer.seen( camp_center ) && label_in_view( camp_center ) ) {
                 const std::string camp_name = camp.camp->camp_name().empty() ?
                                               _( "Faction Camp" ) : camp.camp->camp_name();
                 label_bg( camp.abs_sm_pos, camp_name );
@@ -1347,9 +1354,9 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         }
 
         for( const faction_camp_reference &camp : overmap_buffer.get_faction_camps_near(
-                 center_abs_omt, max_col / 2 + 1, max_row / 2 + 1 ) ) {
+                 label_center, max_col / 2 + 1, max_row / 2 + 1 ) ) {
             if( overmap_buffer.seen( camp.abs_omt_pos ) &&
-                overmap_area.contains( camp.abs_omt_pos.raw() ) ) {
+                label_in_view( camp.abs_omt_pos ) ) {
                 label_bg( project_to<coords::sm>( camp.abs_omt_pos ), camp.name );
             }
         }


### PR DESCRIPTION
## 问题

高层大地图会把地面地形投影到当前视图，但城市名、普通营地名和派系营地名仍按当前高层坐标查询。标签数据实际位于地面层，因此升高视角后标签不会显示。

## 改动内容

- 图块大地图在高层视角下统一从 `z=0` 查询城市、普通营地和派系营地标签。
- 标签可见范围仅按屏幕平面坐标判断，使地面标签能正确叠加到当前高层视图。
- 标签仍以地面层探索状态作为显示条件，不会泄露尚未探索的位置。
- 移除字符大地图中无效的地面投影尝试，保留其原有分层显示逻辑。

## 验证

- `git diff --check` 通过。
- Windows Tiles x64 MSVC 与 Android arm64 双平台测试通过。
- 已进行游戏内高层大地图显示测试，城市名与派系营地名可以正常显示。

测试记录：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/30691941263