### PR TITLE
增加NPC性格标签与静态位置模组API

### DIFF
--- a/data/json/mutations/npc_movement_policy.json
+++ b/data/json/mutations/npc_movement_policy.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "mutation",
+    "id": "NPC_HOLD_POSITION",
+    "name": { "str": "NPC hold position" },
+    "description": "Internal marker used by NPC movement-policy EOCs.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": false
+  }
+]

--- a/data/json/mutations/npc_personality.json
+++ b/data/json/mutations/npc_personality.json
@@ -1,0 +1,153 @@
+[
+  {
+    "//": "This file contains *personality* traits, intended to give players an idea an NPC's decision making via TALK_ASSESS_PERSON and other dialogue.",
+    "//1": "None of them should provide gameplay effects (e.g. more HP or more damage).",
+    "//2": "All of them are reset when the game is loaded, and otherwise applied to any newly generated NPCs at the time of generation.",
+    "id": "personality_ultra_selfish",
+    "type": "mutation",
+    "name": { "str": "Survivor at any cost" },
+    "description": "<npc_name> is certainly a survivor.  You can only wonder how many they've abandoned to save themself.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "//3": "No support for this right now, but maybe in the future? These traits are descriptory, so there's no real problem if the player describes themself however they want.",
+    "vanity": false,
+    "personality_score": { "max_aggression": -3, "max_bravery": -2, "max_altruism": -4 }
+  },
+  {
+    "id": "personality_neg_aggressive",
+    "type": "mutation",
+    "name": { "str": "Timid" },
+    "description": "<npc_name> tries to avoid conflict, even when they have good reason not to.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "max_aggression": -3 }
+  },
+  {
+    "id": "personality_aggressive_mixed",
+    "type": "mutation",
+    "name": { "str": "Hardass" },
+    "description": "<npc_name> loves to fight a good fight, but only for themself.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_bravery": 3, "min_aggression": 3, "max_altruism": -2 }
+  },
+  {
+    "id": "personality_aggressive_plus_mixed",
+    "type": "mutation",
+    "name": { "str": "Freedom fighter" },
+    "description": "<npc_name> believes in fighting… mostly for others, even at risk to their own wellbeing.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_bravery": 1, "min_aggression": 5, "min_altruism": 2 }
+  },
+  {
+    "id": "personality_aggressive_plus",
+    "type": "mutation",
+    "name": { "str": "Volatile" },
+    "description": "<npc_name> is just looking for an excuse.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_aggression": 7 }
+  },
+  {
+    "//": "A straightforward tell for the NPC's bravery, since it has a huge impact on how they engage in combat.",
+    "id": "personality_neg_bravery",
+    "type": "mutation",
+    "name": { "str": "Coward" },
+    "description": "<npc_name> flinches at the thought of fighting, whether it be other people or the undead.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "max_bravery": -4 }
+  },
+  {
+    "//": "A straightforward tell for the NPC's bravery, since it has a huge impact on how they engage in combat.",
+    "id": "personality_neg_bravery_plus",
+    "type": "mutation",
+    "name": { "str": "Craven" },
+    "description": "<npc_name> is afraid of the dark, spiders, and unexplained sounds.  So are you, but only because you've lived through the apocalypse.  <npc_name> has always been like this.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "max_bravery": -7 }
+  },
+  {
+    "//": "A straightforward tell for the NPC's bravery, since it has a huge impact on how they engage in combat.",
+    "id": "personality_brave",
+    "type": "mutation",
+    "name": { "str": "Brave" },
+    "description": "<npc_name> knows the name of fear, but only as a long-defeated foe.  Little can shake them.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_bravery": 4 }
+  },
+  {
+    "id": "personality_brave_plus",
+    "type": "mutation",
+    "name": { "str": "Hero" },
+    "description": "<npc_name> is an ideal ally to those they call friend, always willing to help others.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_bravery": 5, "min_altruism": 2 }
+  },
+  {
+    "id": "personality_collector",
+    "type": "mutation",
+    "name": { "str": "Miser" },
+    "description": "<npc_name> loves their trinkets, and hates giving them away.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_collector": 3, "max_altruism": -1 }
+  },
+  {
+    "id": "personality_collector_plus",
+    "type": "mutation",
+    "name": { "str": "Scrooge" },
+    "description": "<npc_name> collects trash like a RPG protagonist collects potions.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_collector": 6 }
+  },
+  {
+    "id": "personality_altruist",
+    "type": "mutation",
+    "name": { "str": "Kind" },
+    "description": "<npc_name> just wants to help.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_altruism": 4 }
+  },
+  {
+    "id": "personality_neg_altruist",
+    "type": "mutation",
+    "name": { "str": "Self-centered" },
+    "description": "<npc_name> steers every interaction into discussing how it will help them.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "max_altruism": -3 }
+  }
+]

