### PR TITLE
改进 NPC 瞄准逻辑并增加瞄准提示

### DIFF
--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -464724,3 +464724,8 @@ msgstr "%1$s，%2$s"
 #: src/game.cpp
 msgid "other type started"
 msgstr "其他处理已经开始"
+
+#: src/npc_attack.cpp
+#, c-format
+msgid "%s takes aim at you."
+msgstr "%s正在瞄准你。"

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -422,7 +422,7 @@ void npc_attack_gun::use( npc &source, const tripoint &location ) const
         add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is aiming", source.disp_name() );
         Creature *target = get_creature_tracker().creature_at( location );
         if( target != nullptr && target->is_avatar() && get_player_character().sees( source ) ) {
-            add_msg( m_bad, _( "%s takes aim at you." ), source.disp_name() );
+            add_msg( m_warning, _( "%s takes aim at you." ), source.disp_name() );
         }
 
         source.aim( target_attributes );

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -1,5 +1,6 @@
 #include "npc_attack.h"
 
+#include "avatar.h"
 #include "cata_utility.h"
 #include "character.h"
 #include "creature_tracker.h"
@@ -15,6 +16,7 @@
 #include "point.h"
 #include "projectile.h"
 #include "ranged.h"
+#include "translations.h"
 
 static const bionic_id bio_hydraulics( "bio_hydraulics" );
 
@@ -411,23 +413,33 @@ void npc_attack_gun::use( npc &source, const tripoint &location ) const
     }
 
     const int dist = rl_dist_exact( source.pos(), location );
+    const Target_attributes target_attributes( source.pos(), location );
 
     // Only aim if we aren't in risk of being hit
     // TODO: Get distance to closest enemy
-    if( dist > 1 && source.aim_per_move( gun, source.recoil ) > 0 &&
+    if( dist > 1 && source.aim_per_move( gun, source.recoil, target_attributes ) > 0 &&
         source.confident_gun_mode_range( gunmode, source.recoil ) < dist ) {
         add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is aiming", source.disp_name() );
-        source.aim( Target_attributes( source.pos(), location ) );
-    } else {
-        if( source.is_hallucination() ) {
-            gun_mode mode = source.get_wielded_item()->gun_current_mode();
-            source.pretend_fire( &source, mode.qty, *mode );
-        } else {
-            source.fire_gun( location );
+        Creature *target = get_creature_tracker().creature_at( location );
+        if( target != nullptr && target->is_avatar() && get_player_character().sees( source ) ) {
+            add_msg( m_bad, _( "%s takes aim at you." ), source.disp_name() );
         }
-        add_msg_debug( debugmode::debug_filter::DF_NPC, "%s fires %s", source.disp_name(),
-                       gun.display_name() );
+
+        source.aim( target_attributes );
+        if( source.moves > 0 ) {
+            source.moves = 0;
+        }
+        return;
     }
+
+    if( source.is_hallucination() ) {
+        gun_mode mode = source.get_wielded_item()->gun_current_mode();
+        source.pretend_fire( &source, mode.qty, *mode );
+    } else {
+        source.fire_gun( location );
+    }
+    add_msg_debug( debugmode::debug_filter::DF_NPC, "%s fires %s", source.disp_name(),
+                   gun.display_name() );
 }
 
 bool npc_attack_gun::can_use( const npc &source ) const

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2323,7 +2323,8 @@ bool npc::enough_time_to_reload( const item &gun ) const
 void npc::aim( const Target_attributes &target_attributes )
 {
     const item_location weapon = get_wielded_item();
-    double aim_amount = weapon ? aim_per_move( *weapon, recoil ) : 0.0;
+    double aim_amount = weapon ? aim_per_move( *weapon, recoil,
+                        target_attributes ) : 0.0;
     while( aim_amount > 0 && recoil > 0 && moves > 0 ) {
         moves--;
         recoil -= aim_amount;
@@ -2858,8 +2859,6 @@ void npc::move_pause()
             return;
         }
     }
-    // NPCs currently always aim when using a gun, even with no target
-    // This simulates them aiming at stuff just at the edge of their range
     if( !get_wielded_item() || !get_wielded_item()->is_gun() ) {
         pause();
         return;
@@ -2868,10 +2867,18 @@ void npc::move_pause()
     // Stop, drop, and roll
     if( has_effect( effect_onfire ) ) {
         pause();
-    } else {
-        aim( Target_attributes() );
-        moves = std::min( moves, 0 );
+        return;
     }
+
+    Creature *target = current_target();
+    if( target == nullptr || !sees( *target ) ) {
+        recoil = MAX_RECOIL;
+        pause();
+        return;
+    }
+
+    aim( Target_attributes( pos(), target->pos() ) );
+    moves = std::min( moves, 0 );
 }
 
 static std::optional<tripoint> nearest_passable( const tripoint &p, const tripoint &closest_to )


### PR DESCRIPTION
## 修改内容

- 让 NPC 枪械瞄准使用目标感知的 `Target_attributes`，使瞄准计算与实际目标位置一致。
- NPC 只有在存在可见目标时才会继续瞄准；没有目标或目标不可见时停止瞄准并重置后坐力，避免无目标持续瞄准。
- 当 NPC 瞄准玩家且玩家能看到该 NPC 时，显示“%s 正在瞄准你”的战斗提示，并正确消耗本回合行动点。
- 保留幻觉 NPC 和普通 NPC 的开火行为，不改变实际射击流程。
- 增加简体中文翻译“%s正在瞄准你。”。

## 行为变化

- NPC 发现并看见目标后，会先进行与目标相关的瞄准，再开火。
- NPC 看不见目标或没有当前目标时，不再无目标地持续瞄准。
- 玩家能够看到 NPC 瞄准自己时，会收到明确提示。

## 验证

- Windows Tiles x64 MSVC 构建通过：工作流运行 #63。
- 分支：`codex/npc-skill-aiming`