### PR TITLE
确保 Android 构建同步最新汉化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -984,7 +984,7 @@ $(TEST_MO): data/mods/TEST_DATA/lang/po/ru.po
 	msgfmt -f -o $@ $<
 
 MO_DEPS := \
-  $(wildcard lang/*.sh lang/*.py src/*.cpp src/*.h) \
+  $(wildcard lang/*.sh lang/*.py lang/po/*.po src/*.cpp src/*.h) \
   $(shell find data/raw data/json data/mods data/core data/help -type f -name '*.json')
 
 lang/mo_built.stamp: $(MO_DEPS)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -240,6 +240,16 @@ task makeLocalization(type: Exec) {
     commandLine args
 }
 
+task syncLocalizationAssets(type: Sync) {
+    onlyIf {
+        localize && OperatingSystem.current() != OperatingSystem.WINDOWS
+    }
+    dependsOn unzipDeps
+    dependsOn makeLocalization
+    from file("$projectRoot/lang/mo")
+    into file("$assetsDir/lang/mo")
+}
+
 task generateVersionHeader() {
     // Keep the header synchronized during Gradle configuration, before native tasks are scheduled.
     def define = "// NOLINT(cata-header-guard)\n#define VERSION \"$resolved_version\"\n"
@@ -295,6 +305,7 @@ task createWindowsJunctionLinks() {
 
 preBuild.dependsOn unzipDeps
 preBuild.dependsOn makeLocalization
+preBuild.dependsOn syncLocalizationAssets
 preBuild.dependsOn generateVersionHeader
 preBuild.dependsOn createWindowsJunctionLinks
 createWindowsJunctionLinks.dependsOn makeLocalization

--- a/android/app/src/main/java/com/cleverraven/cataclysmdda/SplashScreen.java
+++ b/android/app/src/main/java/com/cleverraven/cataclysmdda/SplashScreen.java
@@ -90,7 +90,7 @@ public class SplashScreen extends Activity {
                 .setTitle(getString(R.string.crashAlert))
                 .setCancelable(false)
                 .setMessage(message)
-                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         SplashScreen.this.startGameActivity(false);
                     }
@@ -156,7 +156,7 @@ public class SplashScreen extends Activity {
         accessibilityServicesAlert = new AlertDialog.Builder(SplashScreen.this)
             .setTitle(getString(R.string.accessibilityServicesTitle))
             .setCancelable(false)
-            .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+            .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface dialog, int id) {
                     SplashScreen.this.installOrRun();
                     return;
@@ -230,9 +230,9 @@ public class SplashScreen extends Activity {
         @Override
         protected void onPreExecute() {
             installationAlert = new AlertDialog.Builder(SplashScreen.this)
-                .setTitle("Installation Failed")
+                .setTitle(R.string.installationFailed)
                 .setCancelable(false)
-                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         SplashScreen.this.finish();
                         return;
@@ -256,7 +256,7 @@ public class SplashScreen extends Activity {
                 .setTitle(getString(R.string.helpTitle))
                 .setCancelable(false)
                 .setMessage(getString(R.string.helpMessage))
-                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         settingsAlert.show();
                         return;

--- a/android/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -68,6 +68,8 @@ import android.window.OnBackInvokedDispatcher;
 
 import android.preference.PreferenceManager;
 
+import com.cleverraven.cataclysmdda.R;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -960,12 +962,9 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         if (mBrokenLibraries) {
             mSingleton = this;
             AlertDialog.Builder dlgAlert = new AlertDialog.Builder(this);
-            dlgAlert.setMessage("An error occurred while trying to start the application. Please try again and/or reinstall."
-                + System.getProperty("line.separator")
-                + System.getProperty("line.separator")
-                + "Error: " + errorMsgBrokenLib);
-            dlgAlert.setTitle("SDL Error");
-            dlgAlert.setPositiveButton("Exit",
+            dlgAlert.setMessage(getString(R.string.sdlErrorMessage, errorMsgBrokenLib));
+            dlgAlert.setTitle(R.string.sdlErrorTitle);
+            dlgAlert.setPositiveButton(R.string.exit,
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int id) {

--- a/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -22,6 +22,11 @@
 （该设置仅在[首次启动]与[覆盖更新]时可调整！）</string>
     <string name="startGame">开始游戏</string>
     <string name="showHelp">查看帮助</string>
+    <string name="showAccessibilitySettings">显示无障碍设置菜单</string>
+    <string name="installationFailed">安装失败</string>
+    <string name="sdlErrorTitle">SDL 错误</string>
+    <string name="sdlErrorMessage">启动应用时发生错误，请重试或重新安装。\n\n错误：%1$s</string>
+    <string name="exit">退出</string>
     <string name="crashAlert">检测到上次游戏未正常退出</string>
     <string name="crashMessage">崩溃日志已保存至安装目录 ./config/debug.log，上传至官方论坛协助开发者解决游戏异常提供帮助。</string>
     <string name="yes">是</string>
@@ -30,4 +35,6 @@
     <string name="cancel">取消</string>
     <string name="unavailable">不可选</string>
     <string name="unavailableOption">该选项已被禁用。</string>
+    <string name="accessibilityServicesTitle">无障碍服务警告</string>
+    <string name="accessibilityServicesMessage">如果游戏中的滑动命令和快捷键菜单无法正常使用，可以尝试停用下列会与触摸屏交互的无障碍服务或软件，例如滑动辅助、自动点击器、单手模式等：\n%1$s</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -12,6 +12,10 @@
     <string name="startGame">Start game</string>
     <string name="showHelp">Show help</string>
     <string name="showAccessibilitySettings">Show accessibility settings menu</string>
+    <string name="installationFailed">Installation failed</string>
+    <string name="sdlErrorTitle">SDL error</string>
+    <string name="sdlErrorMessage">An error occurred while trying to start the application. Please try again or reinstall.\n\nError: %1$s</string>
+    <string name="exit">Exit</string>
     <string name="crashAlert">The game did not quit properly last time</string>
     <string name="crashMessage">The crash report located in ./config/crash.log may help developers troubleshoot program errors.</string>
     <string name="yes">Yes</string>


### PR DESCRIPTION
## 问题

PC 汉化源文件 `lang/po/zh_CN.po` 更新后，现有依赖列表不会因 PO 变化重新编译 MO；Android Gradle 虽会执行汉化编译，却没有把新生成的 `lang/mo` 同步到 APK 实际打包的 `android/app/src/main/assets/lang/mo`，导致 Android 长期携带旧版汉化。

Android 原生启动界面还缺少部分简体中文资源，安装失败和 SDL 启动失败等弹窗存在硬编码英文。

## 改动内容

- 将 `lang/po/*.po` 加入 MO 构建依赖，PO 更新后自动重新生成翻译文件。
- Android 非 Windows 构建在完成汉化编译后，将 `lang/mo` 同步到 APK assets 的翻译目录。
- 保留 Windows 构建现有的目录联接逻辑，不重复复制资源。
- 将原生界面的确定、安装失败、SDL 错误和退出文字改为 Android 字符串资源。
- 补齐无障碍设置提示及错误弹窗的简体中文翻译。

## 兼容性

只修改构建流程与 Android 原生界面资源，不涉及游戏规则、C++ 游戏逻辑或存档格式。仓库目前仅包含简体中文 PO，因此不会额外打包其他语言或显著增加 APK 体积。

## 验证

- 完整补丁可在最新 `main` 干净应用，差异格式检查通过。
- 默认与简体中文资源均为 26 个键，无缺失、额外或重复项目。
- 两个修改过的 Java 文件共引用 20 个字符串资源，全部能在默认资源中找到。
- 已确认 `localize=true` 为 Gradle 默认配置，测试与正式 Android 工作流均会执行同步任务。
- 本机仅有 Java 25，与项目 Gradle 7.5 不兼容，因此未执行本地 Gradle 构建；按本次安排未单独启动 MSVC/Android 工作流，将由下一次双平台构建验证实际 APK。
