### PR TITLE
怪物智能寻路AI：最小耗时计算、声音路由与跨层追踪

### DIFF
--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -54,6 +54,13 @@ bool string_id<monfaction>::is_valid() const
 template<>
 int_id<monfaction>::int_id( const string_id<monfaction> &id ) : _id( id.id() ) {}
 
+/** @relates int_id */
+template<>
+bool int_id<monfaction>::is_valid() const
+{
+    return faction_factory.is_valid( *this );
+}
+
 bool monfaction::is_root() const
 {
     return id == base_faction;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -8,9 +8,12 @@
 #include <cstdlib>
 #include <iterator>
 #include <list>
+#include <map>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 
 #include "behavior.h"
@@ -74,6 +77,65 @@ static const material_id material_iflesh( "iflesh" );
 
 static const species_id species_FUNGUS( "FUNGUS" );
 static const species_id species_ZOMBIE( "ZOMBIE" );
+
+namespace
+{
+// Breeze does not yet have CBN's reusable destination Dijkstra maps.  This
+// compact cache provides the most useful part of that optimisation without
+// replacing map::route: monsters of the same type can reuse suffixes of a
+// route calculated earlier in the same turn.
+constexpr int fallback_monster_path_radius = 24;
+constexpr std::size_t monster_route_cache_max_edges = 8192;
+
+int quantize_monster_bash_strength( int strength )
+{
+    if( strength <= 0 ) {
+        return 0;
+    }
+
+    // Powers of two keep creatures with nearly identical abilities on the
+    // same cache entry and mirror the coarse capability grouping used by CBN.
+    int result = 1;
+    while( result < strength && result < 128 ) {
+        result *= 2;
+    }
+    return result;
+}
+
+struct monster_route_cache_key {
+    mtype_id type_id;
+    tripoint target;
+    int bash_strength_quanta = 0;
+    bool can_open_doors = false;
+
+    bool operator<( const monster_route_cache_key &rhs ) const
+    {
+        return std::tie( type_id, target.x, target.y, target.z,
+                         bash_strength_quanta, can_open_doors ) <
+               std::tie( rhs.type_id, rhs.target.x, rhs.target.y, rhs.target.z,
+                         rhs.bash_strength_quanta, rhs.can_open_doors );
+    }
+};
+
+struct monster_route_cache_entry {
+    // For a route A,B,C,target this stores A->B, B->C and C->target.  A later
+    // monster standing on any recorded tile can rebuild the remaining suffix.
+    std::map<tripoint, tripoint> next_steps;
+};
+
+std::optional<time_point> monster_route_cache_turn;
+std::map<monster_route_cache_key, monster_route_cache_entry> monster_route_cache;
+std::size_t monster_route_cache_edges = 0;
+
+void refresh_monster_route_cache()
+{
+    if( !monster_route_cache_turn || *monster_route_cache_turn != calendar::turn ) {
+        monster_route_cache_turn = calendar::turn;
+        monster_route_cache.clear();
+        monster_route_cache_edges = 0;
+    }
+}
+} // namespace
 
 bool monster::is_immune_field( const field_type_id &fid ) const
 {
@@ -993,43 +1055,174 @@ void monster::move()
         return;
     }
 
-    bool moved = false;
-    tripoint destination;
+    if( failed_pathfinding_cooldown > 0 ) {
+        --failed_pathfinding_cooldown;
+    }
 
+    bool moved = false;
+    tripoint destination = pos();
     bool try_to_move = false;
     creature_tracker &creatures = get_creature_tracker();
+    const bool can_open_doors = has_flag( MF_CAN_OPEN_DOORS ) && !is_hallucination();
+    const int current_bash_estimate = bash_estimate();
+    const bool can_bash = current_bash_estimate > 0;
+
     for( const tripoint &dest : here.points_in_radius( pos(), 1 ) ) {
-        if( dest != pos() ) {
-            if( can_move_to( dest ) &&
-                creatures.creature_at( dest, true ) == nullptr ) {
-                try_to_move = true;
-                break;
-            }
+        if( dest == pos() ) {
+            continue;
+        }
+
+        const Creature *occupant = creatures.creature_at( dest, true );
+        const bool can_enter = can_move_to( dest ) && occupant == nullptr;
+        const bool can_attack_occupant = occupant != nullptr &&
+                                         attitude_to( *occupant ) == Attitude::HOSTILE;
+        const bool can_open = can_open_doors &&
+                              here.open_door( *this, dest, !here.is_outside( pos() ), true );
+        const bool can_break = can_bash && here.bash_rating( current_bash_estimate, dest ) > 0;
+
+        if( can_enter || can_attack_occupant || can_open || can_break ) {
+            try_to_move = true;
+            break;
         }
     }
     // If true, don't try to greedily avoid locally bad paths
     bool pathed = false;
     const tripoint local_dest = here.getlocal( get_dest() );
+
+    pathfinding_settings pf_settings = get_pathfinding_settings();
+    pf_settings.allow_open_doors = pf_settings.allow_open_doors || can_open_doors;
+    pf_settings.bash_strength = std::max( pf_settings.bash_strength, current_bash_estimate );
+
+    // Many old monster definitions have no path radius at all.  Give them a
+    // bounded local search rather than an unlimited one.  Long-distance travel
+    // stays on the cheap greedy movement used by Breeze.
+    if( pf_settings.max_dist <= 0 ) {
+        pf_settings.max_dist = fallback_monster_path_radius;
+        pf_settings.max_length = fallback_monster_path_radius * 5;
+    }
+
+    auto cached_step_is_usable = [&]( const tripoint &step ) {
+        if( !here.inbounds( step ) || rl_dist( pos(), step ) >= 2 ) {
+            return false;
+        }
+        if( can_move_to( step ) ) {
+            return true;
+        }
+        if( can_open_doors &&
+            here.open_door( *this, step, !here.is_outside( pos() ), true ) ) {
+            return true;
+        }
+        return can_bash && here.bash_rating( current_bash_estimate, step ) > 0;
+    };
+
+    auto try_route_to = [&]( const tripoint &route_dest ) {
+        const int route_distance = rl_dist( pos(), route_dest );
+        if( route_dest == pos() || route_distance > pf_settings.max_dist ) {
+            return false;
+        }
+
+        const tripoint_abs_ms absolute_route_dest = here.getglobal( route_dest );
+        if( failed_pathfinding_target && *failed_pathfinding_target != absolute_route_dest ) {
+            failed_pathfinding_target.reset();
+            failed_pathfinding_cooldown = 0;
+        }
+
+        while( !path.empty() && path.front() == pos() ) {
+            path.erase( path.begin() );
+        }
+        if( !path.empty() && !cached_step_is_usable( path.front() ) ) {
+            path.clear();
+        }
+
+        const bool need_new_path = path.empty() || rl_dist( pos(), path.front() ) >= 2 ||
+                                   path.back() != route_dest;
+        if( need_new_path ) {
+            if( failed_pathfinding_target && *failed_pathfinding_target == absolute_route_dest &&
+                failed_pathfinding_cooldown > 0 ) {
+                return false;
+            }
+
+            refresh_monster_route_cache();
+            const monster_route_cache_key cache_key {
+                type->id,
+                route_dest,
+                quantize_monster_bash_strength( pf_settings.bash_strength ),
+                pf_settings.allow_open_doors
+            };
+
+            const auto cache_iter = monster_route_cache.find( cache_key );
+            if( cache_iter != monster_route_cache.end() ) {
+                std::vector<tripoint> cached_path;
+                std::set<tripoint> visited;
+                tripoint cursor = pos();
+                const std::size_t max_cached_steps = static_cast<std::size_t>(
+                            std::max( 1, pf_settings.max_length ) );
+
+                while( cached_path.size() < max_cached_steps && cursor != route_dest &&
+                       visited.insert( cursor ).second ) {
+                    const auto next_iter = cache_iter->second.next_steps.find( cursor );
+                    if( next_iter == cache_iter->second.next_steps.end() ||
+                        next_iter->second == cursor ) {
+                        break;
+                    }
+                    cached_path.push_back( next_iter->second );
+                    cursor = next_iter->second;
+                }
+
+                if( !cached_path.empty() && cached_path.back() == route_dest &&
+                    cached_step_is_usable( cached_path.front() ) ) {
+                    path = std::move( cached_path );
+                }
+            }
+
+            if( path.empty() || path.back() != route_dest ) {
+                path = here.route( pos(), route_dest, pf_settings, get_path_avoid() );
+            }
+
+            if( !path.empty() && path.back() == route_dest ) {
+                failed_pathfinding_target.reset();
+                failed_pathfinding_cooldown = 0;
+
+                if( monster_route_cache_edges < monster_route_cache_max_edges ) {
+                    monster_route_cache_entry &entry = monster_route_cache[cache_key];
+                    tripoint from = pos();
+                    for( const tripoint &step : path ) {
+                        if( monster_route_cache_edges >= monster_route_cache_max_edges ) {
+                            break;
+                        }
+                        const auto inserted = entry.next_steps.emplace( from, step );
+                        if( inserted.second ) {
+                            ++monster_route_cache_edges;
+                        }
+                        from = step;
+                    }
+                }
+            } else {
+                // Different monsters spread retries across several actions, avoiding
+                // a synchronized search spike around an impossible sealed target.
+                failed_pathfinding_target = absolute_route_dest;
+                failed_pathfinding_cooldown = 2 +
+                                               ( std::abs( posx() + posy() + posz() ) % 3 );
+                return false;
+            }
+        }
+
+        if( !path.empty() && path.back() == route_dest ) {
+            destination = path.front();
+            moved = true;
+            pathed = true;
+            return true;
+        }
+        return false;
+    };
+
     if( try_to_move ) {
         if( !is_wandering() ) {
-            while( !path.empty() && path.front() == pos() ) {
-                path.erase( path.begin() );
-            }
-
-            const pathfinding_settings &pf_settings = get_pathfinding_settings();
-            if( pf_settings.max_dist >= rl_dist( get_location(), get_dest() ) &&
-                ( path.empty() || rl_dist( pos(), path.front() ) >= 2 || path.back() != local_dest ) ) {
-                // We need a new path
-                path = here.route( pos(), local_dest, pf_settings, get_path_avoid() );
-            }
-
-            // Try to respect old paths, even if we can't pathfind at the moment
-            if( !path.empty() && path.back() == local_dest ) {
-                destination = path.front();
-                moved = true;
-                pathed = true;
-            } else {
-                // Straight line forward, probably because we can't pathfind (well enough)
+            const int target_distance = rl_dist( pos(), local_dest );
+            if( !try_route_to( local_dest ) && target_distance > pf_settings.max_dist ) {
+                // Keep Breeze's inexpensive long-range steering.  Inside the
+                // bounded path radius a failed route no longer becomes blind
+                // wall-banging.
                 destination = local_dest;
                 moved = true;
             }
@@ -1054,10 +1247,18 @@ void monster::move()
         }
     }
     if( wandf > 0 && !moved && friendly == 0 ) { // No LOS, no scent, so as a fall-back follow sound
-        unset_dest();
         if( wander_pos != get_location() ) {
-            destination = here.getlocal( wander_pos );
-            moved = true;
+            const tripoint sound_dest = here.getlocal( wander_pos );
+            const int sound_distance = rl_dist( pos(), sound_dest );
+            unset_dest();
+
+            if( !try_route_to( sound_dest ) && sound_distance > pf_settings.max_dist ) {
+                // Very distant sounds retain cheap directional pursuit.  Once
+                // close enough, route costs choose doors, windows, stairs or a
+                // bashable weak point instead of the nearest wall.
+                destination = sound_dest;
+                moved = true;
+            }
         }
     }
 
@@ -1080,13 +1281,11 @@ void monster::move()
     }
 
     tripoint_abs_ms next_step;
-    const bool can_open_doors = has_flag( MF_CAN_OPEN_DOORS ) && !is_hallucination();
     const bool staggers = has_flag( MF_STUMBLES );
     if( moved ) {
         // Implement both avoiding obstacles and staggering.
         moved = false;
         float switch_chance = 0.0f;
-        const bool can_bash = bash_skill() > 0;
         // This is a float and using trig_dist() because that Does the Right Thing(tm)
         // in both circular and roguelike distance modes.
         const float distance_to_target = trig_dist( pos(), destination );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -218,6 +218,79 @@ const std::array<point, 16> hostile_search_offsets = {{
     point( 6, 3 ), point( -3, 6 ), point( -6, -3 ), point( 3, -6 )
 }};
 
+
+constexpr int hostile_transition_hint_radius = 2;
+
+std::optional<tripoint_abs_ms> infer_hostile_memory_transition(
+    monster &critter, map &here, const tripoint_abs_ms &memory_origin,
+    int search_lane )
+{
+    const tripoint local_origin = here.getlocal( memory_origin );
+    if( !here.inbounds( local_origin ) ) {
+        return std::nullopt;
+    }
+
+    std::optional<tripoint> best_destination;
+    std::tuple<int, int, int, int> best_score(
+        std::numeric_limits<int>::max(), 0, 0, 0 );
+    const bool can_bash = critter.bash_estimate() > 0;
+
+    for( const tripoint &candidate :
+         here.points_in_radius( local_origin, hostile_transition_hint_radius ) ) {
+        if( candidate.z != local_origin.z ) {
+            continue;
+        }
+
+        const bool can_go_down =
+            here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, candidate ) ||
+            here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, candidate );
+        const bool can_go_up =
+            here.has_flag( ter_furn_flag::TFLAG_GOES_UP, candidate ) ||
+            here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, candidate );
+
+        for( const int dz : { -1, 1 } ) {
+            if( ( dz < 0 && !can_go_down ) || ( dz > 0 && !can_go_up ) ) {
+                continue;
+            }
+
+            const tripoint destination( candidate.x, candidate.y,
+                                        candidate.z + dz );
+            if( !here.inbounds( destination ) ) {
+                continue;
+            }
+
+            const bool paired_stair = dz < 0 ?
+                here.has_flag( ter_furn_flag::TFLAG_GOES_UP, destination ) :
+                here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, destination );
+            const bool explicit_landing = paired_stair ||
+                                          !here.impassable( destination );
+            if( !explicit_landing &&
+                !here.valid_move( candidate, destination, can_bash, true ) ) {
+                continue;
+            }
+
+            // Exact last-seen tile wins.  In a rare stairwell which goes both
+            // ways, stable lanes split a horde instead of making every monster
+            // choose the same speculative floor.
+            const int distance = rl_dist( local_origin, candidate );
+            const int direction_bias = ( search_lane & 1 ) == 0 ?
+                                       ( dz < 0 ? 0 : 1 ) :
+                                       ( dz > 0 ? 0 : 1 );
+            const std::tuple<int, int, int, int> score(
+                distance, direction_bias, candidate.x, candidate.y );
+            if( score < best_score ) {
+                best_score = score;
+                best_destination = destination;
+            }
+        }
+    }
+
+    if( !best_destination ) {
+        return std::nullopt;
+    }
+    return here.getglobal( *best_destination );
+}
+
 std::optional<time_point> monster_path_cache_turn;
 std::map<monster_route_cache_key, monster_route_cache_entry> monster_route_cache;
 std::map<monster_z_route_cache_key, monster_z_route_plan> monster_z_route_cache;
