### PR TITLE
保存尸体处理进度并支持中断后续作

### DIFF
--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -464720,3 +464720,11 @@ msgstr "这里汇总了这个NPC的性格标签。"
 msgctxt "personality summary entry"
 msgid "%1$s, %2$s"
 msgstr "%1$s，%2$s"
+
+#: src/game.cpp
+msgid "other type started"
+msgstr "其他处理已经开始"
+
+#: src/game.cpp
+msgid "A more careful butchery method is already in progress. Starting this cruder method will prevent continuing that work. Continue."
+msgstr "已经开始了更精细的尸体处理，改用更粗糙的方式后将无法继续之前的工作，是否继续。"

--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -464724,7 +464724,3 @@ msgstr "%1$s，%2$s"
 #: src/game.cpp
 msgid "other type started"
 msgstr "其他处理已经开始"
-
-#: src/game.cpp
-msgid "A more careful butchery method is already in progress. Starting this cruder method will prevent continuing that work. Continue."
-msgstr "已经开始了更精细的尸体处理，改用更粗糙的方式后将无法继续之前的工作，是否继续。"

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -346,6 +346,68 @@ std::string enum_to_string<butcher_type>( butcher_type data )
 
 } // namespace io
 
+static std::string butcher_progress_var( const butcher_type action )
+{
+    return io::enum_to_string( action ) + "_progress";
+}
+
+static butcher_type get_butcher_type( const player_activity &act )
+{
+    if( act.id() == ACT_BUTCHER_FULL ) {
+        return butcher_type::FULL;
+    } else if( act.id() == ACT_FIELD_DRESS ) {
+        return butcher_type::FIELD_DRESS;
+    } else if( act.id() == ACT_QUARTER ) {
+        return butcher_type::QUARTER;
+    } else if( act.id() == ACT_DISSECT ) {
+        return butcher_type::DISSECT;
+    } else if( act.id() == ACT_BLEED ) {
+        return butcher_type::BLEED;
+    } else if( act.id() == ACT_SKIN ) {
+        return butcher_type::SKIN;
+    } else if( act.id() == ACT_DISMEMBER ) {
+        return butcher_type::DISMEMBER;
+    }
+    return butcher_type::QUICK;
+}
+
+static bool is_butchery_activity( const player_activity &act )
+{
+    return act.id() == ACT_BLEED || act.id() == ACT_BUTCHER ||
+           act.id() == ACT_BUTCHER_FULL || act.id() == ACT_FIELD_DRESS ||
+           act.id() == ACT_SKIN || act.id() == ACT_QUARTER ||
+           act.id() == ACT_DISMEMBER || act.id() == ACT_DISSECT;
+}
+
+static void save_butchery_progress( player_activity &act )
+{
+    if( !is_butchery_activity( act ) || act.index || act.targets.empty() ||
+        act.moves_total <= 0 ) {
+        return;
+    }
+
+    item_location &target = act.targets.back();
+    if( !target || !target->is_corpse() ) {
+        return;
+    }
+
+    const butcher_type action = get_butcher_type( act );
+    const double completed = std::clamp(
+                                 static_cast<double>( act.moves_total - act.moves_left ) /
+                                 act.moves_total, 0.0, 1.0 );
+    item &corpse_item = *target;
+    const std::string progress_var = butcher_progress_var( action );
+    corpse_item.set_var( progress_var,
+                         std::max( completed, corpse_item.get_var( progress_var, 0.0 ) ) );
+}
+
+void activity_handlers::butcher_canceled( player_activity *act, Character * /*you*/ )
+{
+    if( act != nullptr ) {
+        save_butchery_progress( *act );
+    }
+}
+
 bool activity_handlers::resume_for_multi_activities( Character &you )
 {
     if( !you.backlog.empty() ) {
@@ -541,7 +603,13 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
         }
     }
 
