### PR TITLE
修复垂直爆炸楼板破坏与坑洞生成

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -317,6 +317,7 @@ private:
 
     std::vector<dist_point_pair> blast_map;
     std::vector<dist_point_pair> shrapnel_map;
+    std::set<tripoint> blast_tiles;
     std::priority_queue<time_event_pair, std::vector<time_event_pair>, pair_greater_cmp_first>
         event_queue;
 
@@ -415,6 +416,7 @@ void ExplosionProcess::fill_maps()
         //   which, as stated above, converts trig_dist into int implicitly
         if (blast_radius > 0 && static_cast<int>(z_aware_distance) <= blast_radius) {
             blast_map.push_back({ z_aware_distance, target });
+            blast_tiles.insert(target);
         }
 
         if (shrapnel && static_cast<int>(distance) <= shrapnel_range && target.z == center.z &&
@@ -746,12 +748,16 @@ void ExplosionProcess::blast_tile(const tripoint position, const int rl_distance
         const float blast_force_decay = (ExplosionConstants::VEHICLE_DAMAGE_MULT - 1.0) *
             blast_power / ExplosionConstants::MULTIBASH_COUNT;
         cata_assert(blast_force_decay > 0);
+        const tripoint below = position + tripoint_below;
+        // Lower z-levels are processed later. If the blast reaches the tile below,
+        // allow this floor to be breached without waiting for that tile to become passable.
+        const bool blast_reaches_below = blast_tiles.count(below) > 0;
         while (terrain_blast_force > 0) {
             bash_params bash{
                 static_cast<int>(terrain_blast_force * 0.1),
                 true,
                 false,
-                here.passable(position + tripoint_below),
+                here.passable(below) || blast_reaches_below,
                 terrain_factor,
                 center.z > position.z,
                 true


### PR DESCRIPTION
## 概述

修复垂直爆炸处理顺序导致的楼板未破坏、坑洞生成不完整问题。

## 主要改动

- 在爆炸范围计算阶段记录所有受爆炸波及的 tile。
- 处理上层 tile 时，预先判断正下方 tile 是否也在爆炸范围内。
- 即使下层 tile 尚未按队列处理，只要爆炸确实会到达该位置，就允许上层楼板被爆炸冲击破坏。
- 保留原有多次 bash、地形阻挡和车辆伤害逻辑。

## 测试

- Windows Tiles x64 MSVC：workflow run 81，成功。
- Android arm64：workflow run 81，成功。
- 本地 PC 测试包验证无误。
- 本次改动未加入 Lua 文件、Lua 运行时或 Lua 构建依赖。