@@ -611,6 +684,7 @@ void monster::plan()
         hostile_search_step = 0;
         hostile_search_waypoint_turns = 0;
         hostile_search_lane = 0;
+        hostile_transition_attempts = 0;
     } else {
         if( hostile_target_memory_turns > 0 ) {
             --hostile_target_memory_turns;
@@ -629,6 +703,7 @@ void monster::plan()
             hostile_search_step = 0;
             hostile_search_waypoint_turns = 0;
             hostile_search_lane = 0;
+            hostile_transition_attempts = 0;
         }
     }
     Creature *target = nullptr;
@@ -979,6 +1054,7 @@ void monster::plan()
                 hostile_search_turns = 0;
                 hostile_search_step = 0;
                 hostile_search_waypoint_turns = 0;
+                hostile_transition_attempts = 0;
                 hostile_search_lane =
                     std::abs( posx() * 31 + posy() * 17 + posz() * 13 ) % 4;
             }
@@ -1014,35 +1090,57 @@ void monster::plan()
             // First honour the exact last-known position, including its Z level.
             set_dest( memory_origin );
         } else {
-            const int search_count = smart_planning ? 16 : 8;
-            const int lane = hostile_search_lane;
-            const int waypoint_hold = smart_planning ? 4 : 3;
-
-            if( hostile_search_step == 0 ) {
-                hostile_search_step = 1;
-                hostile_search_turns = smart_planning ? 36 : 18;
-                hostile_search_waypoint_turns = waypoint_hold;
-            } else {
-                const int current_index =
-                    ( hostile_search_step - 1 + lane * 2 ) % search_count;
-                tripoint_abs_ms current_waypoint =
-                    memory_origin + hostile_search_offsets[current_index];
-                current_waypoint.z() = memory_origin.z();
-                if( rl_dist( get_location(), current_waypoint ) <= 1 ||
-                    hostile_search_waypoint_turns <= 0 ) {
-                    ++hostile_search_step;
-                    hostile_search_waypoint_turns = waypoint_hold;
-                } else {
-                    --hostile_search_waypoint_turns;
+            bool followed_transition = false;
+            if( hostile_search_step == 0 && hostile_transition_attempts == 0 &&
+                get_pathfinding_settings().allow_climb_stairs ) {
+                const std::optional<tripoint_abs_ms> transition =
+                    infer_hostile_memory_transition( *this, here, memory_origin,
+                                                     hostile_search_lane );
+                if( transition ) {
+                    hostile_transition_attempts = 1;
+                    last_hostile_target_position = *transition;
+                    hostile_target_memory_turns = std::max(
+                        hostile_target_memory_turns,
+                        smart_planning ? 90 : 45 );
+                    hostile_search_turns = 0;
+                    hostile_search_step = 0;
+                    hostile_search_waypoint_turns = 0;
+                    set_dest( *transition );
+                    followed_transition = true;
                 }
             }
 
-            const int waypoint_index =
-                ( hostile_search_step - 1 + lane * 2 ) % search_count;
-            tripoint_abs_ms search_destination =
-                memory_origin + hostile_search_offsets[waypoint_index];
-            search_destination.z() = memory_origin.z();
-            set_dest( search_destination );
+            if( !followed_transition ) {
+                const int search_count = smart_planning ? 16 : 8;
+                const int lane = hostile_search_lane;
+                const int waypoint_hold = smart_planning ? 4 : 3;
+
+                if( hostile_search_step == 0 ) {
+                    hostile_search_step = 1;
+                    hostile_search_turns = smart_planning ? 36 : 18;
+                    hostile_search_waypoint_turns = waypoint_hold;
+                } else {
+                    const int current_index =
+                        ( hostile_search_step - 1 + lane * 2 ) % search_count;
+                    tripoint_abs_ms current_waypoint =
+                        memory_origin + hostile_search_offsets[current_index];
+                    current_waypoint.z() = memory_origin.z();
+                    if( rl_dist( get_location(), current_waypoint ) <= 1 ||
+                        hostile_search_waypoint_turns <= 0 ) {
+                        ++hostile_search_step;
+                        hostile_search_waypoint_turns = waypoint_hold;
+                    } else {
+                        --hostile_search_waypoint_turns;
+                    }
+                }
+
+                const int waypoint_index =
+                    ( hostile_search_step - 1 + lane * 2 ) % search_count;
+                tripoint_abs_ms search_destination =
+                    memory_origin + hostile_search_offsets[waypoint_index];
+                search_destination.z() = memory_origin.z();
+                set_dest( search_destination );
+            }
         }
     } else if( !patrol_route.empty() ) {
         // If we have a patrol route and no target, find the current step on the route

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -219,6 +219,37 @@ const std::array<point, 16> hostile_search_offsets = {{
 }};
 
 
+
+// Search waypoints are clues, not omniscient destinations.  Keep them inside
+// the open area visible from the last confirmed point.  Closed doors and walls
+// require a new sound or sighting instead of being opened by a blind spiral.
+std::optional<std::pair<int, tripoint_abs_ms>> next_hostile_search_waypoint(
+    map &here, const tripoint_abs_ms &memory_origin, int lane,
+    int first_step, int search_count )
+{
+    const tripoint local_origin = here.getlocal( memory_origin );
+    if( !here.inbounds( local_origin ) ) {
+        return std::nullopt;
+    }
+
+    for( int step = std::max( 1, first_step ); step <= search_count; ++step ) {
+        const int index = ( step - 1 + lane * 2 ) % search_count;
+        const tripoint candidate = local_origin + hostile_search_offsets[index];
+        if( candidate.z != local_origin.z || !here.inbounds( candidate ) ||
+            here.impassable( candidate ) ) {
+            continue;
+        }
+
+        const int range = std::max( 1, rl_dist( local_origin, candidate ) + 1 );
+        if( !here.clear_path( local_origin, candidate, range, 1, 100 ) ) {
+            continue;
+        }
+
+        return std::make_pair( step, here.getglobal( candidate ) );
+    }
+    return std::nullopt;
+}
+
 constexpr int hostile_transition_hint_radius = 2;
 
 std::optional<tripoint_abs_ms> infer_hostile_memory_transition(
@@ -685,6 +716,8 @@ void monster::plan()
         hostile_search_waypoint_turns = 0;
         hostile_search_lane = 0;
         hostile_transition_attempts = 0;
+        hostile_search_deadline.reset();
+        last_hostile_sighting_turn.reset();
     } else {
         if( hostile_target_memory_turns > 0 ) {
             --hostile_target_memory_turns;
@@ -692,8 +725,11 @@ void monster::plan()
         if( hostile_search_turns > 0 ) {
             --hostile_search_turns;
         }
+        const bool search_deadline_expired = hostile_search_deadline &&
+            calendar::turn >= *hostile_search_deadline;
         if( hostile_target_memory_turns <= 0 ||
-            ( hostile_search_step > 0 && hostile_search_turns <= 0 ) ) {
+            ( hostile_search_step > 0 &&
+              ( hostile_search_turns <= 0 || search_deadline_expired ) ) ) {
             if( last_hostile_target_position ) {
                 unset_dest();
             }
@@ -704,6 +740,7 @@ void monster::plan()
             hostile_search_waypoint_turns = 0;
             hostile_search_lane = 0;
             hostile_transition_attempts = 0;
+            hostile_search_deadline.reset();
         }
     }
     Creature *target = nullptr;
@@ -1055,6 +1092,15 @@ void monster::plan()
                 hostile_search_step = 0;
                 hostile_search_waypoint_turns = 0;
                 hostile_transition_attempts = 0;
+                hostile_search_deadline.reset();
+                last_hostile_sighting_turn = calendar::turn;
+                // Direct sight is absolute priority.  Do not let an old search,
+                // sound marker or failed route survive into the new pursuit.
+                wandf = 0;
+                provocative_sound = false;
+                path.clear();
+                failed_pathfinding_target.reset();
+                failed_pathfinding_cooldown = 0;
                 hostile_search_lane =
                     std::abs( posx() * 31 + posy() * 17 + posz() * 13 ) % 4;
             }
@@ -1105,6 +1151,8 @@ void monster::plan()
                     hostile_search_turns = 0;
                     hostile_search_step = 0;
                     hostile_search_waypoint_turns = 0;
+                    hostile_search_deadline.reset();
+                    wandf = 0;
                     set_dest( *transition );
                     followed_transition = true;
                 }
@@ -1113,33 +1161,54 @@ void monster::plan()
             if( !followed_transition ) {
                 const int search_count = smart_planning ? 16 : 8;
                 const int lane = hostile_search_lane;
-                const int waypoint_hold = smart_planning ? 4 : 3;
+                const int waypoint_hold = smart_planning ? 12 : 8;
 
                 if( hostile_search_step == 0 ) {
                     hostile_search_step = 1;
                     hostile_search_turns = smart_planning ? 36 : 18;
                     hostile_search_waypoint_turns = waypoint_hold;
+                    hostile_search_deadline = calendar::turn +
+                        time_duration::from_turns( hostile_search_turns );
+                } else if( hostile_search_waypoint_turns <= 0 ) {
+                    ++hostile_search_step;
+                    hostile_search_waypoint_turns = waypoint_hold;
                 } else {
-                    const int current_index =
-                        ( hostile_search_step - 1 + lane * 2 ) % search_count;
-                    tripoint_abs_ms current_waypoint =
-                        memory_origin + hostile_search_offsets[current_index];
-                    current_waypoint.z() = memory_origin.z();
-                    if( rl_dist( get_location(), current_waypoint ) <= 1 ||
-                        hostile_search_waypoint_turns <= 0 ) {
-                        ++hostile_search_step;
-                        hostile_search_waypoint_turns = waypoint_hold;
-                    } else {
-                        --hostile_search_waypoint_turns;
-                    }
+                    --hostile_search_waypoint_turns;
                 }
 
-                const int waypoint_index =
-                    ( hostile_search_step - 1 + lane * 2 ) % search_count;
-                tripoint_abs_ms search_destination =
-                    memory_origin + hostile_search_offsets[waypoint_index];
-                search_destination.z() = memory_origin.z();
-                set_dest( search_destination );
+                if( hostile_search_deadline &&
+                    calendar::turn >= *hostile_search_deadline ) {
+                    hostile_search_step = search_count + 1;
+                }
+
+                std::optional<std::pair<int, tripoint_abs_ms>> waypoint;
+                if( hostile_search_step <= search_count ) {
+                    waypoint = next_hostile_search_waypoint(
+                        here, memory_origin, lane, hostile_search_step,
+                        search_count );
+                }
+
+                if( !waypoint ) {
+                    // Every safe local clue was exhausted.  End the search now
+                    // instead of wrapping around the same offsets indefinitely.
+                    unset_dest();
+                    last_hostile_target_position.reset();
+                    hostile_target_memory_turns = 0;
+                    hostile_search_turns = 0;
+                    hostile_search_step = 0;
+                    hostile_search_waypoint_turns = 0;
+                    hostile_search_lane = 0;
+                    hostile_transition_attempts = 0;
+                    hostile_search_deadline.reset();
+                } else {
+                    hostile_search_step = waypoint->first;
+                    const tripoint_abs_ms &search_destination = waypoint->second;
+                    if( rl_dist( get_location(), search_destination ) <= 1 ) {
+                        ++hostile_search_step;
+                        hostile_search_waypoint_turns = waypoint_hold;
+                    }
+                    set_dest( search_destination );
+                }
             }
         }
     } else if( !patrol_route.empty() ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2,6 +2,7 @@
 #include "monster.h" // IWYU pragma: associated
 
 #include <algorithm>
+#include <array>
 #include <cfloat>
 #include <climits>
 #include <cmath>
@@ -206,6 +207,16 @@ struct monster_reverse_field_entry {
         frontier.push( { 0, target } );
     }
 };