-    act.moves_left = butcher_time_to_cut( you, corpse_item, action ) * butchery_requirements.first;
+    const int total_moves = butcher_time_to_cut( you, corpse_item, action ) *
+                            butchery_requirements.first;
+    const double completed = std::clamp( corpse_item.get_var( butcher_progress_var( action ), 0.0 ),
+                                        0.0, 1.0 );
+    act.moves_total = total_moves;
+    act.moves_left = std::max( 0, static_cast<int>(
+                                   std::round( total_moves * ( 1.0 - completed ) ) ) );
 
     // We have a valid target, so preform the full finish function
     // instead of just selecting the next valid target
@@ -1118,24 +1186,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
         return;
     }
 
-    butcher_type action = butcher_type::QUICK;
-    if( act->id() == ACT_BUTCHER ) {
-        action = butcher_type::QUICK;
-    } else if( act->id() == ACT_BUTCHER_FULL ) {
-        action = butcher_type::FULL;
-    } else if( act->id() == ACT_FIELD_DRESS ) {
-        action = butcher_type::FIELD_DRESS;
-    } else if( act->id() == ACT_QUARTER ) {
-        action = butcher_type::QUARTER;
-    } else if( act->id() == ACT_DISSECT ) {
-        action = butcher_type::DISSECT;
-    } else if( act->id() == ACT_BLEED ) {
-        action = butcher_type::BLEED;
-    } else if( act->id() == ACT_SKIN ) {
-        action = butcher_type::SKIN;
-    } else if( act->id() == ACT_DISMEMBER ) {
-        action = butcher_type::DISMEMBER;
-    }
+    const butcher_type action = get_butcher_type( *act );
 
     // index is a bool that determines if we are ready to start the next target
     if( act->index ) {
@@ -1144,6 +1195,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
     }
 
     item &corpse_item = *target;
+    corpse_item.erase_var( butcher_progress_var( action ) );
     const mtype *corpse = corpse_item.get_mtype();
     const field_type_id type_blood = corpse->bloodType();
     const field_type_id type_gib = corpse->gibType();
@@ -2762,8 +2814,9 @@ void activity_handlers::repair_item_do_turn( player_activity *act, Character *yo
     }
 }
 
-void activity_handlers::butcher_do_turn( player_activity * /*act*/, Character *you )
+void activity_handlers::butcher_do_turn( player_activity *act, Character *you )
 {
+    save_butchery_progress( *act );
     you->mod_stamina( -20 );
 }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -346,9 +346,14 @@ std::string enum_to_string<butcher_type>( butcher_type data )
 
 } // namespace io
 
-static std::string butcher_progress_var( const butcher_type action )
+std::string butcher_progress_var( const butcher_type action )
 {
     return io::enum_to_string( action ) + "_progress";
+}
+
+double butcher_get_progress( const item &corpse_item, const butcher_type action )
+{
+    return std::clamp( corpse_item.get_var( butcher_progress_var( action ), 0.0 ), 0.0, 1.0 );
 }
 
 static butcher_type get_butcher_type( const player_activity &act )
@@ -605,8 +610,7 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
 
     const int total_moves = butcher_time_to_cut( you, corpse_item, action ) *
                             butchery_requirements.first;
-    const double completed = std::clamp( corpse_item.get_var( butcher_progress_var( action ), 0.0 ),
-                                        0.0, 1.0 );
+    const double completed = butcher_get_progress( corpse_item, action );
     act.moves_total = total_moves;
     act.moves_left = std::max( 0, static_cast<int>(
                                    std::round( total_moves * ( 1.0 - completed ) ) ) );

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -159,6 +159,7 @@ void armor_layers_do_turn( player_activity *act, Character *you );
 void atm_do_turn( player_activity *act, Character *you );
 void build_do_turn( player_activity *act, Character *you );
 void butcher_do_turn( player_activity *act, Character *you );
+void butcher_canceled( player_activity *act, Character *you );
 void chop_trees_do_turn( player_activity *act, Character *you );
 void consume_drink_menu_do_turn( player_activity *act, Character *you );
 void consume_food_menu_do_turn( player_activity *act, Character *you );

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -6,6 +6,7 @@
 #include <list>
 #include <map>
 #include <new>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -120,6 +121,8 @@ struct activity_reason_info {
 };
 
 int butcher_time_to_cut( Character &you, const item &corpse_item, butcher_type action );
