### PR TITLE
移动物品时车辆储物空间不足不再掉落地面

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3595,10 +3595,34 @@ void drop_or_stash_item_info::deserialize( const JsonObject &jsobj )
 void drop_activity_actor::do_turn( player_activity &, Character &who )
 {
     const tripoint_bub_ms pos = placement + who.pos_bub();
+
+    // Do not spend another turn taking items out if the target cargo is already full.
+    if( !force_ground ) {
+        map &here = get_map();
+        const std::optional<vpart_reference> vp = here.veh_at( pos ).part_with_feature( "CARGO", false );
+        if( vp ) {
+            vehicle &veh = vp->vehicle();
+            const int part = vp->part_index();
+            if( veh.free_volume( part ) <= 0_ml ||
+                veh.get_items( part ).size() >= MAX_ITEM_IN_VEHICLE_STORAGE ) {
+                who.add_msg_if_player( m_info,
+                                       _( "Destination area is full.  Remove some items first." ) );
+                who.cancel_activity();
+                return;
+            }
+        }
+    }
+
     who.invalidate_weight_carried_cache();
-    put_into_vehicle_or_drop( who, item_drop_reason::deliberate,
-                              obtain_activity_items( items, handler, who ),
-                              pos, force_ground );
+    const bool vehicle_full = put_into_vehicle_or_drop(
+                                  who, item_drop_reason::deliberate,
+                                  obtain_activity_items( items, handler, who ),
+                                  pos, force_ground );
+    if( vehicle_full ) {
+        who.add_msg_if_player( m_info, _( "Destination area is full.  Remove some items first." ) );
+        who.cancel_activity();
+        return;
+    }
     // Cancel activity if items is empty. Otherwise, we modified in place and we will continue
     // to resolve the drop next turn. This is different from the pickup logic which creates
     // a brand new activity every turn and cancels the old activity

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -141,8 +141,9 @@ enum class item_drop_reason : int {
     tumbling
 };
 
-void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items );
-void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items,
+// Returns true when vehicle cargo was targeted but at least one item did not fit.
+bool put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items );
+bool put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items,
                                const tripoint_bub_ms &where, bool force_ground = false );
 void drop_on_map( Character &you, item_drop_reason reason, const std::list<item> &items,
                   const tripoint_bub_ms &where );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -281,12 +281,12 @@ static bool handle_spillable_contents( Character &c, item &it, map &m )
     return false;
 }
 
-static void put_into_vehicle( Character &c, item_drop_reason reason, const std::list<item> &items,
+static bool put_into_vehicle( Character &c, item_drop_reason reason, const std::list<item> &items,
                               vehicle &veh, int part )
 {
     c.invalidate_weight_carried_cache();
     if( items.empty() ) {
-        return;
+        return false;
     }
 
     const tripoint where = veh.global_part_pos3( part );
@@ -398,7 +398,7 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
         }
     }
 
-    if( retained_count > 0 || fallen_count > 0 ) {
+    if( ( retained_count > 0 || fallen_count > 0 ) && reason != item_drop_reason::deliberate ) {
         if( retained_count > 0 && fallen_count > 0 ) {
             c.add_msg_if_player(
                 m_warning,
@@ -427,6 +427,7 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
             );
         }
     }
+    return retained_count > 0 || fallen_count > 0;
 }
 
 void drop_on_map( Character &you, item_drop_reason reason, const std::list<item> &items,
@@ -521,21 +522,20 @@ void drop_on_map( Character &you, item_drop_reason reason, const std::list<item>
     you.recoil = MAX_RECOIL;
 }
 
-void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
+bool put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
                                const std::list<item> &items )
 {
     return put_into_vehicle_or_drop( you, reason, items, you.pos_bub() );
 }
 