+
+// Fixed, tiny search pattern around a confirmed last-known position.  Four
+// deterministic lanes spread a horde over nearby rooms without creating one
+// unique reverse field per monster.
+const std::array<point, 16> hostile_search_offsets = {{
+    point( 2, 0 ), point( 0, 2 ), point( -2, 0 ), point( 0, -2 ),
+    point( 3, 3 ), point( -3, 3 ), point( -3, -3 ), point( 3, -3 ),
+    point( 5, 0 ), point( 0, 5 ), point( -5, 0 ), point( 0, -5 ),
+    point( 6, 3 ), point( -3, 6 ), point( -6, -3 ), point( 3, -6 )
+}};
 
 std::optional<time_point> monster_path_cache_turn;
 std::map<monster_route_cache_key, monster_route_cache_entry> monster_route_cache;
@@ -588,6 +599,38 @@ void monster::plan()
 
     // Bots are more intelligent than most living stuff
     bool smart_planning = has_flag( MF_PRIORITIZE_TARGETS );
+    const bool improved_pathfinding =
+        get_option<std::string>( "MONSTER_PATHFINDING" ) != "classic";
+    if( !improved_pathfinding ) {
+        if( last_hostile_target_position ) {
+            unset_dest();
+        }
+        last_hostile_target_position.reset();
+        hostile_target_memory_turns = 0;
+        hostile_search_turns = 0;
+        hostile_search_step = 0;
+        hostile_search_waypoint_turns = 0;
+        hostile_search_lane = 0;
+    } else {
+        if( hostile_target_memory_turns > 0 ) {
+            --hostile_target_memory_turns;
+        }
+        if( hostile_search_turns > 0 ) {
+            --hostile_search_turns;
+        }
+        if( hostile_target_memory_turns <= 0 ||
+            ( hostile_search_step > 0 && hostile_search_turns <= 0 ) ) {
+            if( last_hostile_target_position ) {
+                unset_dest();
+            }
+            last_hostile_target_position.reset();
+            hostile_target_memory_turns = 0;
+            hostile_search_turns = 0;
+            hostile_search_step = 0;
+            hostile_search_waypoint_turns = 0;
+            hostile_search_lane = 0;
+        }
+    }
     Creature *target = nullptr;
     int max_sight_range = std::max( type->vision_day, type->vision_night );
     // 8.6f is rating for tank drone 60 tiles away, moose 16 or boomer 33
@@ -930,6 +973,15 @@ void monster::plan()
         const tripoint_abs_ms dest = target->get_location();
         Creature::Attitude att_to_target = attitude_to( *target );
         if( att_to_target == Attitude::HOSTILE && !fleeing ) {
+            if( improved_pathfinding ) {
+                last_hostile_target_position = dest;
+                hostile_target_memory_turns = smart_planning ? 150 : 60;
+                hostile_search_turns = 0;
+                hostile_search_step = 0;
+                hostile_search_waypoint_turns = 0;
+                hostile_search_lane =
+                    std::abs( posx() * 31 + posy() * 17 + posz() * 13 ) % 4;
+            }
             set_dest( dest );
         } else if( fleeing ) {
             tripoint_abs_ms away = get_location() - dest + get_location();
@@ -953,6 +1005,44 @@ void monster::plan()
                     anger -= 10 - static_cast<int>( hp_per / 10 );
                 }
             }
+        }
+    } else if( improved_pathfinding && friendly == 0 &&
+               last_hostile_target_position && hostile_target_memory_turns > 0 ) {
+        const tripoint_abs_ms memory_origin = *last_hostile_target_position;
+        if( hostile_search_step == 0 &&
+            rl_dist( get_location(), memory_origin ) > 1 ) {
+            // First honour the exact last-known position, including its Z level.
+            set_dest( memory_origin );
+        } else {
+            const int search_count = smart_planning ? 16 : 8;
+            const int lane = hostile_search_lane;
+            const int waypoint_hold = smart_planning ? 4 : 3;
+
+            if( hostile_search_step == 0 ) {
+                hostile_search_step = 1;
+                hostile_search_turns = smart_planning ? 36 : 18;
+                hostile_search_waypoint_turns = waypoint_hold;
+            } else {
+                const int current_index =
+                    ( hostile_search_step - 1 + lane * 2 ) % search_count;
+                tripoint_abs_ms current_waypoint =
+                    memory_origin + hostile_search_offsets[current_index];
+                current_waypoint.z() = memory_origin.z();
+                if( rl_dist( get_location(), current_waypoint ) <= 1 ||
+                    hostile_search_waypoint_turns <= 0 ) {
+                    ++hostile_search_step;
+                    hostile_search_waypoint_turns = waypoint_hold;
+                } else {
+                    --hostile_search_waypoint_turns;
+                }
+            }
+
+            const int waypoint_index =
+                ( hostile_search_step - 1 + lane * 2 ) % search_count;
+            tripoint_abs_ms search_destination =
+                memory_origin + hostile_search_offsets[waypoint_index];
+            search_destination.z() = memory_origin.z();
+            set_dest( search_destination );
         }
     } else if( !patrol_route.empty() ) {
         // If we have a patrol route and no target, find the current step on the route
@@ -1602,7 +1692,10 @@ void monster::move()
             }
         }
     }
