### PR TITLE
修复正式发布草稿无法公开

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,7 +369,7 @@ jobs:
         env:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
         run: |
-          gh release edit "${TAG_NAME}" --draft=false
+          gh release edit "${TAG_NAME}" --draft=false --repo "${GITHUB_REPOSITORY}"
 
   cleanup:
     name: 清理失败的草稿发布


### PR DESCRIPTION
## 问题

正式发布的 Windows 与 Android 构建和附件上传均成功，但最后的公开步骤运行在未检出源码的独立作业中。`gh release edit` 未显式指定仓库，会尝试从当前目录查找 `.git`，因此以“not a git repository”失败并留下完整但未公开的草稿。

## 改动内容

- 为公开草稿命令增加 `--repo ${GITHUB_REPOSITORY}`。
- 不增加源码检出，也不改变构建、上传、失败清理或版本号逻辑。

## 验证

- `git diff --check` 通过。
- 差异仅包含发布工作流中的一行命令。
- 12.2 工作流 #392 已证明 Windows、Android、附件上传和草稿创建均成功；失败点仅为缺少仓库上下文的公开命令。
- 已确认当前 12.2 草稿同时包含 Android APK 与 Windows ZIP。