### PR TITLE
完善树冠透明投影与缺贴图显示

### DIFF
--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -573,7 +573,7 @@
     "color": [ "red_green", "red_green", "red_green", "brown" ],
     "//": "barren in winter",
     "move_cost": 4,
-    "roof": "t_treetop_mega_fern",
+    "roof": "t_treetop_giant_fern",
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "NOITEM", "YOUNG", "REDUCE_SCENT", "CLIMB_ADJACENT" ],
     "bash": {
       "str_min": 4,

--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -338,7 +338,7 @@
     "symbol": "#",
     "color": [ "light_green", "green", "yellow_yellow", "brown" ],
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "CLIMBABLE", "SINGLE_SUPPORT" ]
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "CLIMBABLE", "SINGLE_SUPPORT", "Z_TRANSPARENT" ]
   },
   {
     "type": "terrain",
@@ -348,7 +348,7 @@
     "symbol": "#",
     "color": [ "green" ],
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "SINGLE_SUPPORT" ]
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "SINGLE_SUPPORT", "Z_TRANSPARENT" ]
   },
   {
     "type": "terrain",
@@ -358,7 +358,7 @@
     "symbol": "#",
     "color": "brown",
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "SINGLE_SUPPORT" ]
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "SINGLE_SUPPORT", "Z_TRANSPARENT" ]
   },
   {
     "type": "terrain",
@@ -368,6 +368,6 @@
     "symbol": "#",
     "color": "red",
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "SINGLE_SUPPORT" ]
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "SINGLE_SUPPORT", "Z_TRANSPARENT" ]
   }
 ]

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2247,14 +2247,20 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
 
     if( !tt ) {
 
-        // Use fog overlay as fallback for transparent terrain
+        // Use fog overlay as fallback for transparent terrain.
         if (category == TILE_CATEGORY::TERRAIN && !here.dont_draw_lower_floor(pos)) {
+            // Treetops are transparent roof placeholders.  If the tileset has no
+            // dedicated treetop tile, the projected tree below has already received
+            // the normal z-level tint; do not cover it with the gray fallback fog.
+            if( string_starts_with( id, "t_treetop" ) ) {
+                return true;
+            }
+
             draw_zlevel_overlay(pos, ll, height_3d);
 
-            // t_open_air is plentiful at high z-levels.  Treetops are transparent
-            // roof placeholders: when a tileset has no dedicated treetop tile, leave
-            // the projected tree below visible instead of covering it with ASCII '#'.
-            if( id == "t_open_air" || string_starts_with( id, "t_treetop" ) ) {
+            // t_open_air is plentiful at high z-levels.  Skipping the rest of the
+            // fallback code significantly improves performance.
+            if( id == "t_open_air" ) {
                 return true;
             }
         }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2251,9 +2251,10 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
         if (category == TILE_CATEGORY::TERRAIN && !here.dont_draw_lower_floor(pos)) {
             draw_zlevel_overlay(pos, ll, height_3d);
 
-            // t_open_air is plentiful at high z-levels
-            // Skipping the rest of the fallback code will significantly improve performance
-            if (id == "t_open_air") {
+            // t_open_air is plentiful at high z-levels.  Treetops are transparent
+            // roof placeholders: when a tileset has no dedicated treetop tile, leave
+            // the projected tree below visible instead of covering it with ASCII '#'.
+            if( id == "t_open_air" || string_starts_with( id, "t_treetop" ) ) {
                 return true;
             }
         }


### PR DESCRIPTION
## 问题

部分树冠地形使用透明屋顶，但当贴图包缺少对应树冠贴图时，会退回 ASCII `#` 或额外灰色遮罩，无法自然显示下层树木；巨型蕨类树冠还存在屋顶 ID 不一致的问题。

## 改动内容

- 修正巨型蕨类树冠的屋顶地形 ID。
- 为树冠屋顶地形补充 `Z_TRANSPARENT` 标志。
- 缺少树冠贴图时跳过 ASCII 回退，保留已投影的下层树木。
- 缺少树冠贴图时不再叠加额外灰色雾层，沿用现有楼层淡蓝色调，使其与其他下层对象的显示一致。

## 兼容性

- 仅调整缺少对应树冠贴图时的显示回退。
- 拥有专用树冠贴图的贴图包仍使用自身贴图。
- 不改变树木实体、碰撞、移动耗时或地图生成逻辑。

## 验证

- `git diff --check` 通过。
- [Windows & Android Test #57](https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/30751116170) 的 Windows Tiles x64 MSVC 与 Android arm64 均构建通过。
- 已完成不死人贴图游戏内测试：下层树木投影自然显示，灰色方块消失，层级淡蓝色调正常。