--- a/data/json/mutations/npc_personality.json
+++ b/data/json/mutations/npc_personality.json
@@ -16,6 +16,16 @@
     "personality_score": { "max_aggression": -3, "max_bravery": -2, "max_altruism": -4 }
   },
   {
+    "id": "NPC_PERSONALITY_SUMMARY",
+    "type": "mutation",
+    "name": { "str": "Personality" },
+    "description": "The NPC's personality traits are shown here.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": false
+  },
+  {
     "id": "personality_neg_aggressive",
     "type": "mutation",
     "name": { "str": "Timid" },

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -116,6 +116,8 @@ Faction determines what faction, if any, the NPC belongs to.  Some examples are 
 
 Mutations may define a `personality_score` object containing any of `min_aggression`, `max_aggression`, `min_bravery`, `max_bravery`, `min_collector`, `max_collector`, `min_altruism`, and `max_altruism`.  Supplied bounds are clamped to -10 through 10; omitted bounds are unrestricted so class-adjusted NPC personality values outside that range still match.  NPCs automatically gain every matching descriptive trait when generated, loaded, or changed by a personality EOC.  These traits should be descriptive only and should not add gameplay bonuses.
 
+The interface option `NPC_PERSONALITY_TRAIT_DISPLAY` controls how matching personality traits appear in an NPC's character information.  `SEPARATE` keeps every matching trait as an individual entry.  `COMBINED` replaces them with one `Personality` entry and lists each matching trait and description in the information pane.  The combined view also includes personality traits added by mods through `personality_score`.
+
 # Writing dialogues
 Dialogues work like state machines. They start with a certain topic (the NPC says something), the player character can then respond (choosing one of several responses), and that response sets the new talk topic. This goes on until the dialogue is finished, or the NPC turns hostile.
 

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -103,6 +103,19 @@ Faction determines what faction, if any, the NPC belongs to.  Some examples are 
 
 `age` and `height` are optional fields that can be used to define the age and height (in cm) of the NPC respectively.
 
+`personality` optionally fixes the NPC's four personality values instead of using randomized values.  All four members are required and are clamped to the range -10 to 10:
+
+```json
+"personality": {
+  "aggression": 1,
+  "bravery": 6,
+  "collector": -4,
+  "altruism": 7
+}
+```
+
+Mutations may define a `personality_score` object containing any of `min_aggression`, `max_aggression`, `min_bravery`, `max_bravery`, `min_collector`, `max_collector`, `min_altruism`, and `max_altruism`.  Supplied bounds are clamped to -10 through 10; omitted bounds are unrestricted so class-adjusted NPC personality values outside that range still match.  NPCs automatically gain every matching descriptive trait when generated, loaded, or changed by a personality EOC.  These traits should be descriptive only and should not add gameplay bonuses.
+
 # Writing dialogues
 Dialogues work like state machines. They start with a certain topic (the NPC says something), the player character can then respond (choosing one of several responses), and that response sets the new talk topic. This goes on until the dialogue is finished, or the NPC turns hostile.
 
@@ -802,6 +815,9 @@ Effect | Description
 `bionic_remove` | The NPC removes a bionic from your character, using very high skill, and charging you according to the operation's difficulty.
 `npc_class_change: `string or [variable object](#variable-object) | Change the NPC's class to the new value.
 `npc_faction_change: `string or [variable object](#variable-object) | Change the NPC's faction membership to the new value.
+`npc_set_personality: `object | Sets any listed NPC personality values (`aggression`, `bravery`, `collector`, `altruism`) to ints or [variable objects](#variable-object), clamps them to -10 through 10, and refreshes descriptive personality traits.
+`npc_mod_personality: `object | Adds the supplied ints or [variable objects](#variable-object) to the listed NPC personality values, clamps them to -10 through 10, and refreshes descriptive personality traits.
+`npc_set_movement_policy: `string or [variable object](#variable-object) | `HOLD_POSITION` makes the NPC remain on its tile and ignore ordinary threat, sound, need, and tactical movement.  It may step away only when standing directly in fire or acid.  `NORMAL` restores regular AI movement.
 `u_faction_rep: `int or [variable object](#variable-object) | Increases your reputation with the NPC's current faction, or decreases it if the value is negative.
 `toggle_npc_rule: `string or [variable object](#variable-object) | Toggles the value of a boolean NPC follower AI rule such as `"use_silent"` or `"allow_bash"`
 `set_npc_rule: `string or [variable object](#variable-object) | Sets the value of a boolean NPC follower AI rule such as `"use_silent"` or `"allow_bash"`
@@ -976,6 +992,8 @@ Condition | Type | Description
 `"u_cbm_recharge_rule" or "npc_cbm_recharge_rule"` | string or [variable object](#variable-object) | `true` if u or the NPC follower AI rule for cbm recharge matches the string.
 `"u_rule" or "npc_rule"` | string or [variable object](#variable-object) | `true` if u or the NPC follower AI rule for that matches string is set.
 `"u_override" or "npc_override"` | string or [variable object](#variable-object)| `true` if u or the NPC has an override for the string.
+`"npc_personality"` | object | Tests one or more NPC personality values.  A direct integer requires an exact match; a `{ "min": ..., "max": ... }` object tests a range, and either bound may be omitted or use a [variable object](#variable-object).  Example: `{ "npc_personality": { "bravery": { "min": 5 }, "altruism": { "min": 2 } } }`.
+`"npc_movement_policy"` | string or [variable object](#variable-object) | Tests whether the NPC movement policy is `NORMAL` or `HOLD_POSITION`.
 `"has_pickup_list" or "u_has_pickup_list" or "npc_has_pickup_list"` | simple string | `true` if u or the NPC has a pickup list.
 `"roll_contested""`, `difficulty`: int or [variable object](#variable-object), (*optional* `die_size : `int or [variable object](#variable-object) ) | [int expression](#compare-integers-and-arithmetics) | Compares a roll against a difficulty. Returns true if a random number between 1 and `die_size` (defaults to 10) plus the integer expression is greater than `difficulty`. For example { "u_roll_contested": { "u_val": "strength" }, "difficulty": 6 } will return whether a random number between 1 and 10 plus strength is greater than 6.
 

--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -464560,7 +464560,7 @@ msgstr "全力求生"
 msgid ""
 "<npc_name> is certainly a survivor.  You can only wonder how many they've "
 "abandoned to save themself."
-msgstr "<npc_name>肯定是幸存者。你不禁好奇为了拯救自己而付出了多少代价。"
+msgstr "<npc_name>把活下去看得比什么都重要，为了保全自己，他们很可能抛下任何拖累。"
 
 #: data/json/mutations/npc_personality.json
 #. ~ Mutation name
@@ -464570,7 +464570,7 @@ msgstr "谨慎"
 #: data/json/mutations/npc_personality.json
 #. ~ Description of mutation "Timid"
 msgid "<npc_name> tries to avoid conflict, even when they have good reason not to."
-msgstr "<npc_name>总是试图避免冲突，即便他们本有充分的理由去面对。"
+msgstr "<npc_name>总会先避开冲突，即便眼前的麻烦已经很难靠退让解决。"
 
 #: data/json/mutations/npc_personality.json
 #. ~ Mutation name
@@ -464580,7 +464580,7 @@ msgstr "硬汉"
 #: data/json/mutations/npc_personality.json
 #. ~ Description of mutation "Hardass"
 msgid "<npc_name> loves to fight a good fight, but only for themself."
-msgstr "<npc_name>想要好好干一架，但只为了自己。"
+msgstr "<npc_name>喜欢用拳头解决问题，只要最终受益的是自己，他们并不介意把事情闹大。"
 
 #: data/json/mutations/npc_personality.json
 #. ~ Mutation name
@@ -464592,7 +464592,7 @@ msgstr "自由战神"
 msgid ""
 "<npc_name> believes in fighting… mostly for others, even at risk to their own "
 "wellbeing."
-msgstr "<npc_name>执着于为他人而战斗，甚至冒着损害自身利益的风险。"
+msgstr "<npc_name>愿意为他人挺身而出，即便需要承担伤痛和危险，他们也很少退让。"
 
 #: data/json/mutations/npc_personality.json
 #. ~ Mutation name
@@ -464602,7 +464602,7 @@ msgstr "易怒"
 #: data/json/mutations/npc_personality.json
 #. ~ Description of mutation "Volatile"
 msgid "<npc_name> is just looking for an excuse."
-msgstr "<npc_name>只需要一个借口。"
+msgstr "<npc_name>的耐心十分有限，只要找到一点借口，他们就可能立刻诉诸暴力。"
 
 #: data/json/mutations/npc_personality.json
 #: data/mods/Xedra_Evolved/eocs/eoc_riddles.json
@@ -464616,7 +464616,7 @@ msgstr "胆小"
 msgid ""
 "<npc_name> flinches at the thought of fighting, whether it be other people or "
 "the undead."
-msgstr "<npc_name>一想到战斗就会退缩，无论是与其他人还是不死生物。"
+msgstr "<npc_name>一想到战斗就会退缩，无论对手是活人还是不死生物，他们都更愿意避开。"
 
 #: data/json/mutations/npc_personality.json
 #. ~ Mutation name
@@ -464629,7 +464629,7 @@ msgid ""
 "<npc_name> is afraid of the dark, spiders, and unexplained sounds.  So are "
 "you, but only because you've lived through the apocalypse.  <npc_name> has "
 "always been like this."
-msgstr "<npc_name>害怕黑暗、蜘蛛和无法解释的声音。你也是，但只是因为你经历过世界末日。<npc_name>一直都是这样。"
+msgstr "<npc_name>害怕黑暗，蜘蛛和无法解释的声响，灾变并没有造成这种恐惧，他们一直如此。"
 
 #: data/json/mutations/npc_personality.json
 #. ~ Mutation name
@@ -464641,14 +464641,14 @@ msgstr "勇敢"
 msgid ""
 "<npc_name> knows the name of fear, but only as a long-defeated foe.  Little "
 "can shake them."
-msgstr "<npc_name>知道什么叫害怕，但那不过是早已击败过的敌人。没有什么可以使其动摇。"
+msgstr "<npc_name>知道恐惧是什么，也早已学会压住它，寻常危险很难让他们动摇。"
 
 #: data/json/mutations/npc_personality.json
 #. ~ Description of mutation "Hero"
 msgid ""
 "<npc_name> is an ideal ally to those they call friend, always willing to help "
 "others."
-msgstr "<npc_name>对于被其称作朋友的人来说，是个完美的盟友，总是愿意帮助他人。"
+msgstr "<npc_name>会认真保护被自己视作同伴的人，只要有人需要帮助，他们通常愿意承担风险。"
 
 #: data/json/mutations/npc_personality.json
 #. ~ Mutation name
@@ -464658,7 +464658,7 @@ msgstr "吝啬鬼"
 #: data/json/mutations/npc_personality.json
 #. ~ Description of mutation "Miser"
 msgid "<npc_name> loves their trinkets, and hates giving them away."
-msgstr "<npc_name>异常爱惜自己的小玩意，并拒绝把它们交出去。"
+msgstr "<npc_name>异常爱惜自己的财物，也很难接受把它们交给别人，即便这些东西并不贵重。"
 
 #: data/json/mutations/npc_personality.json
 #. ~ Mutation name
@@ -464668,7 +464668,7 @@ msgstr "麦克老鸭"
 #: data/json/mutations/npc_personality.json
 #. ~ Description of mutation "Scrooge"
 msgid "<npc_name> collects trash like a RPG protagonist collects potions."
-msgstr "<npc_name>像RPG游戏里收集药剂一样收集垃圾。"
+msgstr "<npc_name>看到能带走的东西就很难放手，哪怕只是无用的零碎，他们也想收入囊中。"
 
 #: data/json/mutations/npc_personality.json
 #. ~ Mutation name
@@ -464678,7 +464678,7 @@ msgstr "仁善"
 #: data/json/mutations/npc_personality.json
 #. ~ Description of mutation "Kind"
 msgid "<npc_name> just wants to help."
-msgstr "<npc_name>只是想提供帮助。"
+msgstr "<npc_name>愿意主动提供帮助，也会认真顾及他人的处境，很少只考虑自己的得失。"
 
 #: data/json/mutations/npc_personality.json
 #. ~ Mutation name
@@ -464688,4 +464688,35 @@ msgstr "利己"
 #: data/json/mutations/npc_personality.json
 #. ~ Description of mutation "Self-centered"
 msgid "<npc_name> steers every interaction into discussing how it will help them."
-msgstr "<npc_name>总是想把话题导向到如何能够帮助自己。"
+msgstr "<npc_name>总会把事情引向自己的利益，别人的需要只有在对自己有利时才值得考虑。"
+
+#: src/options.cpp
+msgid "NPC personality trait display"
+msgstr "NPC性格标签显示"
+
+#: src/options.cpp
+msgid "Choose how personality traits are shown in an NPC's character information.  Combined displays one Personality entry and lists every matching personality in the description pane.  Separate displays each personality as its own trait."
+msgstr "控制NPC信息界面中的性格标签显示方式。合并显示会在特性栏中只保留一个性格条目，并在说明栏列出全部性格。独立显示会把每项性格分别列为特性。"
+
+#: src/options.cpp
+msgid "Combined"
+msgstr "合并显示"
+
+#: src/options.cpp
+msgid "Separate"
+msgstr "独立显示"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Mutation name
+msgid "Personality"
+msgstr "性格"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Personality"
+msgid "The NPC's personality traits are shown here."
+msgstr "这里汇总了这个NPC的性格标签。"
+
+#: src/player_display.cpp
+msgctxt "personality summary entry"
+msgid "%1$s, %2$s"
+msgstr "%1$s，%2$s"

--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -464570,7 +464570,7 @@ msgstr "谨慎"
 #: data/json/mutations/npc_personality.json
 #. ~ Description of mutation "Timid"
 msgid "<npc_name> tries to avoid conflict, even when they have good reason not to."
-msgstr "<npc_name> 总是试图避免冲突，即便他们本有充分的理由去面对"
+msgstr "<npc_name>总是试图避免冲突，即便他们本有充分的理由去面对。"
 
 #: data/json/mutations/npc_personality.json
 #. ~ Mutation name

--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -426762,6 +426762,7 @@ msgid "Disliked"
 msgstr "厌恶"
 
 #: src/faction.cpp:222
+#: data/json/mutations/npc_personality.json
 msgid "Hero"
 msgstr "人民英雄"
 
@@ -464547,3 +464548,144 @@ msgstr "选择时间"
 #: data/raw/keybindings.json
 msgid "Reset time point to initial value"
 msgstr "将时间重置为初始值"
+
+
+#: data/json/mutations/npc_personality.json
+#. ~ Mutation name
+msgid "Survivor at any cost"
+msgstr "全力求生"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Survivor at any cost"
+msgid ""
+"<npc_name> is certainly a survivor.  You can only wonder how many they've "
+"abandoned to save themself."
+msgstr "<npc_name>肯定是幸存者。你不禁好奇为了拯救自己而付出了多少代价。"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Mutation name
+msgid "Timid"
+msgstr "谨慎"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Timid"
+msgid "<npc_name> tries to avoid conflict, even when they have good reason not to."
+msgstr "<npc_name> 总是试图避免冲突，即便他们本有充分的理由去面对"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Mutation name
+msgid "Hardass"
+msgstr "硬汉"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Hardass"
+msgid "<npc_name> loves to fight a good fight, but only for themself."
+msgstr "<npc_name>想要好好干一架，但只为了自己。"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Mutation name
+msgid "Freedom fighter"
+msgstr "自由战神"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Freedom fighter"
+msgid ""
+"<npc_name> believes in fighting… mostly for others, even at risk to their own "
+"wellbeing."
+msgstr "<npc_name>执着于为他人而战斗，甚至冒着损害自身利益的风险。"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Mutation name
+msgid "Volatile"
+msgstr "易怒"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Volatile"
+msgid "<npc_name> is just looking for an excuse."
+msgstr "<npc_name>只需要一个借口。"
+
+#: data/json/mutations/npc_personality.json
+#: data/mods/Xedra_Evolved/eocs/eoc_riddles.json
+#. ~ Mutation name
+#. ~ EOC option name in effect in EoC "EOC_XE_RIDDLE_09"
+msgid "Coward"
+msgstr "胆小"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Coward"
+msgid ""
+"<npc_name> flinches at the thought of fighting, whether it be other people or "
+"the undead."
+msgstr "<npc_name>一想到战斗就会退缩，无论是与其他人还是不死生物。"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Mutation name
+msgid "Craven"
+msgstr "懦夫"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Craven"
+msgid ""
+"<npc_name> is afraid of the dark, spiders, and unexplained sounds.  So are "
+"you, but only because you've lived through the apocalypse.  <npc_name> has "
+"always been like this."
+msgstr "<npc_name>害怕黑暗、蜘蛛和无法解释的声音。你也是，但只是因为你经历过世界末日。<npc_name>一直都是这样。"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Mutation name
+msgid "Brave"
+msgstr "勇敢"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Brave"
+msgid ""
+"<npc_name> knows the name of fear, but only as a long-defeated foe.  Little "
+"can shake them."
+msgstr "<npc_name>知道什么叫害怕，但那不过是早已击败过的敌人。没有什么可以使其动摇。"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Hero"
+msgid ""
+"<npc_name> is an ideal ally to those they call friend, always willing to help "
+"others."
+msgstr "<npc_name>对于被其称作朋友的人来说，是个完美的盟友，总是愿意帮助他人。"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Mutation name
+msgid "Miser"
+msgstr "吝啬鬼"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Miser"
+msgid "<npc_name> loves their trinkets, and hates giving them away."
+msgstr "<npc_name>异常爱惜自己的小玩意，并拒绝把它们交出去。"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Mutation name
+msgid "Scrooge"
+msgstr "麦克老鸭"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Scrooge"
+msgid "<npc_name> collects trash like a RPG protagonist collects potions."
+msgstr "<npc_name>像RPG游戏里收集药剂一样收集垃圾。"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Mutation name
+msgid "Kind"
+msgstr "仁善"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Kind"
+msgid "<npc_name> just wants to help."
+msgstr "<npc_name>只是想提供帮助。"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Mutation name
+msgid "Self-centered"
+msgstr "利己"
+
+#: data/json/mutations/npc_personality.json
+#. ~ Description of mutation "Self-centered"
+msgid "<npc_name> steers every interaction into discussing how it will help them."
+msgstr "<npc_name>总是想把话题导向到如何能够帮助自己。"

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -967,6 +967,101 @@ void conditional_t<T>::set_npc_override( const JsonObject &jo, const std::string
 }
 
 template<class T>
+void conditional_t<T>::set_npc_personality( const JsonObject &jo, const std::string &member )
+{
+    JsonObject scores = jo.get_object( member );
+    scores.allow_omitted_members();
+
+    std::optional<int_or_var_part<T>> min_aggression;
+    std::optional<int_or_var_part<T>> max_aggression;
+    std::optional<int_or_var_part<T>> min_bravery;
+    std::optional<int_or_var_part<T>> max_bravery;
+    std::optional<int_or_var_part<T>> min_collector;
+    std::optional<int_or_var_part<T>> max_collector;
+    std::optional<int_or_var_part<T>> min_altruism;
+    std::optional<int_or_var_part<T>> max_altruism;
+
+    const auto read_bounds = [&]( const std::string &name,
+                                  std::optional<int_or_var_part<T>> &minimum,
+                                  std::optional<int_or_var_part<T>> &maximum ) {
+        if( !scores.has_member( name ) ) {
+            return;
+        }
+        JsonValue value = scores.get_member( name );
+        if( value.test_int() ) {
+            int_or_var_part<T> exact = get_int_or_var_part<T>( value, name );
+            minimum = exact;
+            maximum = exact;
+            return;
+        }
+        if( !value.test_object() ) {
+            value.throw_error( "npc_personality member must be an integer or min/max object" );
+        }
+        JsonObject bounds = value.get_object();
+        bounds.allow_omitted_members();
+        if( bounds.has_member( "min" ) ) {
+            minimum = get_int_or_var_part<T>( bounds.get_member( "min" ), "min" );
+        }
+        if( bounds.has_member( "max" ) ) {
+            maximum = get_int_or_var_part<T>( bounds.get_member( "max" ), "max" );
+        }
+        if( !minimum && !maximum ) {
+            bounds.throw_error( "npc_personality range requires min and/or max" );
+        }
+    };
+
+    read_bounds( "aggression", min_aggression, max_aggression );
+    read_bounds( "bravery", min_bravery, max_bravery );
+    read_bounds( "collector", min_collector, max_collector );
+    read_bounds( "altruism", min_altruism, max_altruism );
+
+    if( !min_aggression && !max_aggression && !min_bravery && !max_bravery &&
+        !min_collector && !max_collector && !min_altruism && !max_altruism ) {
+        scores.throw_error( "npc_personality requires at least one personality member" );
+    }
+
+    condition = [min_aggression, max_aggression, min_bravery, max_bravery,
+                 min_collector, max_collector, min_altruism, max_altruism]( const T & d ) {
+        const npc *guy = d.actor( true )->get_npc();
+        if( guy == nullptr ) {
+            return false;
+        }
+        const auto within = [&]( int value,
+                                 const std::optional<int_or_var_part<T>> &minimum,
+                                 const std::optional<int_or_var_part<T>> &maximum ) {
+            return ( !minimum || value >= minimum->evaluate( d ) ) &&
+                   ( !maximum || value <= maximum->evaluate( d ) );
+        };
+        return within( guy->personality.aggression, min_aggression, max_aggression ) &&
+               within( guy->personality.bravery, min_bravery, max_bravery ) &&
+               within( guy->personality.collector, min_collector, max_collector ) &&
+               within( guy->personality.altruism, min_altruism, max_altruism );
+    };
+}
+
+template<class T>
+void conditional_t<T>::set_npc_movement_policy( const JsonObject &jo,
+        const std::string &member )
+{
+    str_or_var<T> policy = get_str_or_var<T>( jo.get_member( member ), member, true );
+    condition = [policy]( const T & d ) {
+        const npc *guy = d.actor( true )->get_npc();
+        if( guy == nullptr ) {
+            return false;
+        }
+        const std::string value = policy.evaluate( d );
+        const bool holds = guy->has_trait( trait_id( "NPC_HOLD_POSITION" ) );
+        if( value == "HOLD_POSITION" ) {
+            return holds;
+        }
+        if( value == "NORMAL" ) {
+            return !holds;
+        }
+        return false;
+    };
+}
+
+template<class T>
 void conditional_t<T>::set_days_since( const JsonObject &jo, const std::string &member )
 {
     int_or_var<T> iov = get_int_or_var<T>( jo, member );
@@ -3002,6 +3097,10 @@ conditional_t<T>::conditional_t( const JsonObject &jo )
         set_npc_override( jo, "npc_override", true );
     } else if( jo.has_string( "u_override" ) ) {
         set_npc_override( jo, "u_override", false );
+    } else if( jo.has_object( "npc_personality" ) ) {
+        set_npc_personality( jo, "npc_personality" );
+    } else if( jo.has_member( "npc_movement_policy" ) ) {
+        set_npc_movement_policy( jo, "npc_movement_policy" );
     } else if( jo.has_int( "days_since_cataclysm" ) || jo.has_object( "days_since_cataclysm" ) ) {
         set_days_since( jo, "days_since_cataclysm" );
     } else if( jo.has_string( "is_season" ) ) {

--- a/src/condition.h
+++ b/src/condition.h
@@ -40,7 +40,8 @@ const std::unordered_set<std::string> complex_conds = { {
         "u_at_om_location", "u_near_om_location", "npc_at_om_location", "npc_near_om_location",
         "npc_role_nearby", "npc_allies", "npc_allies_global", "npc_service",
         "u_has_cash", "u_are_owed", "u_query", "npc_query", "u_has_item_with_flag", "npc_has_item_with_flag",
-        "npc_aim_rule", "npc_engagement_rule", "npc_rule", "npc_override", "u_has_hp", "npc_has_hp",
+        "npc_aim_rule", "npc_engagement_rule", "npc_rule", "npc_override", "npc_personality",
+        "npc_movement_policy", "u_has_hp", "npc_has_hp",
         "u_has_part_temp", "npc_has_part_temp", "npc_cbm_reserve_rule", "npc_cbm_recharge_rule", "u_has_faction_trust",
         "days_since_cataclysm", "is_season", "mission_goal", "u_has_var", "npc_has_var",
         "u_has_skill", "npc_has_skill", "u_know_recipe", "u_compare_var", "npc_compare_var",
@@ -169,6 +170,8 @@ struct conditional_t {
         void set_npc_cbm_recharge_rule( const JsonObject &jo, const std::string &member, bool is_npc );
         void set_npc_rule( const JsonObject &jo, const std::string &member, bool is_npc );
         void set_npc_override( const JsonObject &jo, const std::string &member, bool is_npc );
+        void set_npc_personality( const JsonObject &jo, const std::string &member );
+        void set_npc_movement_policy( const JsonObject &jo, const std::string &member );
         void set_days_since( const JsonObject &jo, const std::string &member );
         void set_is_season( const JsonObject &jo, const std::string &member );
         void set_is_weather( const JsonObject &jo, const std::string &member );

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -67,6 +67,8 @@ struct talk_effect_fun_t {
         void set_remove_item_with( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_npc_change_faction( const JsonObject &jo, const std::string &member );
         void set_npc_change_class( const JsonObject &jo, const std::string &member );
+        void set_npc_personality( const JsonObject &jo, const std::string &member, bool modify );
+        void set_npc_movement_policy( const JsonObject &jo, const std::string &member );
         void set_change_faction_rep( const JsonObject &jo, const std::string &member );
         void set_add_debt( const std::vector<trial_mod> &debt_modifiers );
         void set_toggle_npc_rule( const JsonObject &jo, const std::string &member );

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -2076,11 +2076,15 @@ std::string Character::mutation_name( const trait_id &mut ) const
 std::string Character::mutation_desc( const trait_id &mut ) const
 {
     auto it = my_mutations.find( mut );
+    std::string description;
     if( it != my_mutations.end() && it->second.variant != nullptr ) {
-        return mut->desc( it->second.variant->id );
+        description = mut->desc( it->second.variant->id );
+    } else {
+        description = mut->desc();
     }
 
-    return mut->desc();
+    replace_substring( description, "<npc_name>", get_name(), true );
+    return description;
 }
 
 void Character::customize_appearance( customize_appearance_choice choice )

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -6,6 +6,7 @@
 #include <iosfwd>
 #include <map>
 #include <new>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -17,7 +18,6 @@
 #include "damage.h"
 #include "hash_utils.h"
 #include "memory_fast.h"
-#include <optional>
 #include "point.h"
 #include "translations.h"
 #include "type_id.h"
@@ -89,6 +89,21 @@ struct mut_transform {
     /** subtracted from @ref Creature::moves when transformation is successful */
     int moves = 0;
     mut_transform();
+    bool load( const JsonObject &jsobj, const std::string &member );
+};
+
+/** Personality bounds used to derive descriptive NPC traits. */
+struct mut_personality_score {
+    int min_aggression = INT_MIN;
+    int max_aggression = INT_MAX;
+    int min_bravery = INT_MIN;
+    int max_bravery = INT_MAX;
+    int min_collector = INT_MIN;
+    int max_collector = INT_MAX;
+    int min_altruism = INT_MIN;
+    int max_altruism = INT_MAX;
+
+    mut_personality_score();
     bool load( const JsonObject &jsobj, const std::string &member );
 };
 
@@ -236,6 +251,7 @@ struct mutation_branch {
         int butchering_quality = 0;
 
         cata::value_ptr<mut_transform> transform;
+        cata::value_ptr<mut_personality_score> personality_score;
 
         // Cosmetic variants of this mutation
         std::map<std::string, mutation_variant> variants;

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -1,5 +1,6 @@
 #include "mutation.h" // IWYU pragma: associated
 
+#include <algorithm>
 #include <cstdlib>
 #include <map>
 #include <memory>
@@ -235,6 +236,52 @@ bool mut_transform::load( const JsonObject &jsobj, const std::string &member )
     return true;
 }
 
+mut_personality_score::mut_personality_score() = default;
+
+bool mut_personality_score::load( const JsonObject &jsobj, const std::string &member )
+{
+    JsonObject j = jsobj.get_object( member );
+    optional( j, false, "min_aggression", min_aggression, INT_MIN );
+    optional( j, false, "max_aggression", max_aggression, INT_MAX );
+    optional( j, false, "min_bravery", min_bravery, INT_MIN );
+    optional( j, false, "max_bravery", max_bravery, INT_MAX );
+    optional( j, false, "min_collector", min_collector, INT_MIN );
+    optional( j, false, "max_collector", max_collector, INT_MAX );
+    optional( j, false, "min_altruism", min_altruism, INT_MIN );
+    optional( j, false, "max_altruism", max_altruism, INT_MAX );
+
+    if( j.has_member( "min_aggression" ) ) {
+        min_aggression = std::clamp( min_aggression, -10, 10 );
+    }
+    if( j.has_member( "max_aggression" ) ) {
+        max_aggression = std::clamp( max_aggression, -10, 10 );
+    }
+    if( j.has_member( "min_bravery" ) ) {
+        min_bravery = std::clamp( min_bravery, -10, 10 );
+    }
+    if( j.has_member( "max_bravery" ) ) {
+        max_bravery = std::clamp( max_bravery, -10, 10 );
+    }
+    if( j.has_member( "min_collector" ) ) {
+        min_collector = std::clamp( min_collector, -10, 10 );
+    }
+    if( j.has_member( "max_collector" ) ) {
+        max_collector = std::clamp( max_collector, -10, 10 );
+    }
+    if( j.has_member( "min_altruism" ) ) {
+        min_altruism = std::clamp( min_altruism, -10, 10 );
+    }
+    if( j.has_member( "max_altruism" ) ) {
+        max_altruism = std::clamp( max_altruism, -10, 10 );
+    }
+
+    if( min_aggression > max_aggression || min_bravery > max_bravery ||
+        min_collector > max_collector || min_altruism > max_altruism ) {
+        j.throw_error( "personality_score minimum cannot exceed maximum" );
+    }
+    return true;
+}
+
 void reflex_activation_data::load( const JsonObject &jsobj )
 {
     read_condition<dialogue>( jsobj, "condition", trigger, false );
@@ -348,6 +395,10 @@ void mutation_branch::load( const JsonObject &jo, const std::string & )
     if( jo.has_object( "transform" ) ) {
         transform = cata::make_value<mut_transform>();
         transform->load( jo, "transform" );
+    }
+    if( jo.has_object( "personality_score" ) ) {
+        personality_score = cata::make_value<mut_personality_score>();
+        personality_score->load( jo, "personality_score" );
     }
 
     optional( jo, was_loaded, "triggers", trigger_list );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -334,6 +334,15 @@ void npc_template::load( const JsonObject &jsobj )
         guy.myclass = npc_class_id( jsobj.get_string( "class" ) );
     }
 
+    if( jsobj.has_object( "personality" ) ) {
+        const JsonObject personality = jsobj.get_object( "personality" );
+        tem.personality = npc_personality();
+        tem.personality->aggression = std::clamp( personality.get_int( "aggression" ), -10, 10 );
+        tem.personality->bravery = std::clamp( personality.get_int( "bravery" ), -10, 10 );
+        tem.personality->collector = std::clamp( personality.get_int( "collector" ), -10, 10 );
+        tem.personality->altruism = std::clamp( personality.get_int( "altruism" ), -10, 10 );
+    }
+
     guy.set_attitude( static_cast<npc_attitude>( jsobj.get_int( "attitude" ) ) );
     guy.mission = static_cast<npc_mission>( jsobj.get_int( "mission" ) );
     guy.chatbin.first_topic = jsobj.get_string( "chat" );
@@ -681,6 +690,10 @@ void npc::load_npc_template( const string_id<npc_template> &ident )
     idz = tguy.idz;
     myclass = npc_class_id( tguy.myclass );
     randomize( myclass );
+    if( tem.personality.has_value() ) {
+        personality = *tem.personality;
+        refresh_personality_traits();
+    }
     if( tem.gender_override != npc_template::gender::random ) {
         male = tem.gender_override == npc_template::gender::male;
     }
@@ -935,6 +948,8 @@ void npc::randomize( const npc_class_id &type )
         set_mutation( tid, tid->variant( var ) );
     }
 
+    generate_personality_traits();
+
     // Run mutation rounds
     for( const auto &mr : type->mutation_rounds ) {
         int rounds = mr.second.roll();
@@ -1022,6 +1037,42 @@ void npc::select_best_martial_art( bool announce )
         add_msg_if_player_sees( *this, m_info, _( "%1$s改用%2$s！" ),
                                 disp_name(), martial_arts_data->selected_style_name( *this ) );
     }
+}
+
+void npc::clear_personality_traits()
+{
+    const std::vector<trait_id> traits = get_mutations();
+    for( const trait_id &trait : traits ) {
+        if( trait->personality_score ) {
+            unset_mutation( trait );
+        }
+    }
+}
+
+void npc::generate_personality_traits()
+{
+    for( const mutation_branch &mdata : mutation_branch::get_all() ) {
+        if( !mdata.personality_score ) {
+            continue;
+        }
+        const mut_personality_score &required = *mdata.personality_score;
+        if( required.min_aggression <= personality.aggression &&
+            personality.aggression <= required.max_aggression &&
+            required.min_bravery <= personality.bravery &&
+            personality.bravery <= required.max_bravery &&
+            required.min_collector <= personality.collector &&
+            personality.collector <= required.max_collector &&
+            required.min_altruism <= personality.altruism &&
+            personality.altruism <= required.max_altruism ) {
+            set_mutation( mdata.id );
+        }
+    }
+}
+
+void npc::refresh_personality_traits()
+{
+    clear_personality_traits();
+    generate_personality_traits();
 }
 
 void npc::randomize_from_faction( faction *fac )
@@ -3337,6 +3388,7 @@ void npc::npc_update_body()
 
 void npc::on_load()
 {
+    refresh_personality_traits();
     const auto advance_effects = [&]( const time_duration & elapsed_dur ) {
         for( auto &elem : *effects ) {
             for( auto &_effect_it : elem.second ) {

--- a/src/npc.h
+++ b/src/npc.h
@@ -773,6 +773,9 @@ class npc : public Character
         void randomize( const npc_class_id &type = npc_class_id::NULL_ID() );
         void randomize_from_faction( faction *fac );
         void apply_ownership_to_inv();
+        void clear_personality_traits();
+        void generate_personality_traits();
+        void refresh_personality_traits();
         void learn_ma_styles_from_traits();
         void select_best_martial_art( bool announce = true );
         // Faction version number
@@ -1443,6 +1446,7 @@ class npc_template
         translation name_suffix;
         std::vector<matype_id> martial_arts;
         std::optional<matype_id> selected_martial_art;
+        std::optional<npc_personality> personality;
         enum class gender : int {
             random,
             male,

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -136,6 +136,7 @@ static const npc_class_id NC_EVAC_SHOPKEEP( "NC_EVAC_SHOPKEEP" );
 static const skill_id skill_firstaid( "firstaid" );
 
 static const trait_id trait_IGNORE_SOUND( "IGNORE_SOUND" );
+static const trait_id trait_NPC_HOLD_POSITION( "NPC_HOLD_POSITION" );
 static const trait_id trait_RETURN_TO_START_POS( "RETURN_TO_START_POS" );
 
 static const zone_type_id zone_type_NO_NPC_PICKUP( "NO_NPC_PICKUP" );
@@ -826,15 +827,29 @@ void npc::move()
      * them from inadvertently getting themselves run over and/or cause vehicle related errors.
      * NPCs flee from uncontained fires within 3 tiles
      */
-    if( !in_vehicle && ( sees_dangerous_field( pos() ) || has_effect( effect_npc_fire_bad ) ) ) {
-        if( sees_dangerous_field( pos() ) ) {
+    const bool hold_position = has_trait( trait_NPC_HOLD_POSITION );
+    const bool dangerous_here = sees_dangerous_field( pos() );
+    const field &field_here = get_map().field_at( pos() );
+    const bool emergency_field = field_here.find_field( fd_fire ) != nullptr ||
+                                 field_here.find_field( fd_acid ) != nullptr;
+    const bool should_escape_field = hold_position ? emergency_field :
+                                     dangerous_here || has_effect( effect_npc_fire_bad );
+    if( !in_vehicle && should_escape_field ) {
+        if( dangerous_here ) {
             path.clear();
         }
-        const tripoint escape_dir = good_escape_direction( sees_dangerous_field( pos() ) );
+        const tripoint escape_dir = good_escape_direction( dangerous_here );
         if( escape_dir != pos() ) {
             move_to( escape_dir );
             return;
         }
+    }
+
+    // A held NPC ignores threats, sounds, needs, and tactical repositioning.  Fire and acid
+    // are handled above so a static quest giver can still step off an immediately lethal tile.
+    if( hold_position ) {
+        move_pause();
+        return;
     }
 
     // TODO: Place player-aiding actions here, with a weight

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3417,6 +3417,76 @@ void talk_effect_fun_t<T>::set_npc_change_class( const JsonObject &jo, const std
 }
 
 template<class T>
+void talk_effect_fun_t<T>::set_npc_personality( const JsonObject &jo, const std::string &member,
+        bool modify )
+{
+    JsonObject values = jo.get_object( member );
+    values.allow_omitted_members();
+    std::optional<int_or_var<T>> aggression;
+    std::optional<int_or_var<T>> bravery;
+    std::optional<int_or_var<T>> collector;
+    std::optional<int_or_var<T>> altruism;
+    if( values.has_member( "aggression" ) ) {
+        aggression = get_int_or_var<T>( values, "aggression" );
+    }
+    if( values.has_member( "bravery" ) ) {
+        bravery = get_int_or_var<T>( values, "bravery" );
+    }
+    if( values.has_member( "collector" ) ) {
+        collector = get_int_or_var<T>( values, "collector" );
+    }
+    if( values.has_member( "altruism" ) ) {
+        altruism = get_int_or_var<T>( values, "altruism" );
+    }
+    if( !aggression && !bravery && !collector && !altruism ) {
+        values.throw_error( member + " requires at least one personality member" );
+    }
+
+    function = [aggression, bravery, collector, altruism, modify]( const T & d ) {
+        npc *guy = d.actor( true )->get_npc();
+        if( guy == nullptr ) {
+            debugmsg( "npc personality effect requires an NPC beta talker" );
+            return;
+        }
+        const auto apply = [&]( const std::optional<int_or_var<T>> &value, int8_t &field ) {
+            if( !value ) {
+                return;
+            }
+            const int base = modify ? static_cast<int>( field ) : 0;
+            field = static_cast<int8_t>( std::clamp( base + value->evaluate( d ), -10, 10 ) );
+        };
+        apply( aggression, guy->personality.aggression );
+        apply( bravery, guy->personality.bravery );
+        apply( collector, guy->personality.collector );
+        apply( altruism, guy->personality.altruism );
+        guy->refresh_personality_traits();
+    };
+}
+
+template<class T>
+void talk_effect_fun_t<T>::set_npc_movement_policy( const JsonObject &jo,
+        const std::string &member )
+{
+    str_or_var<T> policy = get_str_or_var<T>( jo.get_member( member ), member, true );
+    function = [policy]( const T & d ) {
+        npc *guy = d.actor( true )->get_npc();
+        if( guy == nullptr ) {
+            debugmsg( "npc movement policy effect requires an NPC beta talker" );
+            return;
+        }
+        const std::string value = policy.evaluate( d );
+        const trait_id hold_position( "NPC_HOLD_POSITION" );
+        if( value == "HOLD_POSITION" ) {
+            guy->set_mutation( hold_position );
+        } else if( value == "NORMAL" ) {
+            guy->unset_mutation( hold_position );
+        } else {
+            debugmsg( "invalid npc movement policy '%s'; expected NORMAL or HOLD_POSITION", value );
+        }
+    };
+}
+
+template<class T>
 void talk_effect_fun_t<T>::set_change_faction_rep( const JsonObject &jo, const std::string &member )
 {
     int_or_var<T> rep_change = get_int_or_var<T>( jo, member );
@@ -5104,6 +5174,12 @@ void talk_effect_t<T>::parse_sub_effect( const JsonObject &jo )
         subeffect_fun.set_npc_change_faction( jo, "npc_change_faction" );
     } else if( jo.has_string( "npc_change_class" ) ) {
         subeffect_fun.set_npc_change_class( jo, "npc_change_class" );
+    } else if( jo.has_object( "npc_set_personality" ) ) {
+        subeffect_fun.set_npc_personality( jo, "npc_set_personality", false );
+    } else if( jo.has_object( "npc_mod_personality" ) ) {
+        subeffect_fun.set_npc_personality( jo, "npc_mod_personality", true );
+    } else if( jo.has_member( "npc_set_movement_policy" ) ) {
+        subeffect_fun.set_npc_movement_policy( jo, "npc_set_movement_policy" );
     } else if( jo.has_int( "u_faction_rep" ) ) {
         subeffect_fun.set_change_faction_rep( jo, "u_faction_rep" );
     } else if( jo.has_string( "add_mission" ) ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1617,6 +1617,17 @@ void options_manager::add_options_interface()
         true
     );
 
+    add( "NPC_PERSONALITY_TRAIT_DISPLAY", "interface",
+         to_translation( "NPC personality trait display" ),
+         to_translation( "Choose how personality traits are shown in an NPC's character information.  "
+                         "Combined displays one Personality entry and lists every matching personality "
+                         "in the description pane.  Separate displays each personality as its own trait." ),
+    {
+        { "COMBINED", to_translation( "Combined" ) },
+        { "SEPARATE", to_translation( "Separate" ) }
+    },
+    "COMBINED" );
+
     add_empty_line();
 
     add( "USE_CELSIUS", "interface", to_translation( "Temperature units" ),

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -666,9 +666,13 @@ static std::string personality_summary_description( const Character &you )
     const std::vector<trait_and_var> personality_traits = get_personality_traits_for_display( you );
     std::string result;
     for( const trait_and_var &entry : personality_traits ) {
-        std::string description = you.mutation_desc( entry.trait );
+        std::string description = entry.desc();
+        replace_substring( description, "<npc_name>", "", true );
+        while( !description.empty() && description.front() == ' ' ) {
+            description.erase( description.begin() );
+        }
         if( !result.empty() ) {
-            result += " ";
+            result += "\n";
         }
         result += string_format(
                       pgettext( "personality summary entry", "%1$s, %2$s" ),

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -57,6 +57,7 @@ static const trait_id trait_SUNLIGHT_DEPENDENT( "SUNLIGHT_DEPENDENT" );
 static const trait_id trait_TROGLO( "TROGLO" );
 static const trait_id trait_TROGLO2( "TROGLO2" );
 static const trait_id trait_TROGLO3( "TROGLO3" );
+static const trait_id trait_NPC_PERSONALITY_SUMMARY( "NPC_PERSONALITY_SUMMARY" );
 
 static const std::string title_STATS = translate_marker( "STATS" );
 static const std::string title_ENCUMB = translate_marker( "ENCUMBRANCE AND WARMTH" );
@@ -643,15 +644,56 @@ static void draw_traits_tab( ui_adaptor &ui, const catacurses::window &w_traits,
     wnoutrefresh( w_traits );
 }
 
-static void draw_traits_info( const catacurses::window &w_info, const unsigned line,
-                              const std::vector<trait_and_var> &traitslist )
+static bool is_personality_trait( const trait_and_var &entry )
+{
+    return static_cast<bool>( entry.trait->personality_score );
+}
+
+static std::vector<trait_and_var> get_personality_traits_for_display( const Character &you )
+{
+    std::vector<trait_and_var> result;
+    for( const trait_and_var &entry : you.get_mutations_variants( false ) ) {
+        if( is_personality_trait( entry ) ) {
+            result.push_back( entry );
+        }
+    }
+    std::sort( result.begin(), result.end(), trait_display_sort );
+    return result;
+}
+
+static std::string personality_summary_description( const Character &you )
+{
+    const std::vector<trait_and_var> personality_traits = get_personality_traits_for_display( you );
+    std::string result;
+    for( const trait_and_var &entry : personality_traits ) {
+        std::string description = you.mutation_desc( entry.trait );
+        if( !result.empty() ) {
+            result += " ";
+        }
+        result += string_format(
+                      pgettext( "personality summary entry", "%1$s, %2$s" ),
+                      colorize( you.mutation_name( entry.trait ), entry.trait->get_display_color() ),
+                      description );
+    }
+    return result;
+}
+
+static void draw_traits_info( const catacurses::window &w_info, const Character &you,
+                              const unsigned line, const std::vector<trait_and_var> &traitslist )
 {
     werase( w_info );
     if( line < traitslist.size() ) {
         const trait_and_var &cur = traitslist[line];
-        // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray, string_format( "%s: %s",
-                        colorize( cur.name(), cur.trait->get_display_color() ), cur.desc() ) );
+        if( cur.trait == trait_NPC_PERSONALITY_SUMMARY ) {
+            fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray,
+                            personality_summary_description( you ) );
+        } else {
+            // NOLINTNEXTLINE(cata-use-named-point-constants)
+            fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_light_gray,
+                            string_format( "%s: %s",
+                                           colorize( cur.name(), cur.trait->get_display_color() ),
+                                           you.mutation_desc( cur.trait ) ) );
+        }
     }
     wnoutrefresh( w_info );
 }
@@ -1034,7 +1076,7 @@ static void draw_info_window( const catacurses::window &w_info, const Character 
             draw_skills_info( w_info, you, line, skillslist );
             break;
         case player_display_tab::traits:
-            draw_traits_info( w_info, line, traitslist );
+            draw_traits_info( w_info, you, line, traitslist );
             break;
         case player_display_tab::bionics:
             draw_bionics_info( w_info, line, bionicslist );
@@ -1201,7 +1243,8 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
         info_line = 0;
         ui_info.invalidate_ui();
     } else if( action == "SELECT_TRAIT_VARIANT" ) {
-        if( curtab == player_display_tab::traits ) {
+        if( curtab == player_display_tab::traits &&
+            traitslist[line].trait != trait_NPC_PERSONALITY_SUMMARY ) {
             const mutation_variant *var = traitslist[line].trait->pick_variant_menu();
             you.set_mut_variant( traitslist[line].trait, var );
             const std::string &varid = var == nullptr ? "" : var->id;
@@ -1413,6 +1456,16 @@ void Character::disp_info( bool customize_character )
 
     std::vector<trait_and_var> traitslist = get_mutations_variants( false );
     std::sort( traitslist.begin(), traitslist.end(), trait_display_sort );
+    if( is_npc() && get_option<std::string>( "NPC_PERSONALITY_TRAIT_DISPLAY" ) == "COMBINED" ) {
+        const auto personality_begin = std::remove_if( traitslist.begin(), traitslist.end(),
+        []( const trait_and_var & entry ) {
+            return is_personality_trait( entry );
+        } );
+        if( personality_begin != traitslist.end() ) {
+            traitslist.erase( personality_begin, traitslist.end() );
+            traitslist.insert( traitslist.begin(), trait_and_var( trait_NPC_PERSONALITY_SUMMARY, "" ) );
+        }
+    }
     const unsigned int trait_win_size_y_max = 1 + static_cast<unsigned>( traitslist.size() );
 
     std::vector<bionic_grouping> bionicslist;


### PR DESCRIPTION
## 背景

NPC 的四项性格数值原本只能由本体随机生成，模组无法固定、动态修改或作为 EOC 条件读取；用于商店、任务和剧情的静态 NPC 也可能因普通 AI 判断离开预定位置。同时，多项派生性格标签会挤占 NPC 信息界面的特性列表。

## 改动内容

### NPC 性格模组 API

- NPC 模板新增 `personality`，可固定攻击性、勇气、收集欲和利他心。
- 突变 JSON 新增 `personality_score`，模组可按性格阈值定义描述性标签；未填写的阈值方向保持不设限，兼容职业调整后超出正负 10 的随机性格。
- 新增 `npc_set_personality` 与 `npc_mod_personality` EOC 效果，并在修改后立即刷新派生标签。
- 新增 `npc_personality` 条件，支持精确值、最小值、最大值及变量对象。
- NPC 生成、读档和性格变化时自动刷新标签，不会清除普通突变、职业特质或剧情特质。

### 静态位置策略

- 新增 `npc_set_movement_policy` 效果和 `npc_movement_policy` 条件。
- `HOLD_POSITION` 适用于商人、任务发布者等严格站位 NPC，会暂停普通移动和战术 AI。
- 静态 NPC 脚下出现火焰或酸液时仍可移出危险格；`NORMAL` 可恢复原有 AI。

### 性格标签与界面

- 加入 13 个描述性 NPC 性格标签及简体中文名称和扩写描述。
- 界面选项新增“NPC 性格标签显示”，默认使用合并显示，也可切换为独立显示。
- 合并模式只保留一个“性格”条目，并在说明栏逐行显示全部匹配标签；模组自定义标签同样参与汇总。
- 独立模式保留逐项标签，并将 `<npc_name>` 正确替换为 NPC 实际姓名。
- 合并显示仅影响界面，不改变底层性格数值、标签判定或 NPC 行为。

## 验证

- `git diff --check` 通过。
- 新增 JSON 文件解析通过，翻译条目与文件编码已检查。
- Windows Tiles x64 MSVC 与 Android arm64 双平台构建通过。
- 已完成游戏内验证：性格合并后逐行显示，中文描述和 NPC 姓名正常，未发现游玩问题。

测试记录：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/30703782212