### PR TITLE
调整弱点与赤铜专长学习时间并修正飞艇分类

### DIFF
--- a/data/json/proficiencies/metalwork.json
+++ b/data/json/proficiencies/metalwork.json
@@ -55,7 +55,7 @@
     "can_learn": true,
     "default_time_multiplier": 2,
     "default_fail_multiplier": 1.25,
-    "time_to_learn": "10 h",
+    "time_to_learn": "4 h",
     "required_proficiencies": [ "prof_metalworking" ]
   },
   {

--- a/data/json/proficiencies/misc.json
+++ b/data/json/proficiencies/misc.json
@@ -133,7 +133,7 @@
   {
     "type": "proficiency",
     "id": "prof_airship_pilot",
-    "category": "prof_vehicles",
+    "category": "prof_mechanic",
     "name": { "str": "飞艇驾驶" },
     "description": "你掌握了如何管理轻于空气飞行器的浮力，并使用螺旋桨进行操控。它比直升机更慢，操控也更宽容，但这些原理仍需学习才能精通。",
     "can_learn": true,

--- a/data/json/proficiencies/weakpoints.json
+++ b/data/json/proficiencies/weakpoints.json
@@ -17,7 +17,7 @@
     "name": { "str": "Expert Debug Weakpoint" },
     "description": "Expert improvement on the chance of hitting the Weakpoint Monster's weak points.",
     "can_learn": true,
-    "time_to_learn": "12 h",
+    "time_to_learn": "1 h",
     "required_proficiencies": [ "prof_debug_weakpoint" ]
   },
   {
@@ -27,7 +27,7 @@
     "name": { "str": "Principles of Zombie Biology" },
     "description": "Very basic familiarity with various types of undead creatures.",
     "can_learn": true,
-    "time_to_learn": "6 h",
+    "time_to_learn": "30 m",
     "required_proficiencies": [ "prof_intro_biology" ],
     "default_weakpoint_bonus": 2,
     "default_weakpoint_penalty": 0
@@ -39,7 +39,7 @@
     "name": { "str": "Principles of Near Human Biology" },
     "description": "Very basic familiarity with various types of demihuman creatures.",
     "can_learn": true,
-    "time_to_learn": "6 h",
+    "time_to_learn": "30 m",
     "required_proficiencies": [ "prof_intro_biology" ],
     "default_weakpoint_bonus": 2,
     "default_weakpoint_penalty": 0
@@ -51,7 +51,7 @@
     "name": { "str": "Anatomy of Amalgamations" },
     "description": "You are familiar with the common anatomy of these purpose-built abominations, as far as they have one.",
     "can_learn": true,
-    "time_to_learn": "20 h",
+    "time_to_learn": "30 m",
     "default_weakpoint_bonus": 4,
     "default_weakpoint_penalty": -2
   },
@@ -62,7 +62,7 @@
     "name": { "str": "Synthetic Armors" },
     "description": "Understanding of man-made armors and ways to exploit them.  You're able to find openings in certain kinds of body armor.",
     "can_learn": true,
-    "time_to_learn": "6 h",
+    "time_to_learn": "30 m",
     "default_weakpoint_bonus": 4,
     "default_weakpoint_penalty": -4
   },
@@ -73,7 +73,7 @@
     "name": { "str": "Natural Armors" },
     "description": "You're somewhat familiar with naturally armored creatures.  You're able to find openings in certain kinds of hardened shells.",
     "can_learn": true,
-    "time_to_learn": "8 h",
+    "time_to_learn": "30 m",
     "default_weakpoint_bonus": 4,
     "default_weakpoint_penalty": -4
   },
@@ -84,7 +84,7 @@
     "name": { "str": "Cyborg Anatomy" },
     "description": "You're somewhat familiar with cybernetic creatures.  You're able to find openings and gaps that aren't as hardened.",
     "can_learn": true,
-    "time_to_learn": "19 h",
+    "time_to_learn": "30 m",
     "default_weakpoint_bonus": 4,
     "default_weakpoint_penalty": -4
   },
@@ -95,7 +95,7 @@
     "name": { "str": "Bird Biology" },
     "description": "Basic familiarity with various types of birds.",
     "can_learn": true,
-    "time_to_learn": "8 h",
+    "time_to_learn": "30 m",
     "required_proficiencies": [ "prof_intro_biology" ],
     "default_weakpoint_bonus": 1,
     "default_weakpoint_penalty": 0
@@ -107,7 +107,7 @@
     "name": { "str": "Invertebrate Biology" },
     "description": "Basic familiarity with various types of insects, arachnids, and worms.",
     "can_learn": true,
-    "time_to_learn": "8 h",
+    "time_to_learn": "30 m",
     "required_proficiencies": [ "prof_intro_biology" ],
     "default_weakpoint_bonus": 1,
     "default_weakpoint_penalty": 0
