### PR TITLE
允许越过相邻非敌对角色进行射击与触及攻击

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -389,6 +389,13 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
             critter = nullptr;
         }
 
+        // Adjacent allies can make room for aimed shots.  The intended target is never ignored.
+        if( critter != nullptr && origin != nullptr && tp != target_arg &&
+            rl_dist( source, tp ) == 1 &&
+            origin->attitude_to( *critter ) == Creature::Attitude::FRIENDLY ) {
+            critter = nullptr;
+        }
+
         monster *mon = dynamic_cast<monster *>( critter );
         // ignore non-point-blank digging targets (since they are underground)
         if( mon != nullptr && mon->digging() &&

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -389,10 +389,10 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
             critter = nullptr;
         }
 
-        // Adjacent allies can make room for aimed shots.  The intended target is never ignored.
+        // Adjacent non-hostile creatures can make room for aimed shots.  The intended target is never ignored.
         if( critter != nullptr && origin != nullptr && tp != target_arg &&
             rl_dist( source, tp ) == 1 &&
-            origin->attitude_to( *critter ) == Creature::Attitude::FRIENDLY ) {
+            origin->attitude_to( *critter ) != Creature::Attitude::HOSTILE ) {
             critter = nullptr;
         }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -970,6 +970,11 @@ void Character::reach_attack( const tripoint &p )
     for( const tripoint &path_point : path ) {
         // Possibly hit some unintended target instead
         Creature *inter = creatures.creature_at( path_point );
+        // Adjacent allies can make room for a reach attack.  The intended target was removed above.
+        if( inter != nullptr && rl_dist( pos(), path_point ) == 1 &&
+            attitude_to( *inter ) == Creature::Attitude::FRIENDLY ) {
+            continue;
+        }
         /** @EFFECT_MELEE decreases chance of hitting intervening target on reach attack */
         if( inter != nullptr &&
             !x_in_y( ( target_size * target_size + 1 ) * skill,

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -970,9 +970,9 @@ void Character::reach_attack( const tripoint &p )
     for( const tripoint &path_point : path ) {
         // Possibly hit some unintended target instead
         Creature *inter = creatures.creature_at( path_point );
-        // Adjacent allies can make room for a reach attack.  The intended target was removed above.
+        // Adjacent non-hostile creatures can make room for a reach attack.  The intended target was removed above.
         if( inter != nullptr && rl_dist( pos(), path_point ) == 1 &&
-            attitude_to( *inter ) == Creature::Attitude::FRIENDLY ) {
+            attitude_to( *inter ) != Creature::Attitude::HOSTILE ) {
             continue;
         }
         /** @EFFECT_MELEE decreases chance of hitting intervening target on reach attack */

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -233,8 +233,8 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
             bool can_attack = true;
             for( const tripoint &path_point : path ) {
                 Creature *inter = get_creature_tracker().creature_at( path_point );
-                if( inter != nullptr && source.attitude_to( *inter ) == Creature::Attitude::FRIENDLY ) {
-                    // Adjacent allies can make room for a reach attack.
+                if( inter != nullptr && source.attitude_to( *inter ) != Creature::Attitude::HOSTILE ) {
+                    // Adjacent non-hostile creatures can make room for a reach attack.
                     if( rl_dist( source.pos(), path_point ) == 1 ) {
                         continue;
                     }

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -234,6 +234,10 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
             for( const tripoint &path_point : path ) {
                 Creature *inter = get_creature_tracker().creature_at( path_point );
                 if( inter != nullptr && source.attitude_to( *inter ) == Creature::Attitude::FRIENDLY ) {
+                    // Adjacent allies can make room for a reach attack.
+                    if( rl_dist( source.pos(), path_point ) == 1 ) {
+                        continue;
+                    }
                     add_msg_debug( debugmode::debug_filter::DF_NPC, "%s aborted a reach attack; ally in the way",
                                    source.disp_name() );
                     can_attack = false;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2202,6 +2202,10 @@ bool npc::wont_hit_friend( const tripoint &tar, const item &it, bool throwing ) 
         // TODO: Extract common functions with turret target selection
         units::angle safe_angle_ally = safe_angle;
         int ally_dist = rl_dist( pos(), ally.pos() );
+        // A nearby ally can duck or lean aside for an aimed shot.  Thrown items stay risky.
+        if( !throwing && ally_dist == 1 ) {
+            continue;
+        }
         if( ally_dist < 3 ) {
             safe_angle_ally += ( 3 - ally_dist ) * 30_degrees;
         }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2202,7 +2202,7 @@ bool npc::wont_hit_friend( const tripoint &tar, const item &it, bool throwing ) 
         // TODO: Extract common functions with turret target selection
         units::angle safe_angle_ally = safe_angle;
         int ally_dist = rl_dist( pos(), ally.pos() );
-        // A nearby ally can duck or lean aside for an aimed shot.  Thrown items stay risky.
+        // A nearby non-hostile creature can duck or lean aside for an aimed shot.  Thrown items stay risky.
         if( !throwing && ally_dist == 1 ) {
             continue;
         }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3132,7 +3132,7 @@ std::vector<weak_ptr_fast<Creature>> target_ui::list_friendlies_in_lof()
                     ( cr->is_npc() && a != Creature::Attitude::HOSTILE ) ||
                     ( !cr->is_npc() && a == Creature::Attitude::FRIENDLY )
                 ) {
-                    // Adjacent allies are protected from aimed shots and do not need a warning.
+                    // Adjacent non-hostile creatures are protected from aimed shots and do not need a warning.
                     if( rl_dist( src, p ) == 1 ) {
                         continue;
                     }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3132,6 +3132,10 @@ std::vector<weak_ptr_fast<Creature>> target_ui::list_friendlies_in_lof()
                     ( cr->is_npc() && a != Creature::Attitude::HOSTILE ) ||
                     ( !cr->is_npc() && a == Creature::Attitude::FRIENDLY )
                 ) {
+                    // Adjacent allies are protected from aimed shots and do not need a warning.
+                    if( rl_dist( src, p ) == 1 ) {
+                        continue;
+                    }
                     ret.emplace_back( g->shared_from( *cr ) );
                 }
             }


### PR DESCRIPTION
## 改动内容

- 允许玩家在相邻非敌对 NPC 身旁进行瞄准射击，不再由贴身友军触发误伤警告或拦截弹道。
- 允许玩家与 NPC 的触及攻击越过相邻非敌对角色。
- 同步 NPC 的友军射线判断，使 NPC 能正确使用相同行为。
- 被指定为攻击目标的角色不会被忽略；投掷物仍保留原有友军风险判断。
- 距离超过一格的友军仍会正常阻挡或触发安全检查。

## 验证

- 已完成实际游戏测试，可隔着相邻非敌对 NPC 射击敌人。
- Windows Tiles x64 MSVC 与 Android arm64 测试均通过。
- 测试运行：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/30727202727