-    if( wandf > 0 && !moved && friendly == 0 ) { // No LOS, no scent, so as a fall-back follow sound
+    const bool pursuing_confirmed_hostile = improved_pathfinding &&
+            last_hostile_target_position && hostile_target_memory_turns > 0;
+    if( wandf > 0 && !moved && friendly == 0 &&
+        !pursuing_confirmed_hostile ) { // Sound is below confirmed hostile memory
         if( improved_pathfinding ) {
             if( wander_pos != get_location() ) {
                 const tripoint sound_dest = here.getlocal( wander_pos );
@@ -2180,6 +2273,8 @@ bool monster::bash_at( const tripoint &p )
 
     int bashskill = group_bash_skill( p );
     here.bash( p, bashskill );
+    sounds::tag_recent_sound_from_monster( p, this,
+            sounds::sound_t::destructive_activity );
     moves -= 100;
     return true;
 }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -7,14 +7,18 @@
 #include <cmath>
 #include <cstdlib>
 #include <iterator>
+#include <functional>
 #include <list>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
 #include <ostream>
+#include <queue>
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "behavior.h"
 #include "bionics.h"
@@ -41,6 +45,7 @@
 #include "monster_oracle.h"
 #include "mtype.h"
 #include "npc.h"
+#include "options.h"
 #include "pathfinding.h"
 #include "pimpl.h"
 #include "rng.h"
@@ -80,12 +85,18 @@ static const species_id species_ZOMBIE( "ZOMBIE" );
 
 namespace
 {
-// Breeze does not yet have CBN's reusable destination Dijkstra maps.  This
-// compact cache provides the most useful part of that optimisation without
-// replacing map::route: monsters of the same type can reuse suffixes of a
-// route calculated earlier in the same turn.
+// The first phase shared path suffixes.  Phase two adds a target-rooted,
+// incrementally expanded distance field.  It mirrors the useful part of CBN's
+// destination Dijkstra maps while staying inside Breeze's existing tripoint
+// and map::route interfaces.
 constexpr int fallback_monster_path_radius = 24;
+constexpr int cross_z_monster_path_radius = 96;
+constexpr int reverse_field_radius = 64;
+constexpr int reverse_field_cross_z_radius = 72;
 constexpr std::size_t monster_route_cache_max_edges = 8192;
+constexpr std::size_t monster_reverse_field_max_count = 24;
+constexpr std::size_t monster_reverse_field_request_budget = 4096;
+constexpr std::size_t monster_reverse_field_turn_budget = 49152;
 
 int quantize_monster_bash_strength( int strength )
 {
@@ -93,8 +104,6 @@ int quantize_monster_bash_strength( int strength )
         return 0;
     }
 
-    // Powers of two keep creatures with nearly identical abilities on the
-    // same cache entry and mirror the coarse capability grouping used by CBN.
     int result = 1;
     while( result < strength && result < 128 ) {
         result *= 2;
@@ -118,22 +127,152 @@ struct monster_route_cache_key {
 };
 
 struct monster_route_cache_entry {
-    // For a route A,B,C,target this stores A->B, B->C and C->target.  A later
-    // monster standing on any recorded tile can rebuild the remaining suffix.
     std::map<tripoint, tripoint> next_steps;
 };
 
-std::optional<time_point> monster_route_cache_turn;
-std::map<monster_route_cache_key, monster_route_cache_entry> monster_route_cache;
-std::size_t monster_route_cache_edges = 0;
+struct monster_z_route_cache_key {
+    monster_route_cache_key route_key;
+    int source_z = 0;
 
-void refresh_monster_route_cache()
-{
-    if( !monster_route_cache_turn || *monster_route_cache_turn != calendar::turn ) {
-        monster_route_cache_turn = calendar::turn;
-        monster_route_cache.clear();
-        monster_route_cache_edges = 0;
+    bool operator<( const monster_z_route_cache_key &rhs ) const
+    {
+        if( route_key < rhs.route_key ) {
+            return true;
+        }
+        if( rhs.route_key < route_key ) {
+            return false;
+        }
+        return source_z < rhs.source_z;
     }
+};
+
+struct monster_z_route_plan {
+    tripoint approach;
+    tripoint transition;
+};
+
+struct monster_tripoint_hash {
+    std::size_t operator()( const tripoint &p ) const
+    {
+        std::size_t seed = 0x9e3779b97f4a7c15ULL;
+        const auto mix = [&]( int value ) {
+            seed ^= std::hash<int>()( value ) + 0x9e3779b97f4a7c15ULL +
+                    ( seed << 6 ) + ( seed >> 2 );
+        };
+        mix( p.x );
+        mix( p.y );
+        mix( p.z );
+        return seed;
+    }
+};
+
+struct monster_reverse_field_node {
+    int cost = 0;
+    tripoint position;
+};
+
+struct monster_reverse_field_node_greater {
+    bool operator()( const monster_reverse_field_node &lhs,
+                     const monster_reverse_field_node &rhs ) const
+    {
+        return lhs.cost > rhs.cost;
+    }
+};
+
+struct monster_reverse_field_entry {
+    tripoint target;
+    std::priority_queue<monster_reverse_field_node,
+        std::vector<monster_reverse_field_node>,
+        monster_reverse_field_node_greater> frontier;
+    std::unordered_map<tripoint, int, monster_tripoint_hash> costs;
+    std::unordered_map<tripoint, tripoint, monster_tripoint_hash> next_steps;
+    std::unordered_set<tripoint, monster_tripoint_hash> settled;
+
+    monster_reverse_field_entry()
+    {
+        costs.reserve( 4096 );
+        next_steps.reserve( 4096 );
+        settled.reserve( 4096 );
+    }
+
+    void reset( const tripoint &new_target )
+    {
+        target = new_target;
+        frontier = decltype( frontier )();
+        costs.clear();
+        next_steps.clear();
+        settled.clear();
+        costs.emplace( target, 0 );
+        frontier.push( { 0, target } );
+    }
+};
+
+std::optional<time_point> monster_path_cache_turn;
+std::map<monster_route_cache_key, monster_route_cache_entry> monster_route_cache;
+std::map<monster_z_route_cache_key, monster_z_route_plan> monster_z_route_cache;
+std::map<monster_route_cache_key, std::unique_ptr<monster_reverse_field_entry>>
+monster_reverse_fields;
+std::vector<std::unique_ptr<monster_reverse_field_entry>> monster_reverse_field_pool;
+std::size_t monster_route_cache_edges = 0;
+std::size_t monster_reverse_field_nodes = 0;
+std::optional<bool> monster_improved_pathfinding_mode;
+int monster_pathfinding_mode_generation = 1;
+
+void clear_monster_path_caches()
+{
+    monster_route_cache.clear();
+    monster_z_route_cache.clear();
+    monster_route_cache_edges = 0;
+    monster_reverse_field_nodes = 0;
+
+    for( auto &field_pair : monster_reverse_fields ) {
+        monster_reverse_field_pool.emplace_back( std::move( field_pair.second ) );
+    }
+    monster_reverse_fields.clear();
+}
+
+void refresh_monster_path_caches()
+{
+    if( !monster_path_cache_turn || *monster_path_cache_turn != calendar::turn ) {
+        monster_path_cache_turn = calendar::turn;
+        clear_monster_path_caches();
+    }
+}
+
+int refresh_monster_pathfinding_mode( bool improved )
+{
+    if( !monster_improved_pathfinding_mode ||
+        *monster_improved_pathfinding_mode != improved ) {
+        monster_improved_pathfinding_mode = improved;
+        ++monster_pathfinding_mode_generation;
+        monster_path_cache_turn.reset();
+        clear_monster_path_caches();
+    }
+    return monster_pathfinding_mode_generation;
+}
+
+monster_reverse_field_entry *get_monster_reverse_field(
+    const monster_route_cache_key &key )
+{
+    const auto existing = monster_reverse_fields.find( key );
+    if( existing != monster_reverse_fields.end() ) {
+        return existing->second.get();
+    }
+    if( monster_reverse_fields.size() >= monster_reverse_field_max_count ) {
+        return nullptr;
+    }
+
+    std::unique_ptr<monster_reverse_field_entry> field;
+    if( monster_reverse_field_pool.empty() ) {
+        field = std::make_unique<monster_reverse_field_entry>();
+    } else {
+        field = std::move( monster_reverse_field_pool.back() );
+        monster_reverse_field_pool.pop_back();
+    }
+    field->reset( key.target );
+    monster_reverse_field_entry *result = field.get();
+    monster_reverse_fields.emplace( key, std::move( field ) );
+    return result;
 }
 } // namespace
 
@@ -1055,7 +1194,18 @@ void monster::move()
         return;
     }
 
-    if( failed_pathfinding_cooldown > 0 ) {
+    const bool improved_pathfinding =
+        get_option<std::string>( "MONSTER_PATHFINDING" ) != "classic";
+    const int pathfinding_mode_generation =
+        refresh_monster_pathfinding_mode( improved_pathfinding );
+    if( pathfinding_mode_generation_seen != pathfinding_mode_generation ) {
+        path.clear();
+        failed_pathfinding_target.reset();
+        failed_pathfinding_cooldown = 0;
+        pathfinding_mode_generation_seen = pathfinding_mode_generation;
+    }
+
+    if( improved_pathfinding && failed_pathfinding_cooldown > 0 ) {
         --failed_pathfinding_cooldown;
     }
 
@@ -1065,7 +1215,7 @@ void monster::move()
     creature_tracker &creatures = get_creature_tracker();
     const bool can_open_doors = has_flag( MF_CAN_OPEN_DOORS ) && !is_hallucination();
     const int current_bash_estimate = bash_estimate();
-    const bool can_bash = current_bash_estimate > 0;
+    const bool can_bash = improved_pathfinding ? current_bash_estimate > 0 : bash_skill() > 0;
 
     for( const tripoint &dest : here.points_in_radius( pos(), 1 ) ) {
         if( dest == pos() ) {
@@ -1073,6 +1223,14 @@ void monster::move()
         }
 
         const Creature *occupant = creatures.creature_at( dest, true );
+        if( !improved_pathfinding ) {
+            if( can_move_to( dest ) && occupant == nullptr ) {
+                try_to_move = true;
+                break;
+            }
+            continue;
+        }
+
         const bool can_enter = can_move_to( dest ) && occupant == nullptr;
         const bool can_attack_occupant = occupant != nullptr &&
                                          attitude_to( *occupant ) == Attitude::HOSTILE;
@@ -1085,20 +1243,21 @@ void monster::move()
             break;
         }
     }
+
     // If true, don't try to greedily avoid locally bad paths
     bool pathed = false;
     const tripoint local_dest = here.getlocal( get_dest() );
 
     pathfinding_settings pf_settings = get_pathfinding_settings();
-    pf_settings.allow_open_doors = pf_settings.allow_open_doors || can_open_doors;
-    pf_settings.bash_strength = std::max( pf_settings.bash_strength, current_bash_estimate );
-
-    // Many old monster definitions have no path radius at all.  Give them a
-    // bounded local search rather than an unlimited one.  Long-distance travel
-    // stays on the cheap greedy movement used by Breeze.
-    if( pf_settings.max_dist <= 0 ) {
-        pf_settings.max_dist = fallback_monster_path_radius;
-        pf_settings.max_length = fallback_monster_path_radius * 5;
+    if( improved_pathfinding ) {
+        pf_settings.allow_open_doors = pf_settings.allow_open_doors || can_open_doors;
+        pf_settings.bash_strength = std::max( pf_settings.bash_strength, current_bash_estimate );
+        if( pf_settings.max_dist <= 0 ) {
+            pf_settings.max_dist = fallback_monster_path_radius;
+        }
+        if( pf_settings.max_length <= 0 ) {
+            pf_settings.max_length = pf_settings.max_dist * 5;
+        }
     }
 
     auto cached_step_is_usable = [&]( const tripoint &step ) {
@@ -1116,8 +1275,16 @@ void monster::move()
     };
 
     auto try_route_to = [&]( const tripoint &route_dest ) {
+        if( !improved_pathfinding || route_dest == pos() ) {
+            return false;
+        }
+
+        const bool cross_z = route_dest.z != posz();
+        const int route_radius = cross_z ?
+                                 std::max( pf_settings.max_dist, cross_z_monster_path_radius ) :
+                                 pf_settings.max_dist;
         const int route_distance = rl_dist( pos(), route_dest );
-        if( route_dest == pos() || route_distance > pf_settings.max_dist ) {
+        if( route_distance > route_radius ) {
             return false;
         }
 
@@ -1134,22 +1301,35 @@ void monster::move()
             path.clear();
         }
 
+        refresh_monster_path_caches();
+        const monster_route_cache_key cache_key {
+            type->id,
+            route_dest,
+            quantize_monster_bash_strength( pf_settings.bash_strength ),
+            pf_settings.allow_open_doors
+        };
+        const monster_z_route_cache_key z_cache_key { cache_key, posz() };
+
+        const auto z_plan_iter = cross_z ? monster_z_route_cache.find( z_cache_key ) :
+                                 monster_z_route_cache.end();
+        const bool has_z_plan = z_plan_iter != monster_z_route_cache.end();
+        const tripoint segment_dest = has_z_plan && pos() != z_plan_iter->second.approach ?
+                                      z_plan_iter->second.approach : route_dest;
+
+        const bool existing_path_matches = !path.empty() &&
+                                           ( path.back() == route_dest ||
+                                             path.back() == segment_dest );
         const bool need_new_path = path.empty() || rl_dist( pos(), path.front() ) >= 2 ||
-                                   path.back() != route_dest;
+                                   !existing_path_matches;
         if( need_new_path ) {
+            path.clear();
             if( failed_pathfinding_target && *failed_pathfinding_target == absolute_route_dest &&
                 failed_pathfinding_cooldown > 0 ) {
                 return false;
             }
 
-            refresh_monster_route_cache();
-            const monster_route_cache_key cache_key {
-                type->id,
-                route_dest,
-                quantize_monster_bash_strength( pf_settings.bash_strength ),
-                pf_settings.allow_open_doors
-            };
-
+            // A complete route stores every suffix.  Monsters that already stand
+            // on that route, including a stair approach tile, can join it for free.
             const auto cache_iter = monster_route_cache.find( cache_key );
             if( cache_iter != monster_route_cache.end() ) {
                 std::vector<tripoint> cached_path;
@@ -1175,13 +1355,168 @@ void monster::move()
                 }
             }
 
-            if( path.empty() || path.back() != route_dest ) {
-                path = here.route( pos(), route_dest, pf_settings, get_path_avoid() );
+            auto build_reverse_field_path = [&]( const tripoint &field_target,
+                                                  int field_max_radius ) {
+                std::vector<tripoint> result;
+                if( field_target.z != posz() || pos() == field_target ||
+                    rl_dist( pos(), field_target ) > field_max_radius ) {
+                    return result;
+                }
+
+                const monster_route_cache_key field_key {
+                    type->id,
+                    field_target,
+                    quantize_monster_bash_strength( pf_settings.bash_strength ),
+                    pf_settings.allow_open_doors
+                };
+                monster_reverse_field_entry *field = get_monster_reverse_field( field_key );
+                if( field == nullptr ) {
+                    return result;
+                }
+
+                constexpr int impassable_cost = std::numeric_limits<int>::max() / 8;
+                const auto transition_cost = [&]( const tripoint &from, const tripoint &to ) {
+                    if( !here.inbounds( from ) || !here.inbounds( to ) ||
+                        from.z != to.z ) {
+                        return impassable_cost;
+                    }
+                    if( from.x != to.x && from.y != to.y ) {
+                        const tripoint side_a( from.x, to.y, from.z );
+                        const tripoint side_b( to.x, from.y, from.z );
+                        if( here.impassable( side_a ) && here.impassable( side_b ) ) {
+                            return impassable_cost;
+                        }
+                    }
+
+                    int result_cost = impassable_cost;
+                    if( will_move_to( to ) ) {
+                        result_cost = std::max( 1, calc_movecost( from, to ) );
+                    } else if( can_open_doors &&
+                               here.open_door( *this, to, !here.is_outside( from ), true ) ) {
+                        result_cost = 100;
+                    } else if( can_bash ) {
+                        const int rating = here.bash_rating( current_bash_estimate, to );
+                        if( rating == 1 ) {
+                            result_cost = 2400;
+                        } else if( rating > 1 ) {
+                            result_cost = 100 + std::max( 1, 10 / rating ) * 100;
+                        }
+                    }
+
+                    const Creature *blocking = creatures.creature_at( to, true );
+                    if( result_cost < impassable_cost && blocking != nullptr &&
+                        blocking != this && to != field_target ) {
+                        result_cost += 150;
+                    }
+                    return result_cost;
+                };
+
+                std::size_t expanded_this_request = 0;
+                while( field->settled.count( pos() ) == 0 && !field->frontier.empty() &&
+                       expanded_this_request < monster_reverse_field_request_budget &&
+                       monster_reverse_field_nodes < monster_reverse_field_turn_budget ) {
+                    const monster_reverse_field_node current = field->frontier.top();
+                    field->frontier.pop();
+                    const auto known_cost = field->costs.find( current.position );
+                    if( known_cost == field->costs.end() || known_cost->second != current.cost ||
+                        !field->settled.insert( current.position ).second ) {
+                        continue;
+                    }
+
+                    ++expanded_this_request;
+                    ++monster_reverse_field_nodes;
+                    if( current.position == pos() ) {
+                        break;
+                    }
+
+                    for( int dx = -1; dx <= 1; ++dx ) {
+                        for( int dy = -1; dy <= 1; ++dy ) {
+                            if( dx == 0 && dy == 0 ) {
+                                continue;
+                            }
+                            const tripoint previous( current.position.x + dx,
+                                                     current.position.y + dy,
+                                                     current.position.z );
+                            if( !here.inbounds( previous ) ||
+                                rl_dist( previous, field_target ) > field_max_radius ) {
+                                continue;
+                            }
+                            const int edge_cost = transition_cost( previous, current.position );
+                            if( edge_cost >= impassable_cost ||
+                                current.cost > impassable_cost - edge_cost ) {
+                                continue;
+                            }
+                            const int new_cost = current.cost + edge_cost;
+                            const auto previous_cost = field->costs.find( previous );
+                            if( previous_cost == field->costs.end() || new_cost < previous_cost->second ) {
+                                field->costs[previous] = new_cost;
+                                field->next_steps[previous] = current.position;
+                                field->frontier.push( { new_cost, previous } );
+                            }
+                        }
+                    }
+                }
+
+                if( field->settled.count( pos() ) == 0 ) {
+                    return result;
+                }
+
+                std::set<tripoint> visited;
+                tripoint cursor = pos();
+                const std::size_t max_steps = static_cast<std::size_t>(
+                            std::max( 1, pf_settings.max_length ) );
+                while( cursor != field_target && result.size() < max_steps &&
+                       visited.insert( cursor ).second ) {
+                    const auto next_iter = field->next_steps.find( cursor );
+                    if( next_iter == field->next_steps.end() || next_iter->second == cursor ) {
+                        result.clear();
+                        return result;
+                    }
+                    result.push_back( next_iter->second );
+                    cursor = next_iter->second;
+                }
+                if( result.empty() || result.back() != field_target ||
+                    !cached_step_is_usable( result.front() ) ) {
+                    result.clear();
+                }
+                return result;
+            };
+
+            if( path.empty() && segment_dest != route_dest ) {
+                path = build_reverse_field_path( segment_dest, reverse_field_cross_z_radius );
+            }
+            if( path.empty() && !cross_z ) {
+                path = build_reverse_field_path( route_dest,
+                                                 std::min( route_radius, reverse_field_radius ) );
+            }
+
+            if( path.empty() ) {
+                pathfinding_settings route_settings = pf_settings;
+                if( cross_z ) {
+                    route_settings.max_dist = route_radius;
+                    route_settings.max_length = std::max( route_settings.max_length,
+                                                         route_radius * 8 );
+                }
+                path = here.route( pos(), route_dest, route_settings, get_path_avoid() );
             }
 
             if( !path.empty() && path.back() == route_dest ) {
                 failed_pathfinding_target.reset();
                 failed_pathfinding_cooldown = 0;
+
+                if( cross_z ) {
+                    tripoint previous = pos();
+                    const int wanted_z_direction = route_dest.z > posz() ? 1 : -1;
+                    for( const tripoint &step : path ) {
+                        if( step.z != previous.z ) {
+                            if( ( step.z - previous.z ) * wanted_z_direction > 0 ) {
+                                monster_z_route_cache[z_cache_key] = { previous, step };
+                            }
+                            break;
+                        }
+                        previous = step;
+                    }
+                }
 
                 if( monster_route_cache_edges < monster_route_cache_max_edges ) {
                     monster_route_cache_entry &entry = monster_route_cache[cache_key];
@@ -1197,9 +1532,11 @@ void monster::move()
                         from = step;
                     }
                 }
+            } else if( !path.empty() && path.back() == segment_dest ) {
+                failed_pathfinding_target.reset();
+                failed_pathfinding_cooldown = 0;
             } else {
-                // Different monsters spread retries across several actions, avoiding
-                // a synchronized search spike around an impossible sealed target.
+                path.clear();
                 failed_pathfinding_target = absolute_route_dest;
                 failed_pathfinding_cooldown = 2 +
                                                ( std::abs( posx() + posy() + posz() ) % 3 );
@@ -1207,7 +1544,8 @@ void monster::move()
             }
         }
 
-        if( !path.empty() && path.back() == route_dest ) {
+        if( !path.empty() &&
+            ( path.back() == route_dest || path.back() == segment_dest ) ) {
             destination = path.front();
             moved = true;
             pathed = true;
@@ -1216,13 +1554,31 @@ void monster::move()
         return false;
     };
 
-    if( try_to_move ) {
-        if( !is_wandering() ) {
+    if( try_to_move && !is_wandering() ) {
+        if( improved_pathfinding ) {
             const int target_distance = rl_dist( pos(), local_dest );
-            if( !try_route_to( local_dest ) && target_distance > pf_settings.max_dist ) {
-                // Keep Breeze's inexpensive long-range steering.  Inside the
-                // bounded path radius a failed route no longer becomes blind
-                // wall-banging.
+            const int target_path_radius = local_dest.z != posz() ?
+                                           std::max( pf_settings.max_dist,
+                                                     cross_z_monster_path_radius ) :
+                                           pf_settings.max_dist;
+            if( !try_route_to( local_dest ) && target_distance > target_path_radius ) {
+                destination = local_dest;
+                moved = true;
+            }
+        } else {
+            while( !path.empty() && path.front() == pos() ) {
+                path.erase( path.begin() );
+            }
+            if( pf_settings.max_dist >= rl_dist( get_location(), get_dest() ) &&
+                ( path.empty() || rl_dist( pos(), path.front() ) >= 2 ||
+                  path.back() != local_dest ) ) {
+                path = here.route( pos(), local_dest, pf_settings, get_path_avoid() );
+            }
+            if( !path.empty() && path.back() == local_dest ) {
+                destination = path.front();
+                moved = true;
+                pathed = true;
+            } else {
                 destination = local_dest;
                 moved = true;
             }
@@ -1233,7 +1589,7 @@ void monster::move()
            !has_effect( effect_led_by_leash ) ) ) {
         // No sight... or our plans are invalid (e.g. moving through a transparent, but
         //  solid, square of terrain).  Fall back to smell if we have it.
-        
+
         if (was_controlled_by_friendly_monster_controller) {
             destination = get_map().getlocal(get_dest());
         }
@@ -1247,21 +1603,29 @@ void monster::move()
         }
     }
     if( wandf > 0 && !moved && friendly == 0 ) { // No LOS, no scent, so as a fall-back follow sound
-        if( wander_pos != get_location() ) {
-            const tripoint sound_dest = here.getlocal( wander_pos );
-            const int sound_distance = rl_dist( pos(), sound_dest );
-            unset_dest();
+        if( improved_pathfinding ) {
+            if( wander_pos != get_location() ) {
+                const tripoint sound_dest = here.getlocal( wander_pos );
+                const int sound_distance = rl_dist( pos(), sound_dest );
+                const int sound_path_radius = sound_dest.z != posz() ?
+                                              std::max( pf_settings.max_dist,
+                                                        cross_z_monster_path_radius ) :
+                                              pf_settings.max_dist;
+                unset_dest();
 
-            if( !try_route_to( sound_dest ) && sound_distance > pf_settings.max_dist ) {
-                // Very distant sounds retain cheap directional pursuit.  Once
-                // close enough, route costs choose doors, windows, stairs or a
-                // bashable weak point instead of the nearest wall.
-                destination = sound_dest;
+                if( !try_route_to( sound_dest ) && sound_distance > sound_path_radius ) {
+                    destination = sound_dest;
+                    moved = true;
+                }
+            }
+        } else {
+            unset_dest();
+            if( wander_pos != get_location() ) {
+                destination = here.getlocal( wander_pos );
                 moved = true;
             }
         }
     }
-
     point new_d( destination.xy() - pos().xy() );
 
     // toggle facing direction for sdl flip

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3799,66 +3799,97 @@ float monster::get_mountable_weight_ratio() const
     return type->mountable_weight_ratio;
 }
 
-void monster::hear_sound(const tripoint& source, const int vol, const int dist, bool provocative)
+void monster::hear_sound( const tripoint &source, const int vol, const int dist,
+                          bool provocative )
 {
-    if (!can_hear()) {
+    monster_sound_source source_info;
+    source_info.provocative = provocative;
+    hear_sound( source, vol, dist, source_info );
+}
+
+void monster::hear_sound( const tripoint &source, const int vol, const int dist,
+                          const monster_sound_source &source_info )
+{
+    if( !can_hear() ) {
         return;
     }
 
-    const bool goodhearing = has_flag(MF_GOODHEARING);
+    const bool goodhearing = has_flag( MF_GOODHEARING );
     const int volume = goodhearing ? 2 * vol - dist : vol - dist;
-    // Error is based on volume, louder sound = less error
-    if (volume <= 0) {
+    if( volume <= 0 ) {
         return;
     }
 
-    int tmp_provocative = provocative || volume >= normal_roll(30, 5);
-    // already following a more interesting sound
-    if (provocative_sound && !tmp_provocative && wandf > 0) {
+    const bool improved_pathfinding =
+        get_option<std::string>( "MONSTER_PATHFINDING" ) != "classic";
+    if( improved_pathfinding && source_info.from_monster &&
+        source_info.monster_faction.is_valid() ) {
+        const mf_attitude source_attitude =
+            faction.obj().attitude( source_info.monster_faction );
+        const bool allied_source =
+            get_monster_faction() == source_info.monster_faction ||
+            source_attitude == MFA_FRIENDLY;
+
+        // CBN's most important sound-AI rule.  Allied movement cannot create a
+        // feedback loop, while destructive or urgent allied sounds remain usable.
+        if( allied_source && source_info.movement_noise ) {
+            return;
+        }
+        if( allied_source && source_info.category < sounds::sound_t::alarm &&
+            vol < 90 ) {
+            return;
+        }
+    }
+
+    if( improved_pathfinding && hostile_target_memory_turns > 0 &&
+        last_hostile_target_position ) {
+        const bool urgent_sound = source_info.provocative ||
+                                  source_info.category >= sounds::sound_t::alarm ||
+                                  volume >= 70;
+        const bool pulls_to_another_level =
+            source.z != last_hostile_target_position->z();
+        // A monster that has just confirmed a hostile target should not abandon
+        // that floor for ordinary background noise.  Gunfire, alarms and very
+        // loud destruction can still interrupt it.
+        if( !urgent_sound && ( pulls_to_another_level || volume < 40 ) ) {
+            return;
+        }
+    }
+
+    const bool tmp_provocative = source_info.provocative ||
+                                 volume >= normal_roll( 30, 5 );
+    if( provocative_sound && !tmp_provocative && wandf > 0 ) {
         return;
     }
 
     int max_error = 0;
-    if (volume < 2) {
+    if( volume < 2 ) {
         max_error = 10;
-    }
-    else if (volume < 5) {
+    } else if( volume < 5 ) {
         max_error = 5;
-    }
-    else if (volume < 10) {
+    } else if( volume < 10 ) {
         max_error = 3;
-    }
-    else if (volume < 20) {
+    } else if( volume < 20 ) {
         max_error = 1;
     }
 
-    tripoint_abs_ms target = get_map().getglobal(source) + point(rng(-max_error, max_error),
-        rng(-max_error, max_error));
-    // target_z will require some special check due to soil muffling sounds
-
-    const int wander_turns = volume * (goodhearing ? 6 : 1);
-    // again, already following a more interesting sound
-    if (wander_turns < wandf) {
+    tripoint_abs_ms target = get_map().getglobal( source ) +
+                             point( rng( -max_error, max_error ),
+                                    rng( -max_error, max_error ) );
+    const int wander_turns = volume * ( goodhearing ? 6 : 1 );
+    if( wander_turns < wandf ) {
         return;
     }
-    // only trigger this if the monster is not friendly or the source isn't the player
-    if (friendly == 0 || source != get_player_character().pos()) {
-        process_trigger(mon_trigger::SOUND, volume);
+    if( friendly == 0 || source != get_player_character().pos() ) {
+        process_trigger( mon_trigger::SOUND, volume );
     }
     provocative_sound = tmp_provocative;
-    if (morale >= 0 && anger >= 10) {
-        // TODO: Add a proper check for fleeing attitude
-        // but cache it nicely, because this part is called a lot
-        wander_to(target, wander_turns);
-    }
-    else if (morale < 0) {
-        // Monsters afraid of sound should not go towards sound.
-        // Move towards a point on the opposite side of us from the target.
-        // TODO: make the destination scale with the sound and handle
-        // the case when (x,y) is the same by picking a random direction
-        tripoint_abs_ms away = get_location() + (get_location() - target);
+    if( morale >= 0 && anger >= 10 ) {
+        wander_to( target, wander_turns );
+    } else if( morale < 0 ) {
+        tripoint_abs_ms away = get_location() + ( get_location() - target );
         away.z() = posz();
-        wander_to(away, wander_turns);
+        wander_to( away, wander_turns );
     }
 }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3841,7 +3841,16 @@ void monster::hear_sound( const tripoint &source, const int vol, const int dist,
         }
     }
 
-    bool cross_z_priority_sound = false;
+    // Sight is the top-level sensor.  Use a one-turn stamp instead of an
+    // attack-target lookup here, because this runs in the sound-by-monster hot
+    // loop during a horde event.
+    if( improved_pathfinding && last_hostile_sighting_turn &&
+        calendar::turn <= *last_hostile_sighting_turn +
+        time_duration::from_turns( 1 ) ) {
+        return;
+    }
+
+    bool priority_sound = false;
     if( improved_pathfinding && hostile_target_memory_turns > 0 &&
         last_hostile_target_position ) {
         const bool urgent_sound = source_info.provocative ||
@@ -3849,16 +3858,20 @@ void monster::hear_sound( const tripoint &source, const int vol, const int dist,
                                   volume >= 70;
         const bool pulls_to_another_level =
             source.z != last_hostile_target_position->z();
-        // Ordinary noise remains below a recently confirmed target.  An urgent,
-        // clearly audible sound on another floor is different: it is the missing
-        // hand-off between hearing and cross-Z pathfinding, so retire the stale
-        // visual memory and let the sound route take over.
-        if( !urgent_sound && ( pulls_to_another_level || volume < 40 ) ) {
-            return;
-        }
-        cross_z_priority_sound = urgent_sound && pulls_to_another_level &&
-                                 volume >= 10;
-        if( cross_z_priority_sound ) {
+        const bool searching_last_seen =
+            ( hostile_search_step > 0 || hostile_transition_attempts > 0 ) &&
+            last_hostile_target_position->z() == posz();
+        const bool relevant_search_lead = searching_last_seen &&
+            source.z == posz() && volume >= 4 &&
+            ( source_info.provocative || source_info.movement_noise ||
+              source_info.category >= sounds::sound_t::speech || volume >= 20 );
+
+        // Visual memory wins while the monster is still travelling to the exact
+        // last-seen tile.  Once local search has begun, a plausible sound on the
+        // same floor is better evidence than a blind search pattern and may take
+        // over immediately.  Allied movement was already rejected above.
+        if( relevant_search_lead ) {
+            priority_sound = true;
             last_hostile_target_position.reset();
             hostile_target_memory_turns = 0;
             hostile_search_turns = 0;
@@ -3866,10 +3879,30 @@ void monster::hear_sound( const tripoint &source, const int vol, const int dist,
             hostile_search_waypoint_turns = 0;
             hostile_search_lane = 0;
             hostile_transition_attempts = 0;
+            hostile_search_deadline.reset();
             unset_dest();
+        } else {
+            // Ordinary noise remains below a recently confirmed visual target.
+            // Urgent cross-Z sound is the explicit hand-off to acoustic pursuit.
+            if( !urgent_sound && ( pulls_to_another_level || volume < 40 ) ) {
+                return;
+            }
+            priority_sound = urgent_sound && pulls_to_another_level &&
+                             volume >= 10;
+            if( priority_sound ) {
+                last_hostile_target_position.reset();
+                hostile_target_memory_turns = 0;
+                hostile_search_turns = 0;
+                hostile_search_step = 0;
+                hostile_search_waypoint_turns = 0;
+                hostile_search_lane = 0;
+                hostile_transition_attempts = 0;
+                hostile_search_deadline.reset();
+                unset_dest();
+            }
         }
     } else if( improved_pathfinding && source.z != posz() ) {
-        cross_z_priority_sound =
+        priority_sound =
             ( source_info.provocative ||
               source_info.category >= sounds::sound_t::alarm ) &&
             volume >= 10;
@@ -3896,7 +3929,7 @@ void monster::hear_sound( const tripoint &source, const int vol, const int dist,
                              point( rng( -max_error, max_error ),
                                     rng( -max_error, max_error ) );
     const int wander_turns = volume * ( goodhearing ? 6 : 1 );
-    if( wander_turns < wandf && !cross_z_priority_sound ) {
+    if( wander_turns < wandf && !priority_sound ) {
         return;
     }
     if( friendly == 0 || source != get_player_character().pos() ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3841,6 +3841,7 @@ void monster::hear_sound( const tripoint &source, const int vol, const int dist,
         }
     }
 
+    bool cross_z_priority_sound = false;
     if( improved_pathfinding && hostile_target_memory_turns > 0 &&
         last_hostile_target_position ) {
         const bool urgent_sound = source_info.provocative ||
@@ -3848,12 +3849,30 @@ void monster::hear_sound( const tripoint &source, const int vol, const int dist,
                                   volume >= 70;
         const bool pulls_to_another_level =
             source.z != last_hostile_target_position->z();
-        // A monster that has just confirmed a hostile target should not abandon
-        // that floor for ordinary background noise.  Gunfire, alarms and very
-        // loud destruction can still interrupt it.
+        // Ordinary noise remains below a recently confirmed target.  An urgent,
+        // clearly audible sound on another floor is different: it is the missing
+        // hand-off between hearing and cross-Z pathfinding, so retire the stale
+        // visual memory and let the sound route take over.
         if( !urgent_sound && ( pulls_to_another_level || volume < 40 ) ) {
             return;
         }
+        cross_z_priority_sound = urgent_sound && pulls_to_another_level &&
+                                 volume >= 10;
+        if( cross_z_priority_sound ) {
+            last_hostile_target_position.reset();
+            hostile_target_memory_turns = 0;
+            hostile_search_turns = 0;
+            hostile_search_step = 0;
+            hostile_search_waypoint_turns = 0;
+            hostile_search_lane = 0;
+            hostile_transition_attempts = 0;
+            unset_dest();
+        }
+    } else if( improved_pathfinding && source.z != posz() ) {
+        cross_z_priority_sound =
+            ( source_info.provocative ||
+              source_info.category >= sounds::sound_t::alarm ) &&
+            volume >= 10;
     }
 
     const bool tmp_provocative = source_info.provocative ||
@@ -3877,7 +3896,7 @@ void monster::hear_sound( const tripoint &source, const int vol, const int dist,
                              point( rng( -max_error, max_error ),
                                     rng( -max_error, max_error ) );
     const int wander_turns = volume * ( goodhearing ? 6 : 1 );
-    if( wander_turns < wandf ) {
+    if( wander_turns < wandf && !cross_z_priority_sound ) {
         return;
     }
     if( friendly == 0 || source != get_player_character().pos() ) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -628,6 +628,8 @@ class monster : public Creature
         int hostile_search_step = 0;
         int hostile_search_waypoint_turns = 0;
         int hostile_search_lane = 0;
+        // At most one speculative stair hand-off per confirmed sighting.
+        int hostile_transition_attempts = 0;
         /** patrol points for monsters that can pathfind and have a patrol route! **/
         std::vector<tripoint_abs_ms> patrol_route;
         int next_patrol_point = -1;

--- a/src/monster.h
+++ b/src/monster.h
@@ -39,6 +39,7 @@ class window;
 }  // namespace catacurses
 struct dealt_projectile_attack;
 struct pathfinding_settings;
+struct monster_sound_source;
 struct trap;
 
 enum class mon_trigger : int;
@@ -473,6 +474,8 @@ class monster : public Creature
          * @param distance Distance to sound source (currently just rl_dist)
          */
         void hear_sound( const tripoint &source, int vol, int distance, bool provocative );
+        void hear_sound( const tripoint &source, int vol, int distance,
+                         const monster_sound_source &source_info );
 
         bool is_hallucination() const override;    // true if the monster isn't actually real
 
@@ -617,6 +620,14 @@ class monster : public Creature
         std::optional<tripoint_abs_ms> failed_pathfinding_target;
         int failed_pathfinding_cooldown = 0;
         int pathfinding_mode_generation_seen = 0;
+        // Transient confirmed-hostile memory.  Kept out of saves on purpose;
+        // loading a game must not grant monsters knowledge they did not reacquire.
+        std::optional<tripoint_abs_ms> last_hostile_target_position;
+        int hostile_target_memory_turns = 0;
+        int hostile_search_turns = 0;
+        int hostile_search_step = 0;
+        int hostile_search_waypoint_turns = 0;
+        int hostile_search_lane = 0;
         /** patrol points for monsters that can pathfind and have a patrol route! **/
         std::vector<tripoint_abs_ms> patrol_route;
         int next_patrol_point = -1;

--- a/src/monster.h
+++ b/src/monster.h
@@ -630,6 +630,10 @@ class monster : public Creature
         int hostile_search_lane = 0;
         // At most one speculative stair hand-off per confirmed sighting.
         int hostile_transition_attempts = 0;
+        // Wall-clock deadline makes search expiry independent of plan cadence.
+        std::optional<time_point> hostile_search_deadline;
+        // Cheap sensor-priority stamp, avoids a target lookup for every sound.
+        std::optional<time_point> last_hostile_sighting_turn;
         /** patrol points for monsters that can pathfind and have a patrol route! **/
         std::vector<tripoint_abs_ms> patrol_route;
         int next_patrol_point = -1;

--- a/src/monster.h
+++ b/src/monster.h
@@ -616,6 +616,7 @@ class monster : public Creature
          */
         std::optional<tripoint_abs_ms> failed_pathfinding_target;
         int failed_pathfinding_cooldown = 0;
+        int pathfinding_mode_generation_seen = 0;
         /** patrol points for monsters that can pathfind and have a patrol route! **/
         std::vector<tripoint_abs_ms> patrol_route;
         int next_patrol_point = -1;

--- a/src/monster.h
+++ b/src/monster.h
@@ -610,6 +610,12 @@ class monster : public Creature
         monster_horde_attraction horde_attraction = MHA_NULL;
         /** Found path. Note: Not used by monsters that don't pathfind! **/
         std::vector<tripoint> path;
+        /**
+         * Transient backoff after a failed bounded route.  These values are not
+         * serialized because they are only a CPU-rate limiter, not game state.
+         */
+        std::optional<tripoint_abs_ms> failed_pathfinding_target;
+        int failed_pathfinding_cooldown = 0;
         /** patrol points for monsters that can pathfind and have a patrol route! **/
         std::vector<tripoint_abs_ms> patrol_route;
         int next_patrol_point = -1;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2527,7 +2527,7 @@ void options_manager::add_options_world_default()
     add("怪物可以积累经验值而升级", "world_default", to_translation("怪物可以积累经验值而升级"), to_translation("当此选项的值为 是 时，怪物可以通过击杀敌人来获取经验值，当经验值达到标准后，怪物即可升级。"), false);
     add( "MONSTER_PATHFINDING", "world_default",
          to_translation( "怪物寻路" ),
-    to_translation( "经典使用微风原本的怪物移动逻辑，改进启用门窗判断，声音寻路，声源阵营识别，跨层追击，有限搜索和共享反向距离图。" ), {
+    to_translation( "经典使用微风原本的怪物移动逻辑，改进启用门窗判断，声源阵营识别，楼梯声道，跨层追击，有限搜索和共享反向距离图。" ), {
         { "classic", to_translation( "经典" ) },
         { "improved", to_translation( "改进" ) }
     }, "improved"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2527,7 +2527,7 @@ void options_manager::add_options_world_default()
     add("怪物可以积累经验值而升级", "world_default", to_translation("怪物可以积累经验值而升级"), to_translation("当此选项的值为 是 时，怪物可以通过击杀敌人来获取经验值，当经验值达到标准后，怪物即可升级。"), false);
     add( "MONSTER_PATHFINDING", "world_default",
          to_translation( "怪物寻路" ),
-    to_translation( "经典使用微风原本的怪物移动逻辑，改进启用门窗判断，声音寻路，跨层追击和共享反向距离图。" ), {
+    to_translation( "经典使用微风原本的怪物移动逻辑，改进启用门窗判断，声音寻路，声源阵营识别，跨层追击，有限搜索和共享反向距离图。" ), {
         { "classic", to_translation( "经典" ) },
         { "improved", to_translation( "改进" ) }
     }, "improved"

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2525,6 +2525,13 @@ void options_manager::add_options_world_default()
        );
     add("怪物的等级动态变化", "world_default", to_translation("怪物的等级动态变化"), to_translation("当此选项的值为 是 时，怪物的等级将动态变化。当此选项的值为 否 时，怪物的等级默认为0级。等级影响速度和近战伤害。"), false);
     add("怪物可以积累经验值而升级", "world_default", to_translation("怪物可以积累经验值而升级"), to_translation("当此选项的值为 是 时，怪物可以通过击杀敌人来获取经验值，当经验值达到标准后，怪物即可升级。"), false);
+    add( "MONSTER_PATHFINDING", "world_default",
+         to_translation( "怪物寻路" ),
+    to_translation( "经典使用微风原本的怪物移动逻辑，改进启用门窗判断，声音寻路，跨层追击和共享反向距离图。" ), {
+        { "classic", to_translation( "经典" ) },
+        { "improved", to_translation( "改进" ) }
+    }, "improved"
+       );
 
     add_empty_line();
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -185,7 +185,7 @@ static const trait_id trait_NOPAIN( "NOPAIN" );
 
 struct monster_sound_event {
     int volume;
-    bool provocative;
+    monster_sound_source source;
 };
 
 struct sound_event {
@@ -206,7 +206,7 @@ struct centroid {
     float z;
     float volume;
     float weight;
-    bool provocative;
+    monster_sound_source source;
 };
 
 namespace io
@@ -306,6 +306,20 @@ static bool is_provocative( sounds::sound_t category )
     cata_fatal( "Invalid sound_t category" );
 }
 
+static monster_sound_source make_monster_sound_source(
+    sounds::sound_t category, const monster *source, bool movement_noise )
+{
+    monster_sound_source result;
+    result.category = category;
+    result.provocative = is_provocative( category );
+    result.movement_noise = movement_noise;
+    result.from_monster = source != nullptr;
+    if( source != nullptr ) {
+        result.monster_faction = source->get_monster_faction();
+    }
+    return result;
+}
+
 void sounds::ambient_sound( const tripoint &p, int vol, sound_t category,
                             const std::string &description )
 {
@@ -326,7 +340,9 @@ void sounds::sound( const tripoint &p, int vol, sound_t category, const std::str
     }
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
-    recent_sounds.emplace_back( std::make_pair( p, monster_sound_event{ vol, is_provocative( category ) } ) );
+    recent_sounds.emplace_back( std::make_pair( p, monster_sound_event { vol,
+                                         make_monster_sound_source( category, nullptr,
+                                                 category == sound_t::movement ) } ) );
     sounds_since_last_turn.emplace_back( std::make_pair( p,
                                          sound_event { vol, category, description, ambient,
                                                  false, id, variant, seas_str } ) );
@@ -338,13 +354,59 @@ void sounds::sound( const tripoint &p, int vol, sound_t category, const translat
     sounds::sound( p, vol, category, description.translated(), ambient, id, variant );
 }
 
-void sounds::add_footstep( const tripoint &p, int volume, int, monster *,
+void sounds::sound( const tripoint &p, int vol, sound_t category,
+                    const std::string &description, bool ambient,
+                    const std::string &id, const std::string &variant,
+                    const monster *source )
+{
+    if( vol < 0 ) {
+        debugmsg( "negative sound volume %d", vol );
+        return;
+    }
+    if( description.empty() ) {
+        debugmsg( "Sound at %d:%d has no description!", p.x, p.y );
+    }
+    const season_type seas = season_of_year( calendar::turn );
+    const std::string seas_str = season_str( seas );
+    recent_sounds.emplace_back( std::make_pair( p, monster_sound_event { vol,
+                                         make_monster_sound_source( category, source,
+                                                 category == sound_t::movement ) } ) );
+    sounds_since_last_turn.emplace_back( std::make_pair( p,
+                                         sound_event { vol, category, description, ambient,
+                                                 false, id, variant, seas_str } ) );
+}
+
+void sounds::tag_recent_sound_from_monster( const tripoint &p, const monster *source,
+        sound_t category )
+{
+    if( source == nullptr ) {
+        return;
+    }
+    for( auto event = recent_sounds.rbegin(); event != recent_sounds.rend(); ++event ) {
+        if( event->first == p && !event->second.source.from_monster &&
+            event->second.source.category >= sounds::sound_t::destructive_activity ) {
+            event->second.source = make_monster_sound_source( category, source,
+                                   category == sound_t::movement );
+            return;
+        }
+    }
+}
+
+void sounds::add_footstep( const tripoint &p, int volume, int, monster *source,
                            const std::string &footstep )
 {
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
+    // Normal medium footsteps remain a player-facing marker only.  Large and
+    // huge movement is loud enough to matter to hostile factions, while allied
+    // listeners discard it before distance calculations.
+    if( volume >= 10 ) {
+        recent_sounds.emplace_back( std::make_pair( p, monster_sound_event { volume,
+                                             make_monster_sound_source( sound_t::movement,
+                                                     source, true ) } ) );
+    }
     sounds_since_last_turn.emplace_back( std::make_pair( p, sound_event { volume,
-                                         sound_t::movement, footstep, false, true, "", "", seas_str} ) );
+                                         sound_t::movement, footstep, false, true, "", "", seas_str } ) );
 }
 
 template <typename C>
@@ -358,70 +420,99 @@ static void vector_quick_remove( std::vector<C> &source, int index )
     source.pop_back();
 }
 
+static bool compatible_monster_sound_sources( const monster_sound_source &lhs,
+        const monster_sound_source &rhs )
+{
+    if( lhs.from_monster != rhs.from_monster ||
+        lhs.movement_noise != rhs.movement_noise ) {
+        return false;
+    }
+    return !lhs.from_monster || lhs.monster_faction == rhs.monster_faction;
+}
+
+static centroid make_sound_centroid(
+    const std::pair<tripoint, monster_sound_event> &event )
+{
+    return centroid {
+        static_cast<float>( event.first.x ),
+        static_cast<float>( event.first.y ),
+        static_cast<float>( event.first.z ),
+        static_cast<float>( event.second.volume ),
+        static_cast<float>( event.second.volume ),
+        event.second.source
+    };
+}
+
 static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, monster_sound_event>>
         input_sounds )
 {
-    // If there are too many monsters and too many noise sources (which can be monsters, go figure),
-    // applying sound events to monsters can dominate processing time for the whole game,
-    // so we cluster sounds and apply the centroids of the sounds to the monster AI
-    // to fight the combinatorial explosion.
+    // Keep source factions in separate clusters.  This avoids the old failure
+    // mode where several zombie footsteps became one anonymous centroid which
+    // then attracted the same zombies that created it.
     std::vector<centroid> sound_clusters;
     if( input_sounds.empty() ) {
         return sound_clusters;
     }
+
     const int num_seed_clusters =
         std::max( std::min( input_sounds.size(), static_cast<size_t>( 10 ) ),
                   static_cast<size_t>( std::log( input_sounds.size() ) ) );
     const size_t stopping_point = input_sounds.size() - num_seed_clusters;
     const size_t max_map_distance = sound_distance( tripoint( point_zero, OVERMAP_DEPTH ),
                                     tripoint( MAPSIZE_X, MAPSIZE_Y, OVERMAP_HEIGHT ) );
-    // Randomly choose cluster seeds.
-    for( size_t i = input_sounds.size(); i > stopping_point; i-- ) {
-        size_t index = rng( 0, i - 1 );
-        // The volume and cluster weight are the same for the first element.
-        sound_clusters.push_back(
-            // Assure the compiler that these int->float conversions are safe.
-        {
-            static_cast<float>( input_sounds[index].first.x ), static_cast<float>( input_sounds[index].first.y ),
-            static_cast<float>( input_sounds[index].first.z ),
-            static_cast<float>( input_sounds[index].second.volume ), static_cast<float>( input_sounds[index].second.volume ),
-            input_sounds[index].second.provocative
-        } );
+
+    for( size_t i = input_sounds.size(); i > stopping_point; --i ) {
+        const size_t index = rng( 0, i - 1 );
+        sound_clusters.push_back( make_sound_centroid( input_sounds[index] ) );
         vector_quick_remove( input_sounds, index );
     }
-    for( const auto &sound_event_pair : input_sounds ) {
-        auto found_centroid = sound_clusters.begin();
-        float dist_factor = max_map_distance;
-        const auto cluster_end = sound_clusters.end();
-        for( auto centroid_iter = sound_clusters.begin(); centroid_iter != cluster_end;
-             ++centroid_iter ) {
-            // Scale the distance between the two by the max possible distance.
-            tripoint centroid_pos { static_cast<int>( centroid_iter->x ), static_cast<int>( centroid_iter->y ), static_cast<int>( centroid_iter->z ) };
-            const int dist = sound_distance( sound_event_pair.first, centroid_pos );
+
+    for( const auto &event : input_sounds ) {
+        auto found_centroid = sound_clusters.end();
+        float dist_factor = static_cast<float>( max_map_distance ) *
+                            static_cast<float>( max_map_distance );
+        for( auto centroid_iter = sound_clusters.begin();
+             centroid_iter != sound_clusters.end(); ++centroid_iter ) {
+            if( !compatible_monster_sound_sources( event.second.source,
+                                                   centroid_iter->source ) ) {
+                continue;
+            }
+            const tripoint centroid_pos {
+                static_cast<int>( centroid_iter->x ),
+                static_cast<int>( centroid_iter->y ),
+                static_cast<int>( centroid_iter->z )
+            };
+            const int dist = sound_distance( event.first, centroid_pos );
             if( dist * dist < dist_factor ) {
                 found_centroid = centroid_iter;
-                dist_factor = dist * dist;
+                dist_factor = static_cast<float>( dist * dist );
             }
         }
-        const float volume_sum = static_cast<float>( sound_event_pair.second.volume ) +
+
+        if( found_centroid == sound_clusters.end() ) {
+            sound_clusters.push_back( make_sound_centroid( event ) );
+            continue;
+        }
+
+        const float volume_sum = static_cast<float>( event.second.volume ) +
                                  found_centroid->weight;
-        // Set the centroid location to the average of the two locations, weighted by volume.
-        found_centroid->x = static_cast<float>( ( sound_event_pair.first.x *
-                                                sound_event_pair.second.volume ) +
-                                                ( found_centroid->x * found_centroid->weight ) ) / volume_sum;
-        found_centroid->y = static_cast<float>( ( sound_event_pair.first.y *
-                                                sound_event_pair.second.volume ) +
-                                                ( found_centroid->y * found_centroid->weight ) ) / volume_sum;
-        found_centroid->z = static_cast<float>( ( sound_event_pair.first.z *
-                                                sound_event_pair.second.volume ) +
-                                                ( found_centroid->z * found_centroid->weight ) ) / volume_sum;
-        // Set the centroid volume to the larger of the volumes.
+        found_centroid->x = static_cast<float>( ( event.first.x * event.second.volume ) +
+                                                ( found_centroid->x * found_centroid->weight ) ) /
+                            volume_sum;
+        found_centroid->y = static_cast<float>( ( event.first.y * event.second.volume ) +
+                                                ( found_centroid->y * found_centroid->weight ) ) /
+                            volume_sum;
+        found_centroid->z = static_cast<float>( ( event.first.z * event.second.volume ) +
+                                                ( found_centroid->z * found_centroid->weight ) ) /
+                            volume_sum;
         found_centroid->volume = std::max( found_centroid->volume,
-                                           static_cast<float>( sound_event_pair.second.volume ) );
-        // Set the centroid weight to the sum of the weights.
+                                           static_cast<float>( event.second.volume ) );
         found_centroid->weight = volume_sum;
-        // Set and keep provocative if any sound in the centroid is provocative
-        found_centroid->provocative |= sound_event_pair.second.provocative;
+        found_centroid->source.provocative |= event.second.source.provocative;
+        if( static_cast<int>( event.second.source.category ) >
+            static_cast<int>( found_centroid->source.category ) ) {
+            found_centroid->source.category = event.second.source.category;
+        }
     }
     return sound_clusters;
 }
@@ -456,30 +547,45 @@ void sounds::process_sounds()
 {
     std::vector<centroid> sound_clusters = cluster_sounds( recent_sounds );
     const int weather_vol = get_weather().weather_id->sound_attn;
+    creature_tracker &creatures = get_creature_tracker();
+
     for( const centroid &this_centroid : sound_clusters ) {
-        // Since monsters don't go deaf ATM we can just use the weather modified volume
-        // If they later get physical effects from loud noises we'll have to change this
-        // to use the unmodified volume for those effects.
         const int vol = this_centroid.volume - weather_vol;
-        const tripoint source = tripoint( this_centroid.x, this_centroid.y, this_centroid.z );
-        // --- Monster sound handling here ---
-        // Alert all hordes
+        const tripoint source( this_centroid.x, this_centroid.y, this_centroid.z );
+        monster_sound_source source_info = this_centroid.source;
+
+        // Older callers do not yet pass an explicit source.  Recover it when the
+        // sound centroid still lands on a monster.  Explicit metadata always wins.
+        if( !source_info.from_monster ) {
+            Creature *origin_creature = creatures.creature_at( source, true );
+            monster *origin_monster = dynamic_cast<monster *>( origin_creature );
+            if( origin_monster != nullptr ) {
+                source_info.from_monster = true;
+                source_info.monster_faction = origin_monster->get_monster_faction();
+            }
+        }
+
         int sig_power = get_signal_for_hordes( this_centroid );
         if( sig_power > 0 ) {
-
             const point abs_ms = get_map().getabs( source.xy() );
-            // TODO: fix point types
             const point_abs_sm abs_sm( ms_to_sm_copy( abs_ms ) );
             const tripoint_abs_sm target( abs_sm, source.z );
             overmap_buffer.signal_hordes( target, sig_power );
         }
-        // Alert all monsters (that can hear) to the sound.
+
         for( monster &critter : g->all_monsters() ) {
-            // TODO: Generalize this to Creature::hear_sound
+            // This is the hottest case in a horde.  Reject allied footsteps
+            // before doing distance and hearing calculations.
+            if( source_info.from_monster && source_info.monster_faction.is_valid() &&
+                critter.get_monster_faction() == source_info.monster_faction &&
+                ( source_info.movement_noise ||
+                  ( source_info.category < sounds::sound_t::alarm && vol < 90 ) ) ) {
+                continue;
+            }
+
             const int dist = sound_distance( source, critter.pos() );
             if( vol * 2 > dist ) {
-                // Exclude monsters that certainly won't hear the sound
-                critter.hear_sound( source, vol, dist, this_centroid.provocative );
+                critter.hear_sound( source, vol, dist, source_info );
             }
         }
     }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -4,7 +4,9 @@
 #include <chrono>
 #include <cmath>
 #include <cstdlib>
+#include <map>
 #include <memory>
+#include <tuple>
 #include <type_traits>
 #include <unordered_map>
 
@@ -266,6 +268,156 @@ static int sound_distance( const tripoint &source, const tripoint &sink )
     vertical_attenuation *= 5;
     return rl_dist( source.xy(), sink.xy() ) + vertical_attenuation;
 }
+
+// Phase four: a small acoustic portal cache for monster AI.  The old sound
+// distance remains the fallback for sealed floors.  When a nearby stair, ramp
+// or open shaft exists, sounds may instead travel to the listener's level via
+// that portal.  One route is calculated per sound centroid and target Z level,
+// then shared by every monster on that level.
+namespace
+{
+constexpr int monster_sound_portal_search_radius = 30;
+constexpr int monster_sound_portal_step_cost = 3;
+constexpr int monster_sound_max_z_steps = 3;
+constexpr std::size_t monster_sound_route_cache_max_entries = 96;
+
+struct monster_vertical_sound_route {
+    int source_to_exit_distance = 0;
+    tripoint exit;
+};
+
+std::optional<time_point> monster_sound_route_cache_turn;
+std::optional<point> monster_sound_route_cache_origin;
+std::map<std::pair<tripoint, int>, std::optional<monster_vertical_sound_route>>
+monster_sound_route_cache;
+
+void refresh_monster_sound_route_cache()
+{
+    const point current_origin = get_map().getabs( point_zero );
+    if( !monster_sound_route_cache_turn ||
+        *monster_sound_route_cache_turn != calendar::turn ||
+        !monster_sound_route_cache_origin ||
+        *monster_sound_route_cache_origin != current_origin ) {
+        monster_sound_route_cache_turn = calendar::turn;
+        monster_sound_route_cache_origin = current_origin;
+        monster_sound_route_cache.clear();
+    }
+}
+
+bool is_vertical_sound_portal( map &here, const tripoint &candidate, int dz )
+{
+    const tripoint next( candidate.x, candidate.y, candidate.z + dz );
+    if( !here.inbounds( candidate ) || !here.inbounds( next ) ) {
+        return false;
+    }
+
+    if( dz > 0 ) {
+        const bool explicit_transition =
+            here.has_flag( ter_furn_flag::TFLAG_GOES_UP, candidate ) ||
+            here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, candidate ) ||
+            here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, next );
+        const bool open_shaft =
+            here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, next );
+        return explicit_transition || open_shaft;
+    }
+
+    const bool explicit_transition =
+        here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, candidate ) ||
+        here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, candidate ) ||
+        here.has_flag( ter_furn_flag::TFLAG_GOES_UP, next );
+    const bool open_shaft =
+        here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, candidate );
+    return explicit_transition || open_shaft;
+}
+
+std::optional<tripoint> nearest_vertical_sound_portal( map &here,
+        const tripoint &origin, int dz )
+{
+    std::optional<tripoint> best;
+    int best_distance = monster_sound_portal_search_radius + 1;
+
+    for( const tripoint &candidate :
+         here.points_in_radius( origin, monster_sound_portal_search_radius ) ) {
+        if( candidate.z != origin.z ||
+            !is_vertical_sound_portal( here, candidate, dz ) ) {
+            continue;
+        }
+
+        const int distance = rl_dist( origin, candidate );
+        if( distance < best_distance ||
+            ( distance == best_distance && best &&
+              std::tie( candidate.x, candidate.y, candidate.z ) <
+              std::tie( best->x, best->y, best->z ) ) ) {
+            best = candidate;
+            best_distance = distance;
+        }
+    }
+    return best;
+}
+
+std::optional<monster_vertical_sound_route> vertical_sound_route_to_level(
+    const tripoint &source, int target_z )
+{
+    if( source.z == target_z ) {
+        return monster_vertical_sound_route { 0, source };
+    }
+    if( std::abs( source.z - target_z ) > monster_sound_max_z_steps ) {
+        return std::nullopt;
+    }
+
+    refresh_monster_sound_route_cache();
+    const std::pair<tripoint, int> key( source, target_z );
+    const auto cached = monster_sound_route_cache.find( key );
+    if( cached != monster_sound_route_cache.end() ) {
+        return cached->second;
+    }
+
+    // Refuse to grow without bound in pathological multi-faction sound storms.
+    if( monster_sound_route_cache.size() >=
+        monster_sound_route_cache_max_entries ) {
+        return std::nullopt;
+    }
+
+    map &here = get_map();
+    monster_vertical_sound_route route;
+    route.exit = source;
+    const int dz = target_z > source.z ? 1 : -1;
+
+    while( route.exit.z != target_z ) {
+        const std::optional<tripoint> portal =
+            nearest_vertical_sound_portal( here, route.exit, dz );
+        if( !portal ) {
+            monster_sound_route_cache.emplace( key, std::nullopt );
+            return std::nullopt;
+        }
+
+        route.source_to_exit_distance += rl_dist( route.exit, *portal );
+        route.source_to_exit_distance += monster_sound_portal_step_cost;
+        route.exit = tripoint( portal->x, portal->y, portal->z + dz );
+    }
+
+    monster_sound_route_cache.emplace( key, route );
+    return route;
+}
+
+int monster_sound_distance( const tripoint &source, const tripoint &listener )
+{
+    const int sealed_distance = sound_distance( source, listener );
+    if( source.z == listener.z ) {
+        return sealed_distance;
+    }
+
+    const std::optional<monster_vertical_sound_route> route =
+        vertical_sound_route_to_level( source, listener.z );
+    if( !route ) {
+        return sealed_distance;
+    }
+
+    const int portal_distance = route->source_to_exit_distance +
+                                rl_dist( route->exit, listener );
+    return std::min( sealed_distance, portal_distance );
+}
+} // namespace
 
 static std::string season_str( const season_type &season )
 {
@@ -583,7 +735,7 @@ void sounds::process_sounds()
                 continue;
             }
 
-            const int dist = sound_distance( source, critter.pos() );
+            const int dist = monster_sound_distance( source, critter.pos() );
             if( vol * 2 > dist ) {
                 critter.hear_sound( source, vol, dist, source_info );
             }

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "units_fwd.h"
+#include "type_id.h"
 #include <optional>
 
 class Character;
@@ -58,6 +59,11 @@ void sound( const tripoint &p, int vol, sound_t category, const std::string &des
 void sound( const tripoint &p, int vol, sound_t category, const translation &description,
             bool ambient = false, const std::string &id = "",
             const std::string &variant = "default" );
+void sound( const tripoint &p, int vol, sound_t category, const std::string &description,
+            bool ambient, const std::string &id, const std::string &variant,
+            const monster *source );
+void tag_recent_sound_from_monster( const tripoint &p, const monster *source,
+                                    sound_t category );
 /** Functions identical to sound(..., true). */
 void ambient_sound( const tripoint &p, int vol, sound_t category, const std::string &description );
 /** Creates a list of coordinates at which to draw footsteps. */
@@ -87,6 +93,20 @@ extern bool sound_enabled;
 template<>
 struct enum_traits<sounds::sound_t> {
     static constexpr sounds::sound_t last = sounds::sound_t::LAST;
+};
+
+/** Lightweight source metadata used by monster hearing.
+ *
+ * This deliberately stores a faction id instead of a monster pointer.  Sound
+ * processing is deferred, so the original creature may already have moved or
+ * died by the time listeners react.
+ */
+struct monster_sound_source {
+    sounds::sound_t category = sounds::sound_t::background;
+    bool provocative = false;
+    bool movement_noise = false;
+    bool from_monster = false;
+    mfaction_id monster_faction;
 };
 
 namespace sfx


### PR DESCRIPTION
## 概述

将 `codex/breeze-monster-smart-pathing-phase1` 合并到 `main`，完成怪物智能寻路第一阶段的声音感知、跨层追踪和有限搜索改进。

## 主要改动

- 为怪物声音事件增加来源、阵营、移动噪声和挑衅性元数据，避免同阵营移动噪声互相吸引，并在声音聚类时隔离不同阵营来源。
- 增加跨 Z 级声音路由：通过楼梯等垂直通道传播声音，使用有界缓存控制重复计算和异常噪声场景的开销。
- 改进怪物声音感知、敌对目标记忆和阵营判断，修复追击状态之间的冲突。
- 增加带反向距离场的怪物寻路选项、障碍感知回退和有限的局部搜索，降低无界搜索风险。
- 增加跨层楼梯交接和跨 Z 级声音传播，改善怪物追踪目标在楼层变化后的连续性。
- 修复 `mfaction_id::is_valid` 相关链接问题。
- 在世界设置中可以开关改进AI与旧版本AI。
## 测试

- Windows Tiles x64 MSVC：workflow run 78，提交 `fdf492b1`。
- Android arm64：同一工作流通过。
- 本地 PC 测试包验证通过，工作区差异检查干净。
- 本分支不新增 Lua 内容。