### PR TITLE
完善NPC跟随规则、强盗战斗AI与语音模组接口

### DIFF
--- a/data/json/npcs/npc.json
+++ b/data/json/npcs/npc.json
@@ -28,7 +28,8 @@
       "ignore_noise": true,
       "forbid_engage": false,
       "allow_improvised_throwing": false,
-      "never_flee": true
+      "never_flee": true,
+      "prefer_guns": true
     }
   },
   {
@@ -60,7 +61,8 @@
       "ignore_noise": true,
       "forbid_engage": false,
       "allow_improvised_throwing": false,
-      "never_flee": true
+      "never_flee": true,
+      "prefer_guns": true
     }
   },
   {

--- a/data/json/npcs/npc.json
+++ b/data/json/npcs/npc.json
@@ -8,7 +8,28 @@
     "attitude": 0,
     "mission": 8,
     "chat": "TALK_DONE",
-    "faction": "hells_raiders"
+    "faction": "hells_raiders",
+    "personality": { "aggression": 10, "bravery": 10, "collector": 0, "altruism": -10 },
+    "follower_rules": {
+      "apply_to_all": true,
+      "engagement": "ENGAGE_ALL",
+      "aim": "AIM_WHEN_CONVENIENT",
+      "use_guns": true,
+      "use_grenades": true,
+      "use_silent": false,
+      "avoid_friendly_fire": true,
+      "allow_pick_up": false,
+      "allow_bash": true,
+      "allow_sleep": false,
+      "allow_complain": false,
+      "allow_pulp": false,
+      "close_doors": false,
+      "avoid_doors": false,
+      "ignore_noise": true,
+      "forbid_engage": false,
+      "allow_improvised_throwing": false,
+      "never_flee": true
+    }
   },
   {
     "type": "npc",
@@ -19,7 +40,28 @@
     "attitude": 0,
     "mission": 8,
     "chat": "TALK_DONE",
-    "faction": "hells_raiders"
+    "faction": "hells_raiders",
+    "personality": { "aggression": 10, "bravery": 10, "collector": 0, "altruism": -10 },
+    "follower_rules": {
+      "apply_to_all": true,
+      "engagement": "ENGAGE_ALL",
+      "aim": "AIM_WHEN_CONVENIENT",
+      "use_guns": true,
+      "use_grenades": true,
+      "use_silent": false,
+      "avoid_friendly_fire": true,
+      "allow_pick_up": false,
+      "allow_bash": true,
+      "allow_sleep": false,
+      "allow_complain": false,
+      "allow_pulp": false,
+      "close_doors": false,
+      "avoid_doors": false,
+      "ignore_noise": true,
+      "forbid_engage": false,
+      "allow_improvised_throwing": false,
+      "never_flee": true
+    }
   },
   {
     "type": "npc",

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -151,6 +151,30 @@ Field | Default topic ID  | Uses for...
 NPCs have dialogue depending on the situation.
 This dialogue can be customized in `"type": "npc"` json entries.
 
+For new content, prefer the structured `npc_speech` object.  Every key is the old speech field name with the `snip_` prefix or angle brackets removed.  Unspecified entries keep the normal game text, and snippet tags remain valid.  Unknown keys are reported as JSON errors.
+
+```json
+{
+  "type": "npc",
+  "id": "NPC_EXAMPLE",
+  "class": "NC_EXAMPLE",
+  "attitude": 3,
+  "mission": 0,
+  "chat": "TALK_FRIEND",
+  "faction": "your_followers",
+  "npc_speech": {
+    "hungry": "I need something to eat.",
+    "thirsty": "I need some water.",
+    "let_me_pass": "Excuse me, I need to get through.",
+    "monster_warning": "Watch that",
+    "pickup_item": "Hold on, I want to pick up that %s.",
+    "socialize": "It is good to have a quiet moment together."
+  }
+}
+```
+
+Structured overrides are reapplied from the current NPC template when a save is loaded.  This lets a mod update the voice of an already generated named NPC.  The older top-level fields remain supported for compatibility, but only the structured object receives this live template refresh.
+
 If `npc` has one of the following fields, the NPCs will speak the indicated message or snippet instead of the default message.
 
 All messages can be used with snippets.
@@ -250,6 +274,10 @@ Field | Default messages/snippets | Used for...
 `snip_pulp_zombie` | `Hold on, I want to pulp that %s.` | NPC try to pulp %s.
 `snip_radiation_sickness` | `I'm suffering from radiation sickness…` | NPC are in radiation sickness.
 `snip_wear` | `Thanks, I'll wear that now.` | You gave a clothes or armor and NPC wear it.
+`snip_mutiny` | `<follower_mutiny>  Adios, motherfucker!` | The follower leaves the player's faction because of mistreatment.
+`snip_pickup_item` | `Hold on, I want to pick up that %s.` | A walking follower detours to pick up an item.
+`snip_no_dropoff` | `I don't have anything to drop off.` | The player asks the NPC to unload but they have nothing eligible.
+`snip_socialize` | empty | A line spoken during a socializing activity. Empty keeps the default random `npc_socialize` category.
 
 ### Special Custom Entries
 

--- a/src/dialogue_chatbin.cpp
+++ b/src/dialogue_chatbin.cpp
@@ -51,6 +51,112 @@ void dialogue_chatbin::clear_training()
     dialogue_spell = spell_id();
 }
 
