### PR TITLE
新增玩家和 NPC 移动射击预瞄

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1305,6 +1305,7 @@ bool avatar::wield( item &target, const int obtain_cost )
     }
     cached_info.erase( "weapon_value" );
     if( target.is_null() ) {
+        clear_moving_preaim();
         return true;
     }
 
@@ -1343,6 +1344,7 @@ bool avatar::wield( item &target, const int obtain_cost )
     weapon = get_wielded_item();
     last_item = weapon->typeId();
     recoil = MAX_RECOIL;
+    clear_moving_preaim();
 
     weapon->on_wield( *this );
 

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -262,6 +262,10 @@ class avatar : public Character
         // Preferred aim mode - ranged.cpp aim mode defaults to this if possible
         std::string preferred_aiming_mode;
 
+        void clear_moving_preaim();
+        void update_moving_preaim( int spent_moves, bool stationary );
+        double moving_preaim_recoil( const item &weapon, const Creature &target ) const;
+
         // checks if the point is blocked based on characters current aiming state
         bool cant_see( const tripoint &p );
 
@@ -425,6 +429,12 @@ class avatar : public Character
 
         // true when the space is still visible when aiming
         cata::mdarray<bool, point_bub_ms> aim_cache;
+
+        struct moving_preaim_target_state {
+            weak_ptr_fast<Creature> target;
+            double recoil = MAX_RECOIL;
+        };
+        std::vector<moving_preaim_target_state> moving_preaim_targets; // NOLINT(cata-serialize)
 };
 
 avatar &get_avatar();

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -158,6 +158,19 @@ static bool check_water_affect_items( avatar &you )
 
 bool avatar_action::move( avatar &you, map &m, const tripoint &d )
 {
+    const tripoint preaim_start_pos = you.pos();
+    const int preaim_start_moves = you.moves;
+    struct moving_preaim_guard {
+        avatar &you;
+        tripoint start_pos;
+        int start_moves;
+        ~moving_preaim_guard() {
+            if( you.pos() != start_pos ) {
+                you.update_moving_preaim( std::max( 0, start_moves - you.moves ), false );
+            }
+        }
+    } preaim_guard{ you, preaim_start_pos, preaim_start_moves };
+
     bool in_shell = you.has_active_mutation( trait_SHELL2 ) ||
                     you.has_active_mutation( trait_SHELL3 );
     if( ( !g->check_safe_mode_allowed() ) || in_shell ) {
@@ -326,6 +339,9 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     bool attacking = false;
     if( creatures.creature_at( dest_loc ) ) {
         attacking = true;
+    }
+    if( attacking ) {
+        you.clear_moving_preaim();
     }
 
     if( !you.move_effects( attacking ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11768,6 +11768,9 @@ void Character::environmental_revert_effect()
 
 void Character::pause()
 {
+    if( is_avatar() ) {
+        as_avatar()->update_moving_preaim( std::max( moves, 0 ), true );
+    }
     moves = 0;
     recoil = MAX_RECOIL;
     map &here = get_map();

--- a/src/npc.h
+++ b/src/npc.h
@@ -1142,6 +1142,11 @@ class npc : public Character
         item_location find_usable_ammo( const item_location &weap );
         item_location find_usable_ammo( const item_location &weap ) const;
 
+        void clear_moving_preaim();
+        void update_moving_preaim( int spent_moves, bool stationary );
+        double moving_preaim_recoil( const item &weapon, const Creature &target ) const;
+        void remember_moving_preaim_recoil( const item &weapon, const Creature &target, double recoil );
+
         bool dispose_item( item_location &&obj, const std::string &prompt = std::string() ) override;
 
         void update_cardio_acc() override {};
@@ -1313,6 +1318,10 @@ class npc : public Character
         std::map<std::string, time_point> complaints;
 
         npc_short_term_cache ai_cache;
+
+        weak_ptr_fast<Creature> moving_preaim_target; // NOLINT(cata-serialize)
+        itype_id moving_preaim_weapon = itype_id::NULL_ID(); // NOLINT(cata-serialize)
+        double moving_preaim_recoil_cache = MAX_RECOIL; // NOLINT(cata-serialize)
 
         std::map<npc_need, npc_need_goal_cache> goal_cache;
 

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -386,6 +386,7 @@ void npc_attack_gun::use( npc &source, const tripoint &location ) const
     map& m = get_map();
 
     if( !source.is_wielding( gun ) ) {
+        source.clear_moving_preaim();
         if( !source.wield( gun ) ) {
             debugmsg( "ERROR: npc tried to equip a weapon it couldn't wield" );
         }
@@ -393,6 +394,7 @@ void npc_attack_gun::use( npc &source, const tripoint &location ) const
     }
 
     if( !gun.ammo_sufficient( &source ) ) {
+        source.clear_moving_preaim();
         // todo: make gun an item_location instead of getting wielded item here
         // but since wielding is required before this, it should be fine
         source.do_reload( source.get_wielded_item() );
@@ -415,17 +417,24 @@ void npc_attack_gun::use( npc &source, const tripoint &location ) const
     const int dist = rl_dist_exact( source.pos(), location );
     const Target_attributes target_attributes( source.pos(), location );
 
+    Creature *target = get_creature_tracker().creature_at( location );
+    if( target != nullptr && source.sees( *target ) ) {
+        source.recoil = std::min( source.recoil, source.moving_preaim_recoil( gun, *target ) );
+    }
+
     // Only aim if we aren't in risk of being hit
     // TODO: Get distance to closest enemy
     if( dist > 1 && source.aim_per_move( gun, source.recoil, target_attributes ) > 0 &&
         source.confident_gun_mode_range( gunmode, source.recoil ) < dist ) {
         add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is aiming", source.disp_name() );
-        Creature *target = get_creature_tracker().creature_at( location );
         if( target != nullptr && target->is_avatar() && get_player_character().sees( source ) ) {
             add_msg( m_warning, _( "%s takes aim at you." ), source.disp_name() );
         }
 
         source.aim( target_attributes );
+        if( target != nullptr ) {
+            source.remember_moving_preaim_recoil( gun, *target, source.recoil );
+        }
         if( source.moves > 0 ) {
             source.moves = 0;
         }
@@ -438,6 +447,7 @@ void npc_attack_gun::use( npc &source, const tripoint &location ) const
     } else {
         source.fire_gun( location );
     }
+    source.clear_moving_preaim();
     add_msg_debug( debugmode::debug_filter::DF_NPC, "%s fires %s", source.disp_name(),
                    gun.display_name() );
 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2395,6 +2395,7 @@ bool npc::can_move_to( const tripoint &p, bool no_bashing ) const
 
 void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomove )
 {   
+    const int preaim_start_moves = moves;
     bool has_special_effect_want_trade = has_effect(effect_want_trade);
     tripoint p = pt;
     map &here = get_map();
@@ -2629,6 +2630,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
 
         here.creature_on_trap( *this );
         here.creature_in_field( *this );
+        update_moving_preaim( std::max( 0, preaim_start_moves - moves ), false );
     }
 }
 
@@ -2860,6 +2862,7 @@ void npc::move_pause()
         }
     }
     if( !get_wielded_item() || !get_wielded_item()->is_gun() ) {
+        clear_moving_preaim();
         pause();
         return;
     }
@@ -2870,14 +2873,18 @@ void npc::move_pause()
         return;
     }
 
+    item &weapon = *get_wielded_item();
     Creature *target = current_target();
     if( target == nullptr || !sees( *target ) ) {
+        update_moving_preaim( std::max( moves, 0 ), true );
         recoil = MAX_RECOIL;
         pause();
         return;
     }
 
+    recoil = std::min( recoil, moving_preaim_recoil( weapon, *target ) );
     aim( Target_attributes( pos(), target->pos() ) );
+    remember_moving_preaim_recoil( weapon, *target, recoil );
     moves = std::min( moves, 0 );
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2687,6 +2687,11 @@ void options_manager::add_options_world_default()
     }, "improved"
        );
 