@@ -119,7 +119,7 @@
     "name": { "str": "Beetle Anatomy" },
     "description": "You are familiar with the anatomy of mutated beetles - bypassing their thick armor should be easier.",
     "can_learn": true,
-    "time_to_learn": "12 h",
+    "time_to_learn": "1 h",
     "required_proficiencies": [ "prof_wp_basic_bug" ],
     "default_weakpoint_bonus": 4,
     "default_weakpoint_penalty": -2
@@ -131,7 +131,7 @@
     "name": { "str": "Centipede Anatomy" },
     "description": "You are familiar with the anatomy of mutated centipedes, letting you target their less-deadly parts with ease.",
     "can_learn": true,
-    "time_to_learn": "12 h",
+    "time_to_learn": "30 m",
     "required_proficiencies": [ "prof_wp_basic_bug" ],
     "default_weakpoint_bonus": 4,
     "default_weakpoint_penalty": -2
@@ -144,7 +144,7 @@
     "name": { "str": "Hymenopteran Anatomy" },
     "description": "Familiarity with the comparative anatomy of mutant Hymenopterans - ants, bees, and wasps of all kinds.  You find it easier to exploit their weak points, and possibly disable their natural weaponry.",
     "can_learn": true,
-    "time_to_learn": "12 h",
+    "time_to_learn": "30 m",
     "required_proficiencies": [ "prof_wp_basic_bug" ],
     "default_weakpoint_bonus": 4,
     "default_weakpoint_penalty": -2
@@ -156,7 +156,7 @@
     "name": { "str": "Arachnid Anatomy" },
     "description": "You are familiar with the anatomy of mutated spiders of all shapes and sizes.",
     "can_learn": true,
-    "time_to_learn": "12 h",
+    "time_to_learn": "30 m",
     "required_proficiencies": [ "prof_wp_basic_bug" ],
     "default_weakpoint_bonus": 4,
     "default_weakpoint_penalty": -2
@@ -168,7 +168,7 @@
     "name": { "str": "Creatures of Flight" },
     "description": "Basic understanding of what's needed for certain creatures to fly, as well as ways of preventing it.",
     "can_learn": true,
-    "time_to_learn": "6 h",
+    "time_to_learn": "30 m",
     "default_weakpoint_bonus": 1,
     "default_weakpoint_penalty": 0
   },
@@ -179,7 +179,7 @@
     "name": { "str": "Ossified Exoskeletons" },
     "description": "You're familiar with creatures presenting unsettling bones on their outer structure.",
     "can_learn": true,
-    "time_to_learn": "6 h",
+    "time_to_learn": "30 m",
     "default_weakpoint_bonus": 4,
     "default_weakpoint_penalty": -2
   },
@@ -190,7 +190,7 @@
     "name": { "str": "Small Humanoids" },
     "description": "You have some practice in fighting small humanoids like children.  You don't necessarily feel good about it.",
     "can_learn": true,
-    "time_to_learn": "4 h",
+    "time_to_learn": "30 m",
     "required_proficiencies": [ "prof_intro_biology" ],
     "default_weakpoint_bonus": 2,
     "default_weakpoint_penalty": 0
@@ -202,7 +202,7 @@
     "name": { "str": "Large Humanoids" },
     "description": "You have some practice in fighting large hulking humanoids.  You're better at reaching certain weak points.",
     "can_learn": true,
-    "time_to_learn": "6 h",
+    "time_to_learn": "30 m",
     "required_proficiencies": [ "prof_intro_biology" ],
     "default_weakpoint_bonus": 4,
     "default_weakpoint_penalty": -2


### PR DESCRIPTION
## 问题

部分 CCB 弱点专长和赤铜加工专长的学习时间过长，与当前玩法节奏不匹配。飞艇驾驶专长还使用了未定义的 `prof_vehicles` 分类，加载时会产生专长分类报错。

## 改动内容

- 将基础弱点专长的学习时间调整为 30 分钟，进阶弱点专长调整为 30 分钟至 1 小时。
- 将赤铜加工专长的学习时间由 10 小时调整为 4 小时。
- 将飞艇驾驶专长归入现有机械分类 `prof_mechanic`。
- 保持专长 ID、依赖关系、学习条件、弱点加成和惩罚数值不变。

## 兼容性

修改只涉及专长 JSON 的学习时长和显示分类，不新增或删除专长 ID，不影响旧存档引用。已经获得的专长不会丢失，尚未完成的学习进度仍由原有系统处理。

## 验证

- Windows Tiles x64 MSVC 与 Android arm64 构建均通过。
- 已完成游戏内测试，专长学习时间修改运行正常。
- JSON 解析与差异格式检查通过，并确认 `prof_mechanic` 是已定义分类。
- 测试运行：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/30739001279