+namespace
+{
+using speech_member = std::string dialogue_chatbin::*;
+
+const std::map<std::string, speech_member> &npc_speech_fields()
+{
+    static const std::map<std::string, speech_member> fields = {
+        { "camp_food_thanks", &dialogue_chatbin::snip_camp_food_thanks },
+        { "camp_larder_empty", &dialogue_chatbin::snip_camp_larder_empty },
+        { "camp_water_thanks", &dialogue_chatbin::snip_camp_water_thanks },
+        { "cant_flee", &dialogue_chatbin::snip_cant_flee },
+        { "close_distance", &dialogue_chatbin::snip_close_distance },
+        { "combat_noise_warning", &dialogue_chatbin::snip_combat_noise_warning },
+        { "danger_close_distance", &dialogue_chatbin::snip_danger_close_distance },
+        { "done_mugging", &dialogue_chatbin::snip_done_mugging },
+        { "far_distance", &dialogue_chatbin::snip_far_distance },
+        { "fire_bad", &dialogue_chatbin::snip_fire_bad },
+        { "fire_in_the_hole_h", &dialogue_chatbin::snip_fire_in_the_hole_h },
+        { "fire_in_the_hole", &dialogue_chatbin::snip_fire_in_the_hole },
+        { "general_danger_h", &dialogue_chatbin::snip_general_danger_h },
+        { "general_danger", &dialogue_chatbin::snip_general_danger },
+        { "heal_self", &dialogue_chatbin::snip_heal_self },
+        { "hungry", &dialogue_chatbin::snip_hungry },
+        { "im_leaving_you", &dialogue_chatbin::snip_im_leaving_you },
+        { "its_safe_h", &dialogue_chatbin::snip_its_safe_h },
+        { "its_safe", &dialogue_chatbin::snip_its_safe },
+        { "keep_up", &dialogue_chatbin::snip_keep_up },
+        { "kill_npc_h", &dialogue_chatbin::snip_kill_npc_h },
+        { "kill_npc", &dialogue_chatbin::snip_kill_npc },
+        { "kill_player_h", &dialogue_chatbin::snip_kill_player_h },
+        { "let_me_pass", &dialogue_chatbin::snip_let_me_pass },
+        { "lets_talk", &dialogue_chatbin::snip_lets_talk },
+        { "medium_distance", &dialogue_chatbin::snip_medium_distance },
+        { "monster_warning_h", &dialogue_chatbin::snip_monster_warning_h },
+        { "monster_warning", &dialogue_chatbin::snip_monster_warning },
+        { "movement_noise_warning", &dialogue_chatbin::snip_movement_noise_warning },
+        { "need_batteries", &dialogue_chatbin::snip_need_batteries },
+        { "need_booze", &dialogue_chatbin::snip_need_booze },
+        { "need_fuel", &dialogue_chatbin::snip_need_fuel },
+        { "no_to_thorazine", &dialogue_chatbin::snip_no_to_thorazine },
+        { "run_away", &dialogue_chatbin::snip_run_away },
+        { "speech_warning", &dialogue_chatbin::snip_speech_warning },
+        { "thirsty", &dialogue_chatbin::snip_thirsty },
+        { "wait", &dialogue_chatbin::snip_wait },
+        { "warn_sleep", &dialogue_chatbin::snip_warn_sleep },
+        { "yawn", &dialogue_chatbin::snip_yawn },
+        { "yes_to_lsd", &dialogue_chatbin::snip_yes_to_lsd },
+        { "mug_dontmove", &dialogue_chatbin::snip_mug_dontmove },
+        { "lost_blood", &dialogue_chatbin::snip_lost_blood },
+        { "pulp_zombie", &dialogue_chatbin::snip_pulp_zombie },
+        { "heal_player", &dialogue_chatbin::snip_heal_player },
+        { "wound_infected", &dialogue_chatbin::snip_wound_infected },
+        { "wound_bite", &dialogue_chatbin::snip_wound_bite },
+        { "bleeding", &dialogue_chatbin::snip_bleeding },
+        { "bleeding_badly", &dialogue_chatbin::snip_bleeding_badly },
+        { "radiation_sickness", &dialogue_chatbin::snip_radiation_sickness },
+        { "acknowledged", &dialogue_chatbin::snip_acknowledged },
+        { "bye", &dialogue_chatbin::snip_bye },
+        { "consume_cant_accept", &dialogue_chatbin::snip_consume_cant_accept },
+        { "consume_cant_consume", &dialogue_chatbin::snip_consume_cant_consume },
+        { "consume_rotten", &dialogue_chatbin::snip_consume_rotten },
+        { "consume_eat", &dialogue_chatbin::snip_consume_eat },
+        { "consume_need_item", &dialogue_chatbin::snip_consume_need_item },
+        { "consume_med", &dialogue_chatbin::snip_consume_med },
+        { "consume_nocharge", &dialogue_chatbin::snip_consume_nocharge },
+        { "consume_use_med", &dialogue_chatbin::snip_consume_use_med },
+        { "give_nope", &dialogue_chatbin::snip_give_nope },
+        { "give_to_hallucination", &dialogue_chatbin::snip_give_to_hallucination },
+        { "give_cancel", &dialogue_chatbin::snip_give_cancel },
+        { "give_dangerous", &dialogue_chatbin::snip_give_dangerous },
+        { "give_wield", &dialogue_chatbin::snip_give_wield },
+        { "give_weapon_weak", &dialogue_chatbin::snip_give_weapon_weak },
+        { "give_carry", &dialogue_chatbin::snip_give_carry },
+        { "give_carry_cant", &dialogue_chatbin::snip_give_carry_cant },
+        { "give_carry_cant_few_space", &dialogue_chatbin::snip_give_carry_cant_few_space },
+        { "give_carry_cant_no_space", &dialogue_chatbin::snip_give_carry_cant_no_space },
+        { "give_carry_too_heavy", &dialogue_chatbin::snip_give_carry_too_heavy },
+        { "wear", &dialogue_chatbin::snip_wear },
+        { "mutiny", &dialogue_chatbin::snip_mutiny },
+        { "pickup_item", &dialogue_chatbin::snip_pickup_item },
+        { "no_dropoff", &dialogue_chatbin::snip_no_dropoff },
+        { "socialize", &dialogue_chatbin::snip_socialize },
+    };
+    return fields;
+}
+} // namespace
+
+bool dialogue_chatbin::set_speech_override( const std::string &key, const std::string &value )
+{
+    const auto &fields = npc_speech_fields();
+    const auto found = fields.find( key );
+    if( found == fields.end() ) {
+        return false;
+    }
+    this->*( found->second ) = value;
+    return true;
+}
+
+void dialogue_chatbin::apply_speech_overrides(
+    const std::map<std::string, std::string> &overrides )
+{
+    for( const auto &entry : overrides ) {
+        set_speech_override( entry.first, entry.second );
+    }
+}
+
 void dialogue_chatbin::clear_all()
 {
     clear_training();

--- a/src/dialogue_chatbin.h
+++ b/src/dialogue_chatbin.h
@@ -3,6 +3,8 @@
 #define CATA_SRC_DIALOGUE_CHATBIN_H
 
 #include <iosfwd>
+#include <map>
+#include <string>
 #include <vector>
 
 #include "translations.h"
@@ -149,11 +151,23 @@ struct dialogue_chatbin {
     // talk from npc.cpp(can use snippets in json)
     std::string snip_wear = _( "Thanks, I'll wear that now." );
 
+    // NPC AI speech that was historically hardcoded and could not be customized by mods.
+    std::string snip_mutiny = _( "<follower_mutiny>  Adios, motherfucker!" );
+    std::string snip_pickup_item = _( "Hold on, I want to pick up that %s." );
+    std::string snip_no_dropoff = _( "I don't have anything to drop off." );
+    // Empty keeps the legacy random npc_socialize snippet category.
+    std::string snip_socialize;
+
     dialogue_chatbin() = default;
 
     void clear_all();
     void serialize( JsonOut &json ) const;
     void deserialize( const JsonObject &data );
+
+    // Set one entry from the structured NPC template "npc_speech" object.
+    // Returns false for an unknown key so JSON loaders can report typos.
+    bool set_speech_override( const std::string &key, const std::string &value );
+    void apply_speech_overrides( const std::map<std::string, std::string> &overrides );
 };
 
 #endif // CATA_SRC_DIALOGUE_CHATBIN_H

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3969,6 +3969,7 @@ void npc_follower_rules::load_from_template( const JsonObject &data )
     data.read( "apply_to_all", apply_to_all );
     data.read( "allow_improvised_throwing", allow_improvised_throwing );
     data.read( "never_flee", never_flee );
+    data.read( "prefer_guns", prefer_guns );
 
     for( const auto &rule : ally_rule_strs ) {
         if( !data.has_bool( rule.first ) ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -328,6 +328,10 @@ void npc_template::load( const JsonObject &jsobj )
         guy.set_fac_id( jsobj.get_string( "faction" ) );
     }
 
+    if( jsobj.has_object( "follower_rules" ) ) {
+        guy.rules.load_from_template( jsobj.get_object( "follower_rules" ) );
+    }
+
     if( jsobj.has_int( "class" ) ) {
         guy.myclass = npc_class::from_legacy_int( jsobj.get_int( "class" ) );
     } else if( jsobj.has_string( "class" ) ) {
@@ -690,6 +694,7 @@ void npc::load_npc_template( const string_id<npc_template> &ident )
     idz = tguy.idz;
     myclass = npc_class_id( tguy.myclass );
     randomize( myclass );
+    rules = tguy.rules;
     if( tem.personality.has_value() ) {
         personality = *tem.personality;
         refresh_personality_traits();
@@ -1005,8 +1010,9 @@ void npc::select_best_martial_art( bool announce )
 {
     item_location wielded = get_wielded_item();
     item &weapon = wielded ? *wielded : null_item_reference();
-    const bool can_use_gun = !is_player_ally() || rules.has_flag( ally_rule::use_guns );
-    const bool use_silent = is_player_ally() && rules.has_flag( ally_rule::use_silent );
+    const bool use_rules = uses_follower_rules();
+    const bool can_use_gun = !use_rules || rules.has_flag( ally_rule::use_guns );
+    const bool use_silent = use_rules && rules.has_flag( ally_rule::use_silent );
 
     const matype_id starting_style = martial_arts_data->selected_style();
     matype_id best_style = starting_style;
@@ -2649,6 +2655,11 @@ bool npc::is_player_ally() const
     return is_ally( get_player_character() );
 }
 
+bool npc::uses_follower_rules() const
+{
+    return rules.apply_to_all || is_player_ally() || is_following();
+}
+
 bool npc::is_friendly( const Character &p ) const
 {
     return is_ally( p ) || ( p.is_avatar() && ( is_walking_with() || is_player_ally() ) );
@@ -2836,7 +2847,8 @@ void npc::npc_dismount()
 
 int npc::smash_ability() const
 {
-    if( !is_hallucination() && ( !is_player_ally() || rules.has_flag( ally_rule::allow_bash ) ) ) {
+    if( !is_hallucination() && ( !uses_follower_rules() ||
+                                 rules.has_flag( ally_rule::allow_bash ) ) ) {
         ///\EFFECT_STR_NPC increases smash ability
         int dmg = get_wielded_item() ? get_wielded_item()->damage_melee( damage_type::BASH ) : 0;
         return str_cur + dmg;
@@ -3863,6 +3875,14 @@ npc_attitude npc::get_attitude() const
 
 void npc::set_attitude( npc_attitude new_attitude )
 {
+    if( rules.never_flee && ( new_attitude == NPCATT_FLEE ||
+                              new_attitude == NPCATT_FLEE_TEMP ) ) {
+        if( get_attitude_group( attitude ) == attitude_group::hostile || guaranteed_hostile() ) {
+            new_attitude = NPCATT_KILL;
+        } else {
+            return;
+        }
+    }
     if( new_attitude == attitude ) {
         return;
     }
@@ -3922,6 +3942,44 @@ npc_follower_rules::npc_follower_rules()
     clear_flag( ally_rule::ignore_noise );
     clear_flag( ally_rule::forbid_engage );
     set_flag( ally_rule::follow_distance_2 );
+}
+
+template<typename T>
+static void load_npc_rule_enum( const JsonObject &data, const char *member,
+                                const std::unordered_map<std::string, T> &values, T &target )
+{
+    if( !data.has_string( member ) ) {
+        return;
+    }
+    const std::string value = data.get_string( member );
+    const auto found = values.find( value );
+    if( found == values.end() ) {
+        data.throw_error_at( member, string_format( "invalid NPC rule value: %s", value ) );
+    }
+    target = found->second;
+}
+
+void npc_follower_rules::load_from_template( const JsonObject &data )
+{
+    load_npc_rule_enum( data, "engagement", combat_engagement_strs, engagement );
+    load_npc_rule_enum( data, "aim", aim_rule_strs, aim );
+    load_npc_rule_enum( data, "cbm_recharge", cbm_recharge_strs, cbm_recharge );
+    load_npc_rule_enum( data, "cbm_reserve", cbm_reserve_strs, cbm_reserve );
+
+    data.read( "apply_to_all", apply_to_all );
+    data.read( "allow_improvised_throwing", allow_improvised_throwing );
+    data.read( "never_flee", never_flee );
+
+    for( const auto &rule : ally_rule_strs ) {
+        if( !data.has_bool( rule.first ) ) {
+            continue;
+        }
+        if( data.get_bool( rule.first ) ) {
+            set_flag( rule.second.rule );
+        } else {
+            clear_flag( rule.second.rule );
+        }
+    }
 }
 
 bool npc_follower_rules::has_flag( ally_rule test, bool check_override ) const

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -606,6 +606,32 @@ void npc_template::load( const JsonObject &jsobj )
     if( jsobj.has_string( "snip_wear" ) ) {
         guy.chatbin.snip_wear = jsobj.get_string( "snip_wear" );
     }
+    if( jsobj.has_string( "snip_mutiny" ) ) {
+        guy.chatbin.snip_mutiny = jsobj.get_string( "snip_mutiny" );
+    }
+    if( jsobj.has_string( "snip_pickup_item" ) ) {
+        guy.chatbin.snip_pickup_item = jsobj.get_string( "snip_pickup_item" );
+    }
+    if( jsobj.has_string( "snip_no_dropoff" ) ) {
+        guy.chatbin.snip_no_dropoff = jsobj.get_string( "snip_no_dropoff" );
+    }
+    if( jsobj.has_string( "snip_socialize" ) ) {
+        guy.chatbin.snip_socialize = jsobj.get_string( "snip_socialize" );
+    }
+
+    if( jsobj.has_object( "npc_speech" ) ) {
+        for( const JsonMember member : jsobj.get_object( "npc_speech" ) ) {
+            if( member.is_comment() ) {
+                continue;
+            }
+            const std::string key = member.name();
+            const std::string value = member.get_string();
+            if( !guy.chatbin.set_speech_override( key, value ) ) {
+                member.throw_error( string_format( "unknown NPC speech key '%s'", key ) );
+            }
+            tem.speech_overrides[key] = value;
+        }
+    }
     if( jsobj.has_int( "age" ) ) {
         guy.set_base_age( jsobj.get_int( "age" ) );
     }
@@ -798,6 +824,10 @@ void npc::load_npc_template( const string_id<npc_template> &ident )
     chatbin.snip_give_carry_cant_no_space = tguy.chatbin.snip_give_carry_cant_no_space;
     chatbin.snip_give_carry_too_heavy = tguy.chatbin.snip_give_carry_too_heavy;
     chatbin.snip_wear = tguy.chatbin.snip_wear;
+    chatbin.snip_mutiny = tguy.chatbin.snip_mutiny;
+    chatbin.snip_pickup_item = tguy.chatbin.snip_pickup_item;
+    chatbin.snip_no_dropoff = tguy.chatbin.snip_no_dropoff;
+    chatbin.snip_socialize = tguy.chatbin.snip_socialize;
 
     set_base_age( tguy.base_age() );
     set_base_height( tguy.base_height() );
@@ -1905,7 +1935,7 @@ void npc::mutiny()
     }
     chatbin.first_topic = chatbin.talk_stranger_neutral;
     set_attitude( NPCATT_NULL );
-    say( _( "<follower_mutiny>  Adios, motherfucker!" ), sounds::sound_t::order );
+    say( _( chatbin.snip_mutiny ), sounds::sound_t::order );
     if( seen ) {
         my_fac->known_by_u = true;
     }

--- a/src/npc.h
+++ b/src/npc.h
@@ -487,6 +487,8 @@ struct npc_follower_rules {
     bool allow_improvised_throwing = true;
     // Ignore morale-based retreat while still avoiding fire, explosions and vehicles.
     bool never_flee = false;
+    // Prefer a usable firearm over melee attacks, while retaining melee as a fallback.
+    bool prefer_guns = false;
     ally_rule flags = ally_rule::DEFAULT; // NOLINT(cata-serialize)
     ally_rule override_enable = ally_rule::DEFAULT; // NOLINT(cata-serialize)
     ally_rule overrides = ally_rule::DEFAULT; // NOLINT(cata-serialize)

--- a/src/npc.h
+++ b/src/npc.h
@@ -1459,6 +1459,7 @@ class npc_template
         std::vector<matype_id> martial_arts;
         std::optional<matype_id> selected_martial_art;
         std::optional<npc_personality> personality;
+        std::map<std::string, std::string> speech_overrides;
         enum class gender : int {
             random,
             male,

--- a/src/npc.h
+++ b/src/npc.h
@@ -480,6 +480,13 @@ struct npc_follower_rules {
     aim_rule aim = aim_rule::WHEN_CONVENIENT;
     cbm_recharge_rule cbm_recharge = cbm_recharge_rule::CBM_RECHARGE_SOME;
     cbm_reserve_rule cbm_reserve = cbm_reserve_rule::CBM_RESERVE_SOME;
+    // Apply these rules even when the NPC is not formally in the player's faction.
+    // This is useful for temporary followers and JSON-defined hostile NPC profiles.
+    bool apply_to_all = false;
+    // Permit throwing ordinary inventory items as improvised weapons.
+    bool allow_improvised_throwing = true;
+    // Ignore morale-based retreat while still avoiding fire, explosions and vehicles.
+    bool never_flee = false;
     ally_rule flags = ally_rule::DEFAULT; // NOLINT(cata-serialize)
     ally_rule override_enable = ally_rule::DEFAULT; // NOLINT(cata-serialize)
     ally_rule overrides = ally_rule::DEFAULT; // NOLINT(cata-serialize)
@@ -490,6 +497,7 @@ struct npc_follower_rules {
 
     void serialize( JsonOut &json ) const;
     void deserialize( const JsonObject &data );
+    void load_from_template( const JsonObject &data );
 
     bool has_flag( ally_rule test, bool check_override = true ) const;
     void set_flag( ally_rule setit );
@@ -895,6 +903,8 @@ class npc : public Character
         bool is_ally( const Character &p ) const;
         // Is an ally of the player
         bool is_player_ally() const;
+        // Whether follower-rule settings should control this NPC in its current state.
+        bool uses_follower_rules() const;
         // Isn't moving
         bool is_stationary( bool include_guards = true ) const;
         // Has a guard mission

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -573,7 +573,7 @@ bool npc_attack_activate_item::can_use( const npc &source ) const
         //TODO: make this more complete. only does BOMB type items
         return false;
     }
-    const bool can_use_grenades = !source.is_hallucination() && ( !source.is_player_ally() ||
+    const bool can_use_grenades = !source.is_hallucination() && ( !source.uses_follower_rules() ||
                                   source.rules.has_flag( ally_rule::use_grenades ) );
     return can_use_grenades;
 }
@@ -659,7 +659,7 @@ bool npc_attack_throw::can_use( const npc &source ) const
         return true;
     }
 
-    if( source.is_player_ally() && !source.rules.has_flag( ally_rule::use_guns ) ) {
+    if( source.uses_follower_rules() && !source.rules.has_flag( ally_rule::use_guns ) ) {
         return false;
     }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -175,6 +175,7 @@ enum npc_action : int {
     npc_noop,
     npc_reach_attack,
     npc_do_attack,
+    npc_pursue_target,
     npc_aim,
     npc_investigate_sound,
     npc_return_to_guard_pos,
@@ -615,6 +616,11 @@ void npc::assess_danger()
             float priority = std::max( foe_threat - 2.0f * ( scaled_distance - 1 ),
                                        is_too_close ? std::max( foe_threat, NPC_DANGER_VERY_LOW ) :
                                        0.0f );
+            // JSON-defined hostile profiles using ENGAGE_ALL should actively pursue
+            // visible enemies instead of dropping them when distance lowers threat priority.
+            if( rules.apply_to_all && rules.engagement == combat_engagement::ALL && is_enemy() ) {
+                priority = std::max( priority, NPC_DANGER_VERY_LOW );
+            }
             cur_threat_map[direction_from( pos(), foe.pos() )] += priority;
             if( priority > highest_priority ) {
                 warn_about( warning, 1_minutes );
@@ -1090,6 +1096,18 @@ void npc::execute_action( npc_action action )
             ai_cache.current_attack.reset();
             ai_cache.current_attack_evaluation = npc_attack_rating{};
             break;
+        case npc_pursue_target:
+            if( cur != nullptr ) {
+                update_path( cur->pos() );
+                if( !path.empty() ) {
+                    move_to_next();
+                } else {
+                    move_pause();
+                }
+            } else {
+                move_pause();
+            }
+            break;
         case npc_pause:
             move_pause();
             break;
@@ -1532,10 +1550,13 @@ npc_action npc::method_of_attack()
     std::optional<int> potential = ai_cache.current_attack_evaluation.value();
     if( potential && *potential > 0 ) {
         return npc_do_attack;
-    } else {
-        add_msg_debug( debugmode::debug_filter::DF_NPC, "%s can't figure out what to do", disp_name() );
-        return npc_undecided;
     }
+    if( rules.apply_to_all && rules.engagement == combat_engagement::ALL && is_enemy() &&
+        critter != nullptr && sees( *critter ) ) {
+        return npc_pursue_target;
+    }
+    add_msg_debug( debugmode::debug_filter::DF_NPC, "%s can't figure out what to do", disp_name() );
+    return npc_undecided;
 }
 
 void npc::evaluate_best_attack( const Creature *target )
@@ -4432,6 +4453,8 @@ std::string npc_action_name( npc_action action )
             return "Do nothing";
         case npc_do_attack:
             return "Attack";
+        case npc_pursue_target:
+            return "Pursue target";
         case npc_goto_to_this_pos:
             return "Go to position";
         case num_npc_actions:

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -422,7 +422,7 @@ void npc::assess_danger()
                               !too_close( pos(), player_character.pos(), follow_distance() ) &&
                               !is_guarding();
 
-    if( is_player_ally() ) {
+    if( uses_follower_rules() ) {
         if( rules.engagement == combat_engagement::FREE_FIRE ) {
             def_radius = std::max( 6, max_range );
         } else if( self_defense_only ) {
@@ -563,7 +563,8 @@ void npc::assess_danger()
             }
         }
         // ignore distant monsters that our rules prevent us from attacking
-        if( !is_too_close && is_player_ally() && !ok_by_rules( critter, dist, scaled_distance ) ) {
+        if( !is_too_close && uses_follower_rules() &&
+            !ok_by_rules( critter, dist, scaled_distance ) ) {
             continue;
         }
         // prioritize the biggest, nearest threats, or the biggest threats that are threatening
@@ -610,7 +611,7 @@ void npc::assess_danger()
             }
         }
 
-        if( !is_player_ally() || is_too_close || ok_by_rules( foe, dist, scaled_distance ) ) {
+        if( !uses_follower_rules() || is_too_close || ok_by_rules( foe, dist, scaled_distance ) ) {
             float priority = std::max( foe_threat - 2.0f * ( scaled_distance - 1 ),
                                        is_too_close ? std::max( foe_threat, NPC_DANGER_VERY_LOW ) :
                                        0.0f );
@@ -656,7 +657,8 @@ void npc::assess_danger()
         }
     }
     assessment *= 0.1f;
-    if( !has_effect( effect_npc_run_away ) && !has_effect( effect_npc_fire_bad ) ) {
+    if( !rules.never_flee && !has_effect( effect_npc_run_away ) &&
+        !has_effect( effect_npc_fire_bad ) ) {
         float my_diff = evaluate_enemy( *this );
         if( ( my_diff * 0.5f + personality.bravery + rng( 0, 10 ) ) < assessment ) {
             time_duration run_away_for = 5_turns + 1_turns * rng( 0, 5 );
@@ -782,7 +784,16 @@ void npc::move()
     // don't just return from this function without doing something
     // that will eventually subtract moves, or change the NPC to a different type of action.
     // because this will result in an infinite loop
-    if( attitude == NPCATT_FLEE ) {
+    if( rules.never_flee && has_effect( effect_npc_run_away ) ) {
+        remove_effect( effect_npc_run_away );
+    }
+    if( rules.never_flee && ( attitude == NPCATT_FLEE || attitude == NPCATT_FLEE_TEMP ) ) {
+        npc_attitude restored_attitude = guaranteed_hostile() ? NPCATT_KILL : previous_attitude;
+        if( get_attitude_group( restored_attitude ) == attitude_group::fearful ) {
+            restored_attitude = NPCATT_NULL;
+        }
+        set_attitude( restored_attitude );
+    } else if( attitude == NPCATT_FLEE ) {
         set_attitude( NPCATT_FLEE_TEMP );  // Only run for so many hours
     } else if( attitude == NPCATT_FLEE_TEMP && !has_effect( effect_npc_flee_player ) ) {
         set_attitude( NPCATT_NULL );
@@ -1546,7 +1557,10 @@ void npc::evaluate_best_attack( const Creature *target )
     visit_items( [&compare, &ups_charges, this]( item * it, item * ) {
         // you can theoretically melee with anything.
         compare( std::make_shared<npc_attack_melee>( *it ) );
-        if( !is_wielding( *it ) || !it->has_flag( flag_NO_UNWIELD ) ) {
+        const bool dedicated_throwing_item = it->has_flag( flag_NPC_THROW_NOW ) ||
+                                             it->has_flag( flag_NPC_THROWN );
+        if( ( rules.allow_improvised_throwing || dedicated_throwing_item ) &&
+            ( !is_wielding( *it ) || !it->has_flag( flag_NO_UNWIELD ) ) ) {
             compare( std::make_shared<npc_attack_throw>( *it ) );
         }
         if( !it->type->use_methods.empty() ) {
@@ -1556,7 +1570,7 @@ void npc::evaluate_best_attack( const Creature *target )
             for( const std::pair<const gun_mode_id, gun_mode> &mode : it->gun_all_modes() ) {
                 if( !( mode.second.melee() || mode.second.flags.count( "NPC_AVOID" ) ||
                        !can_use( *mode.second.target ) || mode.second->get_gun_ups_drain() > ups_charges ||
-                       ( rules.has_flag( ally_rule::use_silent ) && is_player_ally() &&
+                       ( rules.has_flag( ally_rule::use_silent ) && uses_follower_rules() &&
                          !mode.second->is_silent() ) ) ) {
                     if( it->ammo_sufficient( this ) || can_reload_current() ) {
                         compare( std::make_shared<npc_attack_gun>( *it, mode.second ) );
@@ -2018,7 +2032,7 @@ npc_action npc::address_needs( float danger )
     };
     // TODO: More risky attempts at sleep when exhausted
     if( one_in( 3 ) && could_sleep() ) {
-        if( !is_player_ally() ) {
+        if( !uses_follower_rules() ) {
             // TODO: Make tired NPCs handle sleep offscreen
             set_fatigue( 0 );
             return npc_undecided;
@@ -2125,7 +2139,7 @@ npc_action npc::long_term_goal_action()
 
 double npc::confidence_mult() const
 {
-    if( !is_player_ally() ) {
+    if( !uses_follower_rules() ) {
         return 1.0f;
     }
 
@@ -2564,7 +2578,8 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
         }
 
         // Close doors behind self (if you can)
-        if( ( rules.has_flag( ally_rule::close_doors ) && is_player_ally() ) && !is_hallucination() ) {
+        if( rules.has_flag( ally_rule::close_doors ) && uses_follower_rules() &&
+            !is_hallucination() ) {
             doors::close_door( here, *this, old_pos );
         }
 
@@ -2919,8 +2934,7 @@ void npc::find_item()
         return;
     }
 
-    if( ( is_player_ally() || is_following() ) &&
-        !rules.has_flag( ally_rule::allow_pick_up ) ) {
+    if( uses_follower_rules() && !rules.has_flag( ally_rule::allow_pick_up ) ) {
         // Grabbing stuff not allowed by our "owner"
         return;
     }
@@ -3089,8 +3103,7 @@ void npc::pick_up_item()
         return;
     }
 
-    if( !rules.has_flag( ally_rule::allow_pick_up ) &&
-        ( is_player_ally() || is_following() ) ) {
+    if( !rules.has_flag( ally_rule::allow_pick_up ) && uses_follower_rules() ) {
         add_msg_debug( debugmode::DF_NPC, "%s::pick_up_item(); Canceling on player's request", get_name() );
         fetching_item = false;
         moves -= 1;
@@ -3215,7 +3228,7 @@ std::list<item> npc::pick_up_item_vehicle( vehicle &veh, int part_index )
 bool npc::find_corpse_to_pulp()
 {
     Character &player_character = get_player_character();
-    if( ( is_player_ally() && ( !rules.has_flag( ally_rule::allow_pulp ) ||
+    if( ( uses_follower_rules() && ( !rules.has_flag( ally_rule::allow_pulp ) ||
                                 player_character.in_vehicle ) ) ||
         is_hallucination() ) {
         return false;
@@ -3383,8 +3396,9 @@ double npc::evaluate_weapon(item& maybe_weapon, bool can_use_gun, bool use_silen
 
 item* npc::evaluate_best_weapon() const
 {
-    bool can_use_gun = !is_player_ally() || rules.has_flag(ally_rule::use_guns);
-    bool use_silent = is_player_ally() && rules.has_flag(ally_rule::use_silent);
+    const bool use_rules = uses_follower_rules();
+    bool can_use_gun = !use_rules || rules.has_flag( ally_rule::use_guns );
+    bool use_silent = use_rules && rules.has_flag( ally_rule::use_silent );
 
     item_location weapon = get_wielded_item();
     item& weap = weapon ? *weapon : null_item_reference();
@@ -3432,8 +3446,9 @@ item* npc::evaluate_best_weapon() const
 bool npc::wield_better_weapon()
 {
     // These are also assigned here so npc::evaluate_best_weapon() can be called by itself
-    bool can_use_gun = !is_player_ally() || rules.has_flag(ally_rule::use_guns);
-    bool use_silent = is_player_ally() && rules.has_flag(ally_rule::use_silent);
+    const bool use_rules = uses_follower_rules();
+    bool can_use_gun = !use_rules || rules.has_flag( ally_rule::use_guns );
+    bool use_silent = use_rules && rules.has_flag( ally_rule::use_silent );
 
     item_location weapon = get_wielded_item();
     item& weap = weapon ? *weapon : null_item_reference();
@@ -3496,7 +3511,8 @@ static void npc_throw( npc &np, item &it, const tripoint &pos )
 
 bool npc::alt_attack()
 {
-    if( ( is_player_ally() && !rules.has_flag( ally_rule::use_grenades ) ) || is_hallucination() ) {
+    if( ( uses_follower_rules() && !rules.has_flag( ally_rule::use_grenades ) ) ||
+        is_hallucination() ) {
         return false;
     }
 
@@ -4566,7 +4582,7 @@ bool npc::complain()
     static const std::string hunger_string = "hunger";
     static const std::string thirst_string = "thirst";
 
-    if( !is_player_ally() || !get_player_view().sees( *this ) ) {
+    if( !uses_follower_rules() || !get_player_view().sees( *this ) ) {
         return false;
     }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1542,6 +1542,8 @@ void npc::evaluate_best_attack( const Creature *target )
 {
     std::shared_ptr<npc_attack> best_attack;
     npc_attack_rating best_evaluated_attack;
+    std::shared_ptr<npc_attack> best_gun_attack;
+    npc_attack_rating best_evaluated_gun_attack;
     const auto compare = [&best_attack, &best_evaluated_attack, this, &target]
     ( const std::shared_ptr<npc_attack> &potential_attack ) {
         const npc_attack_rating evaluated = potential_attack->evaluate( *this, target );
@@ -1549,14 +1551,25 @@ void npc::evaluate_best_attack( const Creature *target )
             best_attack = potential_attack;
             best_evaluated_attack = evaluated;
         }
+        return evaluated;
+    };
+    const auto compare_gun = [&best_gun_attack, &best_evaluated_gun_attack, &compare]
+    ( const std::shared_ptr<npc_attack> &potential_attack ) {
+        const npc_attack_rating evaluated = compare( potential_attack );
+        if( evaluated > best_evaluated_gun_attack ) {
+            best_gun_attack = potential_attack;
+            best_evaluated_gun_attack = evaluated;
+        }
     };
 
     // punching things is always available
     compare( std::make_shared<npc_attack_melee>( null_item_reference() ) );
     const units::energy ups_charges = available_ups();
-    visit_items( [&compare, &ups_charges, this]( item * it, item * ) {
-        // you can theoretically melee with anything.
-        compare( std::make_shared<npc_attack_melee>( *it ) );
+    visit_items( [&compare, &compare_gun, &ups_charges, this]( item * it, item * ) {
+        // Do not turn worn clothing and armor into improvised melee weapons.
+        if( !it->is_armor() || is_wielding( *it ) ) {
+            compare( std::make_shared<npc_attack_melee>( *it ) );
+        }
         const bool dedicated_throwing_item = it->has_flag( flag_NPC_THROW_NOW ) ||
                                              it->has_flag( flag_NPC_THROWN );
         if( ( rules.allow_improvised_throwing || dedicated_throwing_item ) &&
@@ -1573,7 +1586,7 @@ void npc::evaluate_best_attack( const Creature *target )
                        ( rules.has_flag( ally_rule::use_silent ) && uses_follower_rules() &&
                          !mode.second->is_silent() ) ) ) {
                     if( it->ammo_sufficient( this ) || can_reload_current() ) {
-                        compare( std::make_shared<npc_attack_gun>( *it, mode.second ) );
+                        compare_gun( std::make_shared<npc_attack_gun>( *it, mode.second ) );
                     } else {
                         compare( std::make_shared<npc_attack_melee>( *it ) );
                     }
@@ -1584,6 +1597,11 @@ void npc::evaluate_best_attack( const Creature *target )
     } );
     for( const spell_id &sp : magic->spells() ) {
         compare( std::make_shared<npc_attack_spell>( sp ) );
+    }
+
+    if( rules.prefer_guns && best_evaluated_gun_attack > 0 ) {
+        best_attack = best_gun_attack;
+        best_evaluated_attack = best_evaluated_gun_attack;
     }
 
     ai_cache.current_attack = best_attack;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3132,7 +3132,7 @@ void npc::find_item()
     }
 
     if( fetching_item && rl_dist( wanted_item_pos, pos() ) > 1 && is_walking_with() ) {
-        say( _( "Hold on, I want to pick up that %s." ), wanted_name );
+        say( string_format( _( chatbin.snip_pickup_item ), wanted_name ) );
     }
 }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2919,7 +2919,8 @@ void npc::find_item()
         return;
     }
 
-    if( is_player_ally() && !rules.has_flag( ally_rule::allow_pick_up ) ) {
+    if( ( is_player_ally() || is_following() ) &&
+        !rules.has_flag( ally_rule::allow_pick_up ) ) {
         // Grabbing stuff not allowed by our "owner"
         return;
     }
@@ -2991,7 +2992,8 @@ void npc::find_item()
     for( const tripoint &p : closest_points_first( pos(), range ) ) {
         // TODO: Make this sight check not overdraw nearby tiles
         // TODO: Optimize that zone check
-        if( is_player_ally() && g->check_zone( zone_type_NO_NPC_PICKUP, p ) ) {
+        if( ( is_player_ally() || is_following() ) &&
+            g->check_zone( zone_type_NO_NPC_PICKUP, p ) ) {
             continue;
         }
 
@@ -3087,7 +3089,8 @@ void npc::pick_up_item()
         return;
     }
 
-    if( !rules.has_flag( ally_rule::allow_pick_up ) && is_player_ally() ) {
+    if( !rules.has_flag( ally_rule::allow_pick_up ) &&
+        ( is_player_ally() || is_following() ) ) {
         add_msg_debug( debugmode::DF_NPC, "%s::pick_up_item(); Canceling on player's request", get_name() );
         fetching_item = false;
         moves -= 1;
@@ -3101,7 +3104,8 @@ void npc::pick_up_item()
 
     if( ( !here.has_items( wanted_item_pos ) && !has_cargo &&
           !here.is_harvestable( wanted_item_pos ) && sees( wanted_item_pos ) ) ||
-        ( is_player_ally() && g->check_zone( zone_type_NO_NPC_PICKUP, wanted_item_pos ) ) ) {
+        ( ( is_player_ally() || is_following() ) &&
+          g->check_zone( zone_type_NO_NPC_PICKUP, wanted_item_pos ) ) ) {
         // Items we wanted no longer exist and we can see it
         // Or player who is leading us doesn't want us to pick it up
         fetching_item = false;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6090,7 +6090,7 @@ std::string const &npc::get_specified_talk_topic( std::string const &topic_id )
 
 bool npc::has_item_whitelist() const
 {
-    return is_player_ally() && !rules.pickup_whitelist->empty();
+    return ( is_player_ally() || is_following() ) && !rules.pickup_whitelist->empty();
 }
 
 bool npc::item_name_whitelisted( const std::string &to_match )

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -1510,7 +1510,11 @@ void talk_function::morale_chat_activity( npc &p )
     player_character.assign_activity( ACT_SOCIALIZE, moves );
     player_character.activity.str_values.push_back( p.get_name() );
     if( one_in( 3 ) ) {
-        p.say( SNIPPET.random_from_category( "npc_socialize" ).value_or( translation() ).translated() );
+        if( p.chatbin.snip_socialize.empty() ) {
+            p.say( SNIPPET.random_from_category( "npc_socialize" ).value_or( translation() ).translated() );
+        } else {
+            p.say( _( p.chatbin.snip_socialize ) );
+        }
     }
     add_msg( m_good, _( "That was a pleasant conversation with %s." ), p.disp_name() );
     player_character.add_morale( MORALE_CHAT, rng( 3, 10 ), 10, 200_minutes, 5_minutes / 2 );
@@ -1535,9 +1539,9 @@ void talk_function::drop_items_in_place( npc &p )
         p.assign_activity( player_activity( drop_activity_actor(
                                                 to_drop, tripoint_zero, false
                                             ) ) );
-        p.say( "<acknowledged>" );
+        p.say( p.chatbin.snip_acknowledged );
     } else {
-        p.say( _( "I don't have anything to drop off." ) );
+        p.say( _( p.chatbin.snip_no_dropoff ) );
     }
 }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1811,6 +1811,9 @@ void npc_follower_rules::serialize( JsonOut &json ) const
     json.member( "aim", static_cast<int>( aim ) );
     json.member( "cbm_reserve", static_cast<int>( cbm_reserve ) );
     json.member( "cbm_recharge", static_cast<int>( cbm_recharge ) );
+    json.member( "apply_to_all", apply_to_all );
+    json.member( "allow_improvised_throwing", allow_improvised_throwing );
+    json.member( "never_flee", never_flee );
 
     // serialize the flags so they can be changed between save games
     for( const auto &rule : ally_rule_strs ) {
@@ -1843,6 +1846,9 @@ void npc_follower_rules::deserialize( const JsonObject &data )
     int tmprecharge = 50;
     data.read( "cbm_recharge", tmprecharge );
     cbm_recharge = static_cast<cbm_recharge_rule>( tmprecharge );
+    data.read( "apply_to_all", apply_to_all );
+    data.read( "allow_improvised_throwing", allow_improvised_throwing );
+    data.read( "never_flee", never_flee );
 
     // deserialize the flags so they can be changed between save games
     for( const auto &rule : ally_rule_strs ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1814,6 +1814,7 @@ void npc_follower_rules::serialize( JsonOut &json ) const
     json.member( "apply_to_all", apply_to_all );
     json.member( "allow_improvised_throwing", allow_improvised_throwing );
     json.member( "never_flee", never_flee );
+    json.member( "prefer_guns", prefer_guns );
 
     // serialize the flags so they can be changed between save games
     for( const auto &rule : ally_rule_strs ) {
@@ -1849,6 +1850,10 @@ void npc_follower_rules::deserialize( const JsonObject &data )
     data.read( "apply_to_all", apply_to_all );
     data.read( "allow_improvised_throwing", allow_improvised_throwing );
     data.read( "never_flee", never_flee );
+    if( !data.read( "prefer_guns", prefer_guns ) && apply_to_all && never_flee ) {
+        // Compatibility with the first version of the hostile NPC rule patch.
+        prefer_guns = true;
+    }
 
     // deserialize the flags so they can be changed between save games
     for( const auto &rule : ally_rule_strs ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2002,6 +2002,10 @@ void dialogue_chatbin::serialize( JsonOut &json ) const
     json.member( "snip_give_carry_cant_no_space", snip_give_carry_cant_no_space );
     json.member( "snip_give_carry_too_heavy", snip_give_carry_too_heavy );
     json.member( "snip_wear", snip_wear );
+    json.member( "snip_mutiny", snip_mutiny );
+    json.member( "snip_pickup_item", snip_pickup_item );
+    json.member( "snip_no_dropoff", snip_no_dropoff );
+    json.member( "snip_socialize", snip_socialize );
 
     if( mission_selected != nullptr ) {
         json.member( "mission_selected", mission_selected->get_id() );
@@ -2113,6 +2117,10 @@ void dialogue_chatbin::deserialize( const JsonObject &data )
     data.read( "snip_give_carry_cant_no_space", snip_give_carry_cant_no_space );
     data.read( "snip_give_carry_too_heavy", snip_give_carry_too_heavy );
     data.read( "snip_wear", snip_wear );
+    data.read( "snip_mutiny", snip_mutiny );
+    data.read( "snip_pickup_item", snip_pickup_item );
+    data.read( "snip_no_dropoff", snip_no_dropoff );
+    data.read( "snip_socialize", snip_socialize );
 
     std::vector<int> tmpmissions;
     data.read( "missions", tmpmissions );
@@ -2420,6 +2428,12 @@ void npc::load( const JsonObject &data )
 
     data.read( "op_of_u", op_of_u );
     data.read( "chatbin", chatbin );
+    const string_id<npc_template> template_id( idz.str() );
+    if( template_id.is_valid() ) {
+        // Structured speech overrides are reapplied from the current template so mods can
+        // update the voice of already generated named NPCs without editing save files.
+        chatbin.apply_speech_overrides( template_id.obj().speech_overrides );
+    }
     if( !data.read( "rules", rules ) ) {
         data.read( "misc_rules", rules );
         data.read( "combat_rules", rules );


### PR DESCRIPTION
## 问题

- 临时跟随 NPC 在部分状态下不会遵守“禁止拾取”规则。
- JSON 定义的敌对 NPC 无法完整复用跟随者战斗规则，强盗可能拿衣物近战、忽略可用枪械，或看见敌人后停止主动追击。
- NPC 若干状态发言仍写死在代码中，模组难以统一定制角色语音；更新模板后，已生成 NPC 也无法获得新的结构化语音覆盖。

## 改动内容

- 统一判断需要应用跟随规则的 NPC，让正式同伴、临时跟随者及显式启用规则的 JSON NPC 遵守拾取、破坏、关门、战斗距离、枪械、投掷、抱怨和逃跑等设置。
- 为 NPC 模板增加 `follower_rules` 支持，并为强盗配置积极交战、优先枪械、禁止随意投掷物品和不因士气逃跑等战斗行为。
- 强盗会优先选择实际可用的枪械，不再把穿戴中的衣物当作临时近战武器；看见可攻击目标但暂时无法开火时会继续追击。
- 增加结构化 `npc_speech` 模组接口，覆盖全部 75 个 NPC 状态语音字段；未知键会报告 JSON 错误。
- 补全叛变、拾取物品、无物品卸载及社交活动语音，并在读取旧存档时重新应用当前 NPC 模板的结构化语音覆盖。
- 更新 NPC 模组文档和示例。

## 兼容性

- 保留原有顶层 `snip_*` 字段，旧 NPC 模组无需修改。
- 新增存档字段均具有默认值；旧存档缺少字段时继续使用原版行为。
- 只有显式启用 `apply_to_all` 的非同伴 NPC 才会受模板战斗规则控制。

## 验证

- `git diff --check` 通过。
- 75 个语音字段与结构化键逐项核对，无遗漏、无重复、无错配。
- Windows Tiles x64 MSVC 与 Android arm64 构建通过。
- 游戏内测试确认临时跟随者规则、强盗枪械选择与主动追击、NPC 语音覆盖功能正常。
- 测试运行：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/30747994669