-void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
+bool put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
                                const std::list<item> &items,
                                const tripoint_bub_ms &where, bool force_ground )
 {
     map &here = get_map();
     const std::optional<vpart_reference> vp = here.veh_at( where ).part_with_feature( "CARGO", false );
     if( vp && !force_ground ) {
-        put_into_vehicle( you, reason, items, vp->vehicle(), vp->part_index() );
-        return;
+        return put_into_vehicle( you, reason, items, vp->vehicle(), vp->part_index() );
     }
     drop_on_map( you, reason, items, where );
 
@@ -588,6 +588,7 @@ void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
 
     }
 
+    return false;
 }
 
 static std::list<act_item> convert_to_act_item( const player_activity &act, Character &guy )

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -293,6 +293,7 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
     map &here = get_map();
     const std::string ter_name = here.name( where );
     int fallen_count = 0;
+    int retained_count = 0;
     int into_vehicle_count = 0;
 
     // can't use constant reference here because of the spill_contents()
@@ -315,8 +316,18 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
                 it.mod_charges( -charges_added );
                 into_vehicle_count += charges_added;
             }
-            here.add_item_or_charges( where, it );
-            fallen_count += it.count();
+            if( it.count() > 0 ) {
+                if( c.can_stash( it ) ) {
+                    retained_count += it.count();
+                    c.i_add( it );
+                } else if( !c.has_wield_conflicts( it ) && c.can_wield( it ).success() ) {
+                    retained_count += it.count();
+                    c.wield( it );
+                } else {
+                    here.add_item_or_charges( where, it );
+                    fallen_count += it.count();
+                }
+            }
         }
         it.handle_pickup_ownership( c );
     }