+std::string butcher_progress_var( butcher_type action );
+double butcher_get_progress( const item &corpse_item, butcher_type action );
 
 // activity_item_handling.cpp
 void activity_on_turn_drop();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <clocale>
 #include <algorithm>
+#include <array>
 #include <bitset>
 #include <chrono>
 #include <climits>
@@ -9180,24 +9181,69 @@ static void add_disassemblables( uilist &menu,
 static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, int index = -1 )
 {
     avatar &player_character = get_avatar();
-    auto cut_time = [&]( butcher_type bt ) {
-        int time_to_cut = 0;
-        if( index != -1 ) {
-            const mtype &corpse = *corpses[index]->get_mtype();
+    constexpr int num_butcher_types = static_cast<int>( butcher_type::NUM_TYPES );
+    std::array<int, num_butcher_types> total_cut_moves = {};
+    std::array<int, num_butcher_types> remaining_cut_moves = {};
+    std::array<bool, num_butcher_types> has_started = {};
+
+    for( int bt_i = 0; bt_i < num_butcher_types; bt_i++ ) {
+        const butcher_type bt = static_cast<butcher_type>( bt_i );
+        auto add_corpse_time = [&]( const item &corpse_item ) {
+            const mtype &corpse = *corpse_item.get_mtype();
             const float factor = corpse.harvest->get_butchery_requirements().get_fastest_requirements(
                                      player_character.crafting_inventory(),
                                      corpse.size, bt ).first;
-            time_to_cut = butcher_time_to_cut( player_character, *corpses[index], bt ) * factor;
+            const int total_moves = butcher_time_to_cut( player_character, corpse_item, bt ) * factor;
+            const double completed = butcher_get_progress( corpse_item, bt );
+            total_cut_moves[bt_i] += total_moves;
+            remaining_cut_moves[bt_i] += std::max( 0, static_cast<int>(
+                                                   std::round( total_moves * ( 1.0 - completed ) ) ) );
+            has_started[bt_i] = has_started[bt_i] || completed > 0.0;
+        };
+
+        if( index != -1 ) {
+            add_corpse_time( *corpses[index] );
         } else {
             for( const map_stack::iterator &it : corpses ) {
-                const mtype &corpse = *it->get_mtype();
-                const float factor = corpse.harvest->get_butchery_requirements().get_fastest_requirements(
-                                         player_character.crafting_inventory(),
-                                         corpse.size, bt ).first;
-                time_to_cut += butcher_time_to_cut( player_character, *it, bt ) * factor;
+                add_corpse_time( *it );
             }
         }
-        return to_string_clipped( time_duration::from_moves( time_to_cut ) );
+    }
+
+    auto cut_time = [&]( butcher_type bt ) {
+        return to_string_clipped( time_duration::from_moves(
+                                      remaining_cut_moves[static_cast<int>( bt )] ) );
+    };
+    auto progress_str = [&]( butcher_type bt ) {
+        const int bt_i = static_cast<int>( bt );
+        const int total_moves = total_cut_moves[bt_i];
+        const int remaining_moves = remaining_cut_moves[bt_i];
+        if( total_moves <= 0 || remaining_moves >= total_moves ) {
+            return std::string();
+        }
+        const int percentage = std::clamp(
+                                   static_cast<int>( std::round(
+                                                       100.0 * ( total_moves - remaining_moves ) /
+                                                       total_moves ) ), 1, 100 );
+        return string_format( " [%d%%]", percentage );
+    };
+    auto has_started_cruder_type = [&]( butcher_type bt ) {
+        const int bt_i = static_cast<int>( bt );
+        for( int other_bt = 0; other_bt < num_butcher_types; other_bt++ ) {
+            if( has_started[other_bt] && total_cut_moves[other_bt] < total_cut_moves[bt_i] ) {
+                return true;
+            }
+        }
+        return false;
+    };
+    auto has_started_finer_type = [&]( butcher_type bt ) {
+        const int bt_i = static_cast<int>( bt );
+        for( int other_bt = 0; other_bt < num_butcher_types; other_bt++ ) {
+            if( has_started[other_bt] && total_cut_moves[other_bt] > total_cut_moves[bt_i] ) {
+                return true;
+            }
+        }
+        return false;
     };
     const bool enough_light = player_character.fine_detail_vision_mod() <= 4;
 
@@ -9253,16 +9299,56 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
         }
     }
 
+    auto is_enabled = [&]( butcher_type bt ) {
+        if( bt == butcher_type::DISMEMBER ) {
+            return true;
+        }
+        if( !enough_light ||
+            ( bt == butcher_type::FIELD_DRESS && !has_organs ) ||
+            ( bt == butcher_type::SKIN && !has_skin ) ||
+            ( bt == butcher_type::BLEED && !has_blood ) ||
+            has_started_cruder_type( bt ) ) {
+            return false;
+        }
+        return true;
+    };
+
+    const std::string cannot_see = colorize( _( "can't see!" ), c_red );
+    auto time_or_disabledreason = [&]( butcher_type bt ) {
+        if( bt == butcher_type::DISMEMBER ) {
+            return cut_time( bt );
+        }
+        if( !enough_light ) {
+            return cannot_see;
+        }
+        if( bt == butcher_type::FIELD_DRESS && !has_organs ) {
+            return colorize( _( "has no organs" ), c_red );
+        }
+        if( bt == butcher_type::SKIN && !has_skin ) {
+            return colorize( _( "has no skin" ), c_red );
+        }
+        if( bt == butcher_type::BLEED && !has_blood ) {
+            return colorize( _( "has no blood" ), c_red );
+        }
+        if( has_started_cruder_type( bt ) ) {
+            return colorize( _( "other type started" ), c_red );
+        }
+        return cut_time( bt );
+    };
+    auto confirm_cruder_switch = [&]( butcher_type bt ) {
+        return !has_started_finer_type( bt ) || query_yn(
+                   _( "A more careful butchery method is already in progress. "
+                      "Starting this cruder method will prevent continuing that work. Continue." ) );
+    };
+
     uilist smenu;
     smenu.desc_enabled = true;
     smenu.desc_lines_hint += dissect_wp_hint_lines;
     smenu.text = _( "Choose type of butchery:" );
 
-    const std::string cannot_see = colorize( _( "can't see!" ), c_red );
-
-    smenu.addentry_col( static_cast<int>( butcher_type::QUICK ), enough_light,
-                        'B', _( "Quick butchery" ),
-                        enough_light ? cut_time( butcher_type::QUICK ) : cannot_see,
+    smenu.addentry_col( static_cast<int>( butcher_type::QUICK ), is_enabled( butcher_type::QUICK ),
+                        'B', _( "Quick butchery" ) + progress_str( butcher_type::QUICK ),
+                        time_or_disabledreason( butcher_type::QUICK ),
                         string_format( "%s  %s",
                                        _( "This technique is used when you are in a hurry, "
                                           "but still want to harvest something from the corpse. "
@@ -9270,9 +9356,9 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
                                           "but it's useful if you don't want to set up a workshop.  "
                                           "Prevents zombies from raising." ),
                                        msgFactor ) );
-    smenu.addentry_col( static_cast<int>( butcher_type::FULL ), enough_light,
-                        'b', _( "Full butchery" ),
-                        enough_light ? cut_time( butcher_type::FULL ) : cannot_see,
+    smenu.addentry_col( static_cast<int>( butcher_type::FULL ), is_enabled( butcher_type::FULL ),
+                        'b', _( "Full butchery" ) + progress_str( butcher_type::FULL ),
+                        time_or_disabledreason( butcher_type::FULL ),
                         string_format( "%s  %s",
                                        _( "This technique is used to properly butcher a corpse, "
                                           "and requires a rope & a tree or a butchering rack, "
@@ -9280,10 +9366,10 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
                                           "and good tools.  Yields are plentiful and varied, "
                                           "but it is time consuming." ),
                                        msgFactor ) );
-    smenu.addentry_col( static_cast<int>( butcher_type::FIELD_DRESS ), enough_light && has_organs,
-                        'f', _( "Field dress corpse" ),
-                        enough_light ? ( has_organs ? cut_time( butcher_type::FIELD_DRESS ) :
-                                         colorize( _( "has no organs" ), c_red ) ) : cannot_see,
+    smenu.addentry_col( static_cast<int>( butcher_type::FIELD_DRESS ),
+                        is_enabled( butcher_type::FIELD_DRESS ),
+                        'f', _( "Field dress corpse" ) + progress_str( butcher_type::FIELD_DRESS ),
+                        time_or_disabledreason( butcher_type::FIELD_DRESS ),
                         string_format( "%s  %s",
                                        _( "Technique that involves removing internal organs and "
                                           "viscera to protect the corpse from rotting from inside.  "
@@ -9291,10 +9377,9 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
                                           "stay fresh longer.  Can be combined with other methods for "
                                           "better effects." ),
                                        msgFactor ) );
-    smenu.addentry_col( static_cast<int>( butcher_type::SKIN ), enough_light && has_skin,
-                        's', _( "Skin corpse" ),
-                        enough_light ? ( has_skin ? cut_time( butcher_type::SKIN ) : colorize( _( "has no skin" ),
-                                         c_red ) ) : cannot_see,
+    smenu.addentry_col( static_cast<int>( butcher_type::SKIN ), is_enabled( butcher_type::SKIN ),
+                        's', _( "Skin corpse" ) + progress_str( butcher_type::SKIN ),
+                        time_or_disabledreason( butcher_type::SKIN ),
                         string_format( "%s  %s",
                                        _( "Skinning a corpse is an involved and careful process that "
                                           "usually takes some time.  You need skill and an appropriately "
@@ -9302,19 +9387,18 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
                                           "too small to yield a full-sized hide and will instead produce "
                                           "scraps that can be used in other ways." ),
                                        msgFactor ) );
-    smenu.addentry_col( static_cast<int>( butcher_type::BLEED ), enough_light && has_blood,
-                        'l', _( "Bleed corpse" ),
-                        enough_light ? ( has_blood ? cut_time( butcher_type::BLEED ) : colorize( _( "has no blood" ),
-                                         c_red ) ) : cannot_see,
+    smenu.addentry_col( static_cast<int>( butcher_type::BLEED ), is_enabled( butcher_type::BLEED ),
+                        'l', _( "Bleed corpse" ) + progress_str( butcher_type::BLEED ),
+                        time_or_disabledreason( butcher_type::BLEED ),
                         string_format( "%s  %s",
                                        _( "Bleeding involves severing the carotid arteries and jugular "
                                           "veins, or the blood vessels from which they arise.  "
                                           "You need skill and an appropriately sharp and precise knife "
                                           "to do a good job." ),
                                        msgFactor ) );
-    smenu.addentry_col( static_cast<int>( butcher_type::QUARTER ), enough_light,
-                        'k', _( "Quarter corpse" ),
-                        enough_light ? cut_time( butcher_type::QUARTER ) : cannot_see,
+    smenu.addentry_col( static_cast<int>( butcher_type::QUARTER ), is_enabled( butcher_type::QUARTER ),
+                        'k', _( "Quarter corpse" ) + progress_str( butcher_type::QUARTER ),
+                        time_or_disabledreason( butcher_type::QUARTER ),
                         string_format( "%s  %s",
                                        _( "By quartering a previously field dressed corpse you will "
                                           "acquire four parts with reduced weight and volume.  It "
@@ -9323,16 +9407,16 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
                                           "harvest them later." ),
                                        msgFactor ) );
     smenu.addentry_col( static_cast<int>( butcher_type::DISMEMBER ), true,
-                        'm', _( "Dismember corpse" ),
+                        'm', _( "Dismember corpse" ) + progress_str( butcher_type::DISMEMBER ),
                         cut_time( butcher_type::DISMEMBER ),
                         string_format( "%s  %s",
                                        _( "If you're aiming to just destroy a body outright and don't "
                                           "care about harvesting it, dismembering it will hack it apart "
                                           "in a very short amount of time but yields little to no usable flesh." ),
                                        msgFactor ) );
-    smenu.addentry_col( static_cast<int>( butcher_type::DISSECT ), enough_light,
-                        'd', _( "Dissect corpse" ),
-                        enough_light ? cut_time( butcher_type::DISSECT ) : cannot_see,
+    smenu.addentry_col( static_cast<int>( butcher_type::DISSECT ), is_enabled( butcher_type::DISSECT ),
+                        'd', _( "Dissect corpse" ) + progress_str( butcher_type::DISSECT ),
+                        time_or_disabledreason( butcher_type::DISSECT ),
                         string_format( "%s  %s%s",
                                        _( "By careful dissection of the corpse, you will examine it for "
                                           "possible bionic implants, or discrete organs and harvest them "
@@ -9341,30 +9425,36 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
                                           "is most useful here." ),
                                        msgFactorD, dissect_wp_hint ) );
     smenu.query();
+
+    auto assign_butchery_activity = [&]( butcher_type bt, const activity_id &activity ) {
+        if( confirm_cruder_switch( bt ) ) {
+            player_character.assign_activity( activity, 0, true );
+        }
+    };
     switch( smenu.ret ) {
         case static_cast<int>( butcher_type::QUICK ):
-            player_character.assign_activity( ACT_BUTCHER, 0, true );
+            assign_butchery_activity( butcher_type::QUICK, ACT_BUTCHER );
             break;
         case static_cast<int>( butcher_type::FULL ):
-            player_character.assign_activity( ACT_BUTCHER_FULL, 0, true );
+            assign_butchery_activity( butcher_type::FULL, ACT_BUTCHER_FULL );
             break;
         case static_cast<int>( butcher_type::FIELD_DRESS ):
-            player_character.assign_activity( ACT_FIELD_DRESS, 0, true );
+            assign_butchery_activity( butcher_type::FIELD_DRESS, ACT_FIELD_DRESS );
             break;
         case static_cast<int>( butcher_type::SKIN ):
-            player_character.assign_activity( ACT_SKIN, 0, true );
+            assign_butchery_activity( butcher_type::SKIN, ACT_SKIN );
             break;
-        case static_cast<int>( butcher_type::BLEED ) :
-            player_character.assign_activity( ACT_BLEED, 0, true );
+        case static_cast<int>( butcher_type::BLEED ):
+            assign_butchery_activity( butcher_type::BLEED, ACT_BLEED );
             break;
         case static_cast<int>( butcher_type::QUARTER ):
-            player_character.assign_activity( ACT_QUARTER, 0, true );
+            assign_butchery_activity( butcher_type::QUARTER, ACT_QUARTER );
             break;
         case static_cast<int>( butcher_type::DISMEMBER ):
-            player_character.assign_activity( ACT_DISMEMBER, 0, true );
+            assign_butchery_activity( butcher_type::DISMEMBER, ACT_DISMEMBER );
             break;
         case static_cast<int>( butcher_type::DISSECT ):
-            player_character.assign_activity( ACT_DISSECT, 0, true );
+            assign_butchery_activity( butcher_type::DISSECT, ACT_DISSECT );
             break;
         default:
             return;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9236,15 +9236,6 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
         }
         return false;
     };
-    auto has_started_finer_type = [&]( butcher_type bt ) {
-        const int bt_i = static_cast<int>( bt );
-        for( int other_bt = 0; other_bt < num_butcher_types; other_bt++ ) {
-            if( has_started[other_bt] && total_cut_moves[other_bt] > total_cut_moves[bt_i] ) {
-                return true;
-            }
-        }
-        return false;
-    };
     const bool enough_light = player_character.fine_detail_vision_mod() <= 4;
 
     const int factor = player_character.max_quality( qual_BUTCHER, PICKUP_RANGE );
@@ -9335,12 +9326,6 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
         }
         return cut_time( bt );
     };
-    auto confirm_cruder_switch = [&]( butcher_type bt ) {
-        return !has_started_finer_type( bt ) || query_yn(
-                   _( "A more careful butchery method is already in progress. "
-                      "Starting this cruder method will prevent continuing that work. Continue." ) );
-    };
-
     uilist smenu;
     smenu.desc_enabled = true;
     smenu.desc_lines_hint += dissect_wp_hint_lines;
@@ -9426,35 +9411,30 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
                                        msgFactorD, dissect_wp_hint ) );
     smenu.query();
 
-    auto assign_butchery_activity = [&]( butcher_type bt, const activity_id &activity ) {
-        if( confirm_cruder_switch( bt ) ) {
-            player_character.assign_activity( activity, 0, true );
-        }
-    };
     switch( smenu.ret ) {
         case static_cast<int>( butcher_type::QUICK ):
-            assign_butchery_activity( butcher_type::QUICK, ACT_BUTCHER );
+            player_character.assign_activity( ACT_BUTCHER, 0, true );
             break;
         case static_cast<int>( butcher_type::FULL ):
-            assign_butchery_activity( butcher_type::FULL, ACT_BUTCHER_FULL );
+            player_character.assign_activity( ACT_BUTCHER_FULL, 0, true );
             break;
         case static_cast<int>( butcher_type::FIELD_DRESS ):
-            assign_butchery_activity( butcher_type::FIELD_DRESS, ACT_FIELD_DRESS );
+            player_character.assign_activity( ACT_FIELD_DRESS, 0, true );
             break;
         case static_cast<int>( butcher_type::SKIN ):
-            assign_butchery_activity( butcher_type::SKIN, ACT_SKIN );
+            player_character.assign_activity( ACT_SKIN, 0, true );
             break;
         case static_cast<int>( butcher_type::BLEED ):
-            assign_butchery_activity( butcher_type::BLEED, ACT_BLEED );
+            player_character.assign_activity( ACT_BLEED, 0, true );
             break;
         case static_cast<int>( butcher_type::QUARTER ):
-            assign_butchery_activity( butcher_type::QUARTER, ACT_QUARTER );
+            player_character.assign_activity( ACT_QUARTER, 0, true );
             break;
         case static_cast<int>( butcher_type::DISMEMBER ):
-            assign_butchery_activity( butcher_type::DISMEMBER, ACT_DISMEMBER );
+            player_character.assign_activity( ACT_DISMEMBER, 0, true );
             break;
         case static_cast<int>( butcher_type::DISSECT ):
-            assign_butchery_activity( butcher_type::DISSECT, ACT_DISSECT );
+            player_character.assign_activity( ACT_DISSECT, 0, true );
             break;
         default:
             return;

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -29,6 +29,9 @@ static const activity_id ACT_ADV_INVENTORY( "ACT_ADV_INVENTORY" );
 static const activity_id ACT_AIM( "ACT_AIM" );
 static const activity_id ACT_ARMOR_LAYERS( "ACT_ARMOR_LAYERS" );
 static const activity_id ACT_ATM( "ACT_ATM" );
+static const activity_id ACT_BLEED( "ACT_BLEED" );
+static const activity_id ACT_BUTCHER( "ACT_BUTCHER" );
+static const activity_id ACT_BUTCHER_FULL( "ACT_BUTCHER_FULL" );
 static const activity_id ACT_BUILD( "ACT_BUILD" );
 static const activity_id ACT_CHOP_LOGS( "ACT_CHOP_LOGS" );
 static const activity_id ACT_CHOP_PLANKS( "ACT_CHOP_PLANKS" );
@@ -38,7 +41,10 @@ static const activity_id ACT_CONSUME( "ACT_CONSUME" );
 static const activity_id ACT_CONSUME_DRINK_MENU( "ACT_CONSUME_DRINK_MENU" );
 static const activity_id ACT_CONSUME_FOOD_MENU( "ACT_CONSUME_FOOD_MENU" );
 static const activity_id ACT_CONSUME_MEDS_MENU( "ACT_CONSUME_MEDS_MENU" );
+static const activity_id ACT_DISMEMBER( "ACT_DISMEMBER" );
+static const activity_id ACT_DISSECT( "ACT_DISSECT" );
 static const activity_id ACT_EAT_MENU( "ACT_EAT_MENU" );
+static const activity_id ACT_FIELD_DRESS( "ACT_FIELD_DRESS" );
 static const activity_id ACT_FIRSTAID( "ACT_FIRSTAID" );
 static const activity_id ACT_FISH( "ACT_FISH" );
 static const activity_id ACT_GAME( "ACT_GAME" );
@@ -52,7 +58,9 @@ static const activity_id ACT_NULL( "ACT_NULL" );
 static const activity_id ACT_OXYTORCH( "ACT_OXYTORCH" );
 static const activity_id ACT_PICKAXE( "ACT_PICKAXE" );
 static const activity_id ACT_PICKUP_MENU( "ACT_PICKUP_MENU" );
+static const activity_id ACT_QUARTER( "ACT_QUARTER" );
 static const activity_id ACT_READ( "ACT_READ" );
+static const activity_id ACT_SKIN( "ACT_SKIN" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
@@ -201,9 +209,18 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
             type == ACT_CHOP_TREE ||
             type == ACT_CHOP_LOGS ||
             type == ACT_CHOP_PLANKS ||
-            type == ACT_HEATING
+            type == ACT_HEATING ||
+            type == ACT_BLEED ||
+            type == ACT_BUTCHER ||
+            type == ACT_BUTCHER_FULL ||
+            type == ACT_FIELD_DRESS ||
+            type == ACT_SKIN ||
+            type == ACT_QUARTER ||
+            type == ACT_DISMEMBER ||
+            type == ACT_DISSECT
           ) {
-            const int percentage = ( ( moves_total - moves_left ) * 100 ) / moves_total;
+            const int percentage = std::clamp( ( ( moves_total - moves_left ) * 100 ) / moves_total,
+                                               0, 100 );
 
             extra_info = string_format( "%d%%", percentage );
         }
@@ -392,8 +409,13 @@ void player_activity::do_turn( Character &you )
 
 void player_activity::canceled( Character &who )
 {
-    if( *this && actor ) {
+    if( !*this ) {
+        return;
+    }
+    if( actor ) {
         actor->canceled( *this, who );
+    } else {
+        activity_handlers::butcher_canceled( this, &who );
     }
 }
 


### PR DESCRIPTION
## 问题

尸体处理耗时较长，活动被敌人、移动或保存退出打断后，原有进度会全部丢失。处理菜单也缺少当前进度和剩余时间反馈，不同处理方式之间没有明确的降级规则。

## 改动内容

- 按尸体和处理方式分别保存屠宰、完整屠宰、清理内脏、剥皮、放血、分割、肢解及解剖的完成进度。
- 再次选择相同处理方式时从已保存进度继续，并在活动界面与处理菜单显示完成百分比和预计剩余时间。
- 粗糙处理真正产生进度后，锁定比它更精细的处理方式，避免通过反复切换获取不合理收益。
- 从精细处理改用粗糙处理时直接开始，不再弹出额外确认窗口；仅选择后立即取消不会触发锁定。
- 补充“其他处理已经开始”的中文提示。

## 兼容性

进度使用尸体物品的可选变量保存；旧存档中的尸体没有该变量时按零进度处理，不影响存档读取。完成处理后会清除相应进度变量，不修改尸体类型或原有处理产物规则。

## 验证

- Windows Tiles x64 MSVC 与 Android arm64 构建均通过。
- 已在游戏内验证进度显示、中断后续作、保存后继续和单向降级行为。
- 差异格式检查通过，移除确认提示后无残留未使用译文。
- 测试运行：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/30737571868
