### PR TITLE
中立怪物攻击改由安全模式拦截并清理旧干扰选项

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -343,10 +343,6 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
                 you.clear_destination();
                 return false;
             }
-            if (critter.attitude(&you) != MATT_ATTACK && uistate.distraction_neutral_monsters_in_the_direction_of_movement 
-                && !query_yn("移动方向存在中立怪物，这将会变成对怪物的攻击行为，确定要继续吗？")) {
-                return false;
-            }
             if( you.has_effect( effect_relax_gas ) ) {
                 if( one_in( 8 ) ) {
                     add_msg( m_good, _( "Your willpower asserts itself, and so do you!" ) );
@@ -355,6 +351,14 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
                     add_msg( m_bad, _( "You're too pacified to strike anything…" ) );
                     return false;
                 }
+            }
+            if( g->safe_mode == SAFE_MODE_ON &&
+                critter.attitude_to( you ) == Creature::Attitude::NEUTRAL ) {
+                const std::string msg_safe_mode = press_x( ACTION_TOGGLE_SAFEMODE );
+                add_msg( m_warning,
+                         _( "不会攻击%1$s，安全模式已开启，按%2$s关闭安全模式。" ),
+                         critter.name(), msg_safe_mode );
+                return false;
             }
             you.melee_attack( critter, true );
             if( critter.is_hallucination() ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -356,7 +356,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
                 critter.attitude_to( you ) == Creature::Attitude::NEUTRAL ) {
                 const std::string msg_safe_mode = press_x( ACTION_TOGGLE_SAFEMODE );
                 add_msg( m_warning,
-                         _( "不会攻击%1$s，安全模式已开启，按%2$s关闭安全模式。" ),
+                         _( "不会攻击%1$s，安全模式已开启，%2$s关闭安全模式。" ),
                          critter.name(), msg_safe_mode );
                 return false;
             }

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -21,7 +21,6 @@ static const std::vector<std::pair<std::string, std::string>> configurable_distr
     {"受到攻击",                       translate_marker("This distraction will interrupt your activity when you're attacked.")},
     {translate_marker( "Hostile is dangerously close" ), translate_marker( "This distraction will interrupt your activity when a hostile comes within 5 tiles from you." )},
     {translate_marker( "Hostile spotted" ),              translate_marker( "This distraction will interrupt your activity when you spot a hostile." )},
-    {"移动方向存在中立怪物",                       "这项干扰会在你的移动方向存在中立怪物时中断你当前的行动。"},
     {translate_marker( "Conversation" ),                 translate_marker( "This distraction will interrupt your activity when someone starts a conversation with you." )},
     {translate_marker( "Asthma" ),                       translate_marker( "This distraction will interrupt your activity when you suffer an asthma attack." )},
     {translate_marker( "Dangerous field" ),              translate_marker( "This distraction will interrupt your activity when you're standing in a dangerous field." )},
@@ -70,7 +69,6 @@ void distraction_manager_gui::show()
         uistate.distraction_attack,
         uistate.distraction_hostile_close,
         uistate.distraction_hostile_spotted,
-        uistate.distraction_neutral_monsters_in_the_direction_of_movement,
         uistate.distraction_conversation,
         uistate.distraction_asthma,
         uistate.distraction_dangerous_field,
@@ -189,30 +187,27 @@ void distraction_manager_gui::show()
                     uistate.distraction_hostile_spotted = !uistate.distraction_hostile_spotted;
                     break;
                 case 5:
-                    uistate.distraction_neutral_monsters_in_the_direction_of_movement = !uistate.distraction_neutral_monsters_in_the_direction_of_movement;
-                    break;
-                case 6:
                     uistate.distraction_conversation = !uistate.distraction_conversation;
                     break;
-                case 7:
+                case 6:
                     uistate.distraction_asthma = !uistate.distraction_asthma;
                     break;
-                case 8:
+                case 7:
                     uistate.distraction_dangerous_field = !uistate.distraction_dangerous_field;
                     break;
-                case 9:
+                case 8:
                     uistate.distraction_weather_change = !uistate.distraction_weather_change;
                     break;
-                case 10:
+                case 9:
                     uistate.distraction_hunger = !uistate.distraction_hunger;
                     break;
-                case 11:
+                case 10:
                     uistate.distraction_thirst = !uistate.distraction_thirst;
                     break;
-                case 12:
+                case 11:
                     uistate.distraction_temperature = !uistate.distraction_temperature;
                     break;
-                case 13:
+                case 12:
                     uistate.distraction_mutation = !uistate.distraction_mutation;
                     break;
                 default:

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -375,7 +375,6 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "distraction_attack", distraction_attack );
     json.member( "distraction_hostile_close", distraction_hostile_close );
     json.member( "distraction_hostile_spotted", distraction_hostile_spotted );
-    json.member("distraction_neutral_monsters_in_the_direction_of_movement", distraction_neutral_monsters_in_the_direction_of_movement);
     json.member( "distraction_conversation", distraction_conversation );
     json.member( "distraction_asthma", distraction_asthma );
     json.member( "distraction_dangerous_field", distraction_dangerous_field );
@@ -443,7 +442,6 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "distraction_attack", distraction_attack );
     jo.read( "distraction_hostile_close", distraction_hostile_close );
     jo.read( "distraction_hostile_spotted", distraction_hostile_spotted );
-    jo.read("distraction_neutral_monsters_in_the_direction_of_movement",distraction_neutral_monsters_in_the_direction_of_movement);
     jo.read( "distraction_conversation", distraction_conversation );
     jo.read( "distraction_asthma", distraction_asthma );
     jo.read( "distraction_dangerous_field", distraction_dangerous_field );

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -139,7 +139,6 @@ class uistatedata
         bool distraction_attack = true;
         bool distraction_hostile_close = true;
         bool distraction_hostile_spotted = true;
-        bool distraction_neutral_monsters_in_the_direction_of_movement = true;
         bool distraction_conversation = true;
         bool distraction_asthma = true;
         bool distraction_dangerous_field = true;


### PR DESCRIPTION
## 修改内容

- 将移动撞击中立怪物的保护机制统一交由安全模式处理：安全模式开启时阻止攻击，并提示关闭安全模式的快捷键。
- 移除原“移动方向存在中立怪物”干扰选项及对应状态字段，避免与安全模式形成两套重复确认机制。
- 清理 uistate 配置保存与读取中的旧字段引用。
- 修正快捷键提示中重复显示“按”的问题。

## 行为变化

- 安全模式开启：不会攻击中立怪物，并显示关闭安全模式的提示。
- 安全模式关闭：允许直接攻击中立怪物，不再弹出旧确认框。

## 验证

- Windows Tiles x64 MSVC 构建通过（工作流 #61）。
- 游戏内验证安全模式拦截与快捷键提示正常。