@@ -330,13 +341,15 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
 
         switch( reason ) {
             case item_drop_reason::deliberate:
-                c.add_msg_player_or_npc(
-                    n_gettext( "You put your %1$s in the %2$s's %3$s.",
-                               "You put your %1$s in the %2$s's %3$s.", dropcount ),
-                    n_gettext( "<npcname> puts their %1$s in the %2$s's %3$s.",
-                               "<npcname> puts their %1$s in the %2$s's %3$s.", dropcount ),
-                    it_name, veh.name, part_name
-                );
+                if( retained_count == 0 && fallen_count == 0 ) {
+                    c.add_msg_player_or_npc(
+                        n_gettext( "You put your %1$s in the %2$s's %3$s.",
+                                   "You put your %1$s in the %2$s's %3$s.", dropcount ),
+                        n_gettext( "<npcname> puts their %1$s in the %2$s's %3$s.",
+                                   "<npcname> puts their %1$s in the %2$s's %3$s.", dropcount ),
+                        it_name, veh.name, part_name
+                    );
+                }
                 break;
             case item_drop_reason::too_large:
                 c.add_msg_if_player(
@@ -366,11 +379,13 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
     } else {
         switch( reason ) {
             case item_drop_reason::deliberate:
-                c.add_msg_player_or_npc(
-                    _( "You put several items in the %1$s's %2$s." ),
-                    _( "<npcname> puts several items in the %1$s's %2$s." ),
-                    veh.name, part_name
-                );
+                if( retained_count == 0 && fallen_count == 0 ) {
+                    c.add_msg_player_or_npc(
+                        _( "You put several items in the %1$s's %2$s." ),
+                        _( "<npcname> puts several items in the %1$s's %2$s." ),
+                        veh.name, part_name
+                    );
+                }
                 break;
             case item_drop_reason::too_large:
             case item_drop_reason::too_heavy:
@@ -383,8 +398,20 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
         }
     }
 
-    if( fallen_count > 0 ) {
-        if( into_vehicle_count > 0 ) {
+    if( retained_count > 0 || fallen_count > 0 ) {
+        if( retained_count > 0 && fallen_count > 0 ) {
+            c.add_msg_if_player(
+                m_warning,
+                _( "The %1$s is full, so items that do not fit stay with you when possible, and the rest fall to the %2$s." ),
+                part_name, ter_name
+            );
+        } else if( retained_count > 0 ) {
+            c.add_msg_if_player(
+                m_warning,
+                _( "The %s is full, so items that do not fit stay with you." ),
+                part_name
+            );
+        } else if( into_vehicle_count > 0 ) {
             c.add_msg_if_player(
                 m_warning,
                 n_gettext( "The %s is full, so something fell to the %s.",

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -43,6 +43,8 @@
 #include "type_id.h"
 #include "ui.h"
 #include "uistate.h"
+#include "vehicle.h"
+#include "vpart_position.h"
 
 static const efftype_id effect_pet( "pet" );
 
@@ -680,6 +682,33 @@ static item wishitem_produce( const itype &type, std::string &flags, bool incont
     return granted;
 }
 
+static bool wishitem_put_in_vehicle( Character &you, item &it )
+{
+    map &here = get_map();
+    const optional_vpart_position vp = here.veh_at( you.pos() );
+    if( !vp ) {
+        return false;
+    }
+
+    vehicle &veh = vp->vehicle();
+    const int cargo_part = veh.part_with_feature( vp->part_index(), "CARGO", false );
+    if( cargo_part < 0 ) {
+        return false;
+    }
+
+    if( veh.add_item( cargo_part, it ) ) {
+        return true;
+    }
+
+    if( it.count_by_charges() ) {
+        const int charges_added = veh.add_charges( cargo_part, it );
+        it.mod_charges( -charges_added );
+        return it.charges <= 0;
+    }
+
+    return false;
+}
+
 class wish_item_callback: public uilist_callback
 {
     public:
@@ -969,7 +998,7 @@ void debug_menu::wishitem( Character *you, const tripoint &pos )
                             granted.charges = amount;
                             if( you->can_stash( granted ) ) {
                                 you->i_add( granted );
-                            } else {
+                            } else if( !wishitem_put_in_vehicle( *you, granted ) ) {
                                 get_map().add_item_or_charges( you->pos(), granted );
                             }
                         }
@@ -977,7 +1006,7 @@ void debug_menu::wishitem( Character *you, const tripoint &pos )
                         for( int i = 0; i < amount; i++ ) {
                             if( you->can_stash( granted ) ) {
                                 you->i_add( granted );
-                            } else {
+                            } else if( !wishitem_put_in_vehicle( *you, granted ) ) {
                                 get_map().add_item_or_charges( you->pos(), granted );
                             }
                         }


### PR DESCRIPTION
## 变更内容

改进车辆货舱满载时的物品处理：

- 让车辆放置函数返回“是否有物品未能放入”的结果。
- 货舱放不下时，优先将物品保留在角色库存或手中，无法保留时才掉落到地面。
- 在物品活动继续消耗回合前检测货舱是否已满，并及时结束活动。
- 使用 debug wish 生成物品时，优先放入角色所在车辆的货舱。

## 修改原因

原逻辑在车辆空间不足时直接把剩余物品放到地面，并可能继续对已满货舱重复尝试，造成物品落地和活动回合浪费。现在会尽量保留物品，并在目标确实满载时给出提示并停止活动。

## 代码审查结论

- 已检查车辆放置、活动取消、库存/持握回退以及 debug wish 调用链。
- 保留了无法放入库存时掉落到地面的兜底路径。
- 未发现新增的资源生命周期问题或 Lua 内容。

## 验证结果

- `git diff --check` 通过。
- 变更范围仅包含预期的 C++ 文件。
- Lua 禁入检查通过。
- GitHub Actions [Windows & Android Test #31264653512](https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/31264653512)（提交 `69c96f3b2d15fa3f481b9e4c1fe95007cced37cb`）整体成功。
- `Windows Tiles x64 MSVC` job #93120733298：成功；artifact `CDDA-Breeze-windows-msvc-test-86`。
- `Android arm64` job #93120733272：成功；artifact `CDDA-Breeze-android-arm64-test-86`。
- 你已完成对应 Windows 测试包的 PC 验证。

## 测试建议

1. 测试货舱完全满载、只剩部分空间和多个物品混合的情况。
2. 测试可堆叠物品、不可堆叠物品、库存保留、持握保留和地面兜底。
3. 确认满载后活动停止，且不会继续消耗物品处理回合。
4. 在车辆旁使用 debug wish 生成普通物品和充数物品，确认放置顺序正确。
