### PR TITLE
防止公路桥在道路连接中孤立生成

### DIFF
--- a/data/json/overmap/overmap_connections.json
+++ b/data/json/overmap/overmap_connections.json
@@ -3,14 +3,15 @@
     "type": "overmap_connection",
     "id": "local_road",
     "subtypes": [
-      { "terrain": "road", "locations": [ "field", "road" ] },
+      { "terrain": "road", "locations": [ "road" ], "basic_cost": 0, "flags": [ "ORTHOGONAL" ] },
+      { "terrain": "road", "locations": [ "field" ], "basic_cost": 5 },
       { "terrain": "road", "locations": [ "forest_without_trail" ], "basic_cost": 20 },
       { "terrain": "road", "locations": [ "forest_trail" ], "basic_cost": 25 },
       { "terrain": "road", "locations": [ "swamp" ], "basic_cost": 40 },
       { "terrain": "road", "locations": [ "highway" ], "basic_cost": 80, "flags": [ "PERPENDICULAR_CROSSING" ] },
       { "terrain": "road_nesw_manhole", "locations": [  ] },
-      { "terrain": "bridge", "locations": [ "water" ], "basic_cost": 120 },
-      { "terrain": "bridgehead_ground", "locations": [ "water" ], "basic_cost": 120 }
+      { "terrain": "bridge", "locations": [ "water" ], "basic_cost": 120, "flags": [ "ORTHOGONAL" ] },
+      { "terrain": "bridgehead_ground", "locations": [ "water" ], "basic_cost": 120, "flags": [ "ORTHOGONAL" ] }
     ]
   },
   {


### PR DESCRIPTION
## 问题

普通道路在连接既有道路并跨越水域时，路径可能在水面或桥头临时转弯，导致桥梁与两端道路方向不一致，出现孤立桥段。

## 改动内容

- 将普通道路的既有道路与田野连接规则拆开，既有道路连接采用正交约束。
- 为公路桥和地面桥头增加正交约束，使跨水路径优先保持单一方向。
- 保留微风现有的森林、沼泽和高速公路连接成本及规则。
- 不修改 C++ 地图生成逻辑，也不增加存档字段。

## 兼容性

修复只影响尚未生成的大地图区域；已经写入存档的旧地图不会自动重建，也不会因此损坏。

## 验证

- JSON 解析与差异格式检查通过。
- Windows Tiles x64 MSVC 与 Android arm64 测试均通过。
- 已进行游戏内新地图区域测试，暂未发现异常。
- 测试运行：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/30729033565