+    add( "MOVING_PREAIM", "world_default", to_translation( "移动射击预瞄" ),
+         to_translation( "开启后，玩家和NPC只有在实际看见敌对目标时才会积累预瞄，移动和等待都可用于预瞄，不同移动姿态具有不同速度和精度上限，目标离开视野后已有预瞄会逐渐衰减。" ),
+         true
+       );
+
     add_empty_line();
 
     add( "VEHICLE_PART_DEGRADATION", "world_default",

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -142,6 +144,27 @@ static const std::set<material_id> ferric = { material_iron, material_steel, mat
 // Maximum duration of aim-and-fire loop, in turns
 static constexpr int AIF_DURATION_LIMIT = 10;
 
+static constexpr double MOVING_PREAIM_WALK_EFFICIENCY = 0.40;
+static constexpr double MOVING_PREAIM_CROUCH_EFFICIENCY = 0.50;
+static constexpr double MOVING_PREAIM_RUN_EFFICIENCY = 0.20;
+static constexpr double MOVING_PREAIM_PRONE_EFFICIENCY = 0.35;
+static constexpr double MOVING_PREAIM_WALK_CAP = 0.65;
+static constexpr double MOVING_PREAIM_CROUCH_CAP = 0.75;
+static constexpr double MOVING_PREAIM_RUN_CAP = 0.35;
+static constexpr double MOVING_PREAIM_PRONE_CAP = 0.85;
+static constexpr double MOVING_PREAIM_OUT_OF_RANGE_EFFICIENCY = 0.25;
+static constexpr double MOVING_PREAIM_OUT_OF_RANGE_CAP = 0.25;
+static constexpr double MOVING_PREAIM_BOW_CAP = 0.50;
+// A completely prepared aim fades to an unprepared state after about five seconds
+// without visual contact.  This keeps short corner peeks useful without allowing
+// permanent wall tracking.
+static constexpr int MOVING_PREAIM_LOST_SIGHT_DECAY_MOVES = 500;
+
+struct moving_preaim_parameters {
+    double efficiency = 1.0;
+    double cap = 1.0;
+};
+
 static projectile make_gun_projectile( const item &gun );
 static int time_to_attack( const Character &p, const itype &firing );
 /**
@@ -152,6 +175,262 @@ static int time_to_attack( const Character &p, const itype &firing );
 */
 static void cycle_action( item &weap, const itype_id &ammo, const tripoint &pos );
 static void make_gun_sound_effect( const Character &p, bool burst, item *weapon );
+
+static moving_preaim_parameters moving_preaim_params( const Character &who, const bool stationary )
+{
+    if( stationary ) {
+        return { 1.0, 1.0 };
+    }
+    if( who.is_running() ) {
+        return { MOVING_PREAIM_RUN_EFFICIENCY, MOVING_PREAIM_RUN_CAP };
+    }
+    if( who.is_prone() ) {
+        return { MOVING_PREAIM_PRONE_EFFICIENCY, MOVING_PREAIM_PRONE_CAP };
+    }
+    if( who.is_crouching() ) {
+        return { MOVING_PREAIM_CROUCH_EFFICIENCY, MOVING_PREAIM_CROUCH_CAP };
+    }
+    return { MOVING_PREAIM_WALK_EFFICIENCY, MOVING_PREAIM_WALK_CAP };
+}
+
+static double moving_preaim_floor( const Character &who, const item &weapon,
+                                   double cap, const bool out_of_range )
+{
+    if( out_of_range ) {
+        cap = std::min( cap, MOVING_PREAIM_OUT_OF_RANGE_CAP );
+    }
+    if( weapon.ammo_types().count( ammo_arrow ) > 0 ) {
+        cap = std::min( cap, MOVING_PREAIM_BOW_CAP );
+    }
+
+    const double best = who.most_accurate_aiming_method_limit( weapon );
+    return MAX_RECOIL - ( MAX_RECOIL - best ) * cap;
+}
+
+static double improve_moving_preaim( const Character &who, item &weapon,
+                                     const Creature &target, double recoil,
+                                     const int spent_moves, const bool stationary )
+{
+    if( spent_moves <= 0 ) {
+        return recoil;
+    }
+
+    const moving_preaim_parameters params = moving_preaim_params( who, stationary );
+    int effective_moves = std::max( 1, static_cast<int>( std::round( spent_moves *
+                                    params.efficiency ) ) );
+    gun_mode mode = weapon.gun_current_mode();
+    const bool out_of_range = mode && rl_dist( who.pos(), target.pos() ) > mode.target->gun_range( &who );
+    if( out_of_range ) {
+        effective_moves = std::max( 1, static_cast<int>( std::round( effective_moves *
+                                        MOVING_PREAIM_OUT_OF_RANGE_EFFICIENCY ) ) );
+    }
+
+    const double floor = moving_preaim_floor( who, weapon, params.cap, out_of_range );
+    // Entering a less stable movement mode immediately sheds aim that the new posture
+    // cannot physically maintain.
+    double result = std::max( recoil, floor );
+    const Target_attributes attributes( who.pos(), target.pos() );
+    for( int i = 0; i < effective_moves; ++i ) {
+        const double amount = who.aim_per_move( weapon, result, attributes );
+        if( amount <= MIN_RECOIL_IMPROVEMENT ) {
+            break;
+        }
+        result = std::max( floor, result - amount );
+    }
+    return result;
+}
+
+static double decay_moving_preaim( const double recoil, const int spent_moves )
+{
+    if( recoil >= MAX_RECOIL || spent_moves <= 0 ) {
+        return recoil;
+    }
+    const double loss = MAX_RECOIL * static_cast<double>( spent_moves ) /
+                        MOVING_PREAIM_LOST_SIGHT_DECAY_MOVES;
+    return std::min( MAX_RECOIL, recoil + loss );
+}
+
+void avatar::clear_moving_preaim()
+{
+    moving_preaim_targets.clear();
+}
+
+void avatar::update_moving_preaim( const int spent_moves, const bool stationary )
+{
+    if( !get_option<bool>( "MOVING_PREAIM" ) ) {
+        clear_moving_preaim();
+        return;
+    }
+    if( spent_moves <= 0 ) {
+        return;
+    }
+    if( is_driving() || is_mounted() || is_underwater() ) {
+        clear_moving_preaim();
+        return;
+    }
+
+    item_location weapon_loc = get_wielded_item();
+    if( !weapon_loc || !weapon_loc->is_gun() ) {
+        clear_moving_preaim();
+        return;
+    }
+    item *weapon = &*weapon_loc;
+    gun_mode current_mode = weapon->gun_current_mode();
+    if( !current_mode || current_mode.melee() ) {
+        clear_moving_preaim();
+        return;
+    }
+
+    std::vector<Creature *> hostiles = g->get_creatures_if( [this]( const Creature &cr ) {
+        return &cr != this && attitude_to( cr ) == Creature::Attitude::HOSTILE &&
+               ( sees( cr ) || sees_with_infrared( cr ) );
+    } );
+
+    std::unordered_map<const Creature *, double> previous_recoil;
+    previous_recoil.reserve( moving_preaim_targets.size() );
+    for( const moving_preaim_target_state &state : moving_preaim_targets ) {
+        if( shared_ptr_fast<Creature> previous = state.target.lock() ) {
+            previous_recoil.emplace( previous.get(), state.recoil );
+        }
+    }
+
+    std::unordered_set<const Creature *> visible;
+    visible.reserve( hostiles.size() );
+    std::vector<moving_preaim_target_state> next_targets;
+    next_targets.reserve( hostiles.size() + moving_preaim_targets.size() );
+    for( Creature *cr : hostiles ) {
+        visible.emplace( cr );
+        const auto previous = previous_recoil.find( cr );
+        double tracked_recoil = previous != previous_recoil.end() ? previous->second : MAX_RECOIL;
+        // A target exposed by the movement that just finished starts at zero progress.
+        // Waiting is sampled before the world advances, so a target visible during a wait
+        // was already visible when that action began.
+        if( previous != previous_recoil.end() || stationary ) {
+            tracked_recoil = improve_moving_preaim( *this, *weapon, *cr, tracked_recoil,
+                                                    spent_moves, stationary );
+        }
+        next_targets.push_back( { g->shared_from( *cr ), tracked_recoil } );
+    }
+
+    for( const moving_preaim_target_state &state : moving_preaim_targets ) {
+        shared_ptr_fast<Creature> previous = state.target.lock();
+        if( !previous || visible.count( previous.get() ) > 0 ) {
+            continue;
+        }
+        if( attitude_to( *previous ) != Creature::Attitude::HOSTILE ) {
+            continue;
+        }
+        const double faded = decay_moving_preaim( state.recoil, spent_moves );
+        if( faded < MAX_RECOIL ) {
+            next_targets.push_back( { state.target, faded } );
+        }
+    }
+    moving_preaim_targets.swap( next_targets );
+}
+
+double avatar::moving_preaim_recoil( const item &weapon, const Creature &target ) const
+{
+    if( !get_option<bool>( "MOVING_PREAIM" ) || !weapon.is_gun() ||
+        attitude_to( target ) != Creature::Attitude::HOSTILE ||
+        !( sees( target ) || sees_with_infrared( target ) ) ) {
+        return MAX_RECOIL;
+    }
+    item_location wielded = get_wielded_item();
+    if( !wielded || &*wielded != &weapon ) {
+        return MAX_RECOIL;
+    }
+    for( const moving_preaim_target_state &state : moving_preaim_targets ) {
+        if( state.target.lock().get() == &target ) {
+            return state.recoil;
+        }
+    }
+    return MAX_RECOIL;
+}
+
+void npc::clear_moving_preaim()
+{
+    moving_preaim_target.reset();
+    moving_preaim_weapon = itype_id::NULL_ID();
+    moving_preaim_recoil_cache = MAX_RECOIL;
+}
+
+void npc::update_moving_preaim( const int spent_moves, const bool stationary )
+{
+    if( !get_option<bool>( "MOVING_PREAIM" ) ) {
+        clear_moving_preaim();
+        return;
+    }
+    if( is_driving() || is_mounted() || is_underwater() ) {
+        clear_moving_preaim();
+        return;
+    }
+
+    item_location weapon_loc = get_wielded_item();
+    if( !weapon_loc || !weapon_loc->is_gun() ) {
+        clear_moving_preaim();
+        return;
+    }
+    item *weapon = &*weapon_loc;
+    gun_mode current_mode = weapon->gun_current_mode();
+    if( !current_mode || current_mode.melee() ) {
+        clear_moving_preaim();
+        return;
+    }
+
+    Creature *target = current_target();
+    shared_ptr_fast<Creature> previous = moving_preaim_target.lock();
+    if( target == nullptr || attitude_to( *target ) != Creature::Attitude::HOSTILE ) {
+        if( previous && spent_moves > 0 ) {
+            moving_preaim_recoil_cache = decay_moving_preaim( moving_preaim_recoil_cache,
+                                          spent_moves );
+            if( moving_preaim_recoil_cache >= MAX_RECOIL ) {
+                clear_moving_preaim();
+            }
+        }
+        return;
+    }
+
+    const bool same_target = previous && previous.get() == target &&
+                             moving_preaim_weapon == weapon->typeId();
+    if( !same_target ) {
+        moving_preaim_target = g->shared_from( *target );
+        moving_preaim_weapon = weapon->typeId();
+        moving_preaim_recoil_cache = MAX_RECOIL;
+    }
+
+    if( !( sees( *target ) || sees_with_infrared( *target ) ) ) {
+        moving_preaim_recoil_cache = decay_moving_preaim( moving_preaim_recoil_cache,
+                                      spent_moves );
+        return;
+    }
+
+    if( same_target || stationary ) {
+        moving_preaim_recoil_cache = improve_moving_preaim( *this, *weapon, *target,
+                                      moving_preaim_recoil_cache, spent_moves, stationary );
+    }
+}
+
+double npc::moving_preaim_recoil( const item &weapon, const Creature &target ) const
+{
+    if( !get_option<bool>( "MOVING_PREAIM" ) || moving_preaim_weapon != weapon.typeId() ||
+        attitude_to( target ) != Creature::Attitude::HOSTILE ||
+        !( sees( target ) || sees_with_infrared( target ) ) ) {
+        return MAX_RECOIL;
+    }
+    shared_ptr_fast<Creature> tracked = moving_preaim_target.lock();
+    return tracked && tracked.get() == &target ? moving_preaim_recoil_cache : MAX_RECOIL;
+}
+
+void npc::remember_moving_preaim_recoil( const item &weapon, const Creature &target,
+        const double new_recoil )
+{
+    if( !get_option<bool>( "MOVING_PREAIM" ) || attitude_to( target ) != Creature::Attitude::HOSTILE ) {
+        return;
+    }
+    moving_preaim_target = g->shared_from( target );
+    moving_preaim_weapon = weapon.typeId();
+    moving_preaim_recoil_cache = std::min( moving_preaim_recoil_cache, new_recoil );
+}
 
 class target_ui
 {
@@ -207,6 +486,10 @@ class target_ui
         aim_type get_selected_aim_type() const;
 
         int get_sight_dispersion() const;
+
+        double get_predicted_recoil() const {
+            return predicted_recoil;
+        }
 
     private:
         enum class Status : int {
@@ -947,6 +1230,10 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun )
     // Use different amounts of time depending on the type of gun and our skill
     moves -= time_to_attack( *this, *gun_id );
 
+    if( curshot > 0 && is_avatar() ) {
+        as_avatar()->clear_moving_preaim();
+    }
+
     // Practice the base gun skill proportionally to number of hits, but always by one.
     if( !gun.has_flag( flag_WONT_TRAIN_MARKSMANSHIP ) ) {
         practice( skill_gun, ( hits + 1 ) * 5 );
@@ -1607,18 +1894,21 @@ static std::vector<aim_type_prediction> calculate_ranged_chances(
         if( mode == target_ui::TargetMode::Throw || mode == target_ui::TargetMode::ThrowBlind ) {
             prediction.moves = throw_cost( you, weapon );
         } else {
-            prediction.moves = you.gun_engagement_moves( weapon, aim_type.threshold, you.recoil, target )
+            prediction.moves = you.gun_engagement_moves( weapon, aim_type.threshold,
+                               static_cast<int>( ui.get_predicted_recoil() ), target )
                                + time_to_attack( you, *weapon.type );
         }
+        const double start_recoil = mode == target_ui::TargetMode::Fire ?
+                                    ui.get_predicted_recoil() : you.recoil;
         // predict how long it'll take to reach from current recoil
         // to the current aim mode's threshold.
         const recoil_prediction aim_to_type = predict_recoil( you, weapon, target,
-                                              ui.get_sight_dispersion(), aim_type, you.recoil );
+                                              ui.get_sight_dispersion(), aim_type, start_recoil );
 
         // predict how long it'll take to reach from current recoil
         // to the ui's selected default aim mode threshold.
         const recoil_prediction aim_to_selected = predict_recoil( you, weapon, target,
-                ui.get_sight_dispersion(), ui.get_selected_aim_type(), you.recoil );
+                ui.get_sight_dispersion(), ui.get_selected_aim_type(), start_recoil );
 
         // if the default method is "behind" the selected; e.g. you are in immediate
         // firing mode with almost close no chances of hitting, but UI has selected
@@ -2599,6 +2889,9 @@ target_handler::trajectory target_ui::run()
                 continue;
             }
             set_last_target();
+            if( mode == TargetMode::Fire ) {
+                apply_aim_turning_penalty();
+            }
             loop_exit_code = ExitCode::Fire;
             break;
         } else if( action == "AIM" ) {
@@ -2938,6 +3231,10 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
 
     // Update UI controls & colors
     update_status();
+    if( mode == TargetMode::Fire && status == Status::Good && dst_critter != nullptr ) {
+        predicted_recoil = std::min( predicted_recoil,
+                                     you->moving_preaim_recoil( *relevant, *dst_critter ) );
+    }
 
     return true;
 }


### PR DESCRIPTION
## 变更概要

为玩家和 NPC 增加“移动射击预瞄”机制，使角色在移动或等待过程中也能积累有限的瞄准进度，并在射击界面中正确反映预计后坐力。

## 修改目的

当前移动后再射击会完全丢失移动前已经建立的瞄准节奏。这个改动让移动射击更连贯，同时限制移动中的精度收益，避免移动预瞄等同于静止瞄准。

## 实现方案

- 新增世界选项 `MOVING_PREAIM`，默认开启。
- 玩家按目标分别记录预瞄状态；NPC 按当前目标和武器记录预瞄状态。
- 只有实际看见或红外发现的敌对目标才会积累预瞄；目标离开视野后预瞄逐渐衰减。
- 行走、蹲伏、奔跑、卧倒分别使用不同的积累效率和精度上限；静止等待可正常积累。
- 超出武器射程、弓箭武器和姿态变化会进一步限制可获得的预瞄收益。
- 切换武器、换弹、开火或发生近身攻击时清理不再适用的预瞄状态。
- 射击目标界面的预计后坐力和开火耗时使用移动预瞄结果，避免界面显示与实际射击状态不一致。
- 使用弱引用保存目标，避免目标生命周期变化造成悬空状态。

## 测试验证

- 工作流运行 [#80](https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/31254890554)
  - Windows x64 MSVC 构建：成功
  - Android arm64 构建：成功
- `git diff --check`：通过。
- 分支：`codex/moving-preaim-v3`
- 提交：`5f94ddeba72299d517d80dddb132d30c604cb07f`

## 补充说明

本 PR 只包含 C++ 源码和选项注册修改，不包含 Lua 文件或 Lua API。