### PR TITLE
修复：在 Windows manifest 中声明 DPI 兼容策略

### DIFF
--- a/data/application_manifest.xml
+++ b/data/application_manifest.xml
@@ -2,8 +2,10 @@
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
     <assemblyIdentity type="win32" name="com.cleverraven.cataclysmdda" version="0.0.0.0"/>
     <asmv3:application>
-        <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">
-            <activeCodePage>UTF-8</activeCodePage>
+        <asmv3:windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">false</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">unaware</dpiAwareness>
+            <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
         </asmv3:windowsSettings>
     </asmv3:application>
     <dependency>


### PR DESCRIPTION
## 变更内容

更新 `data/application_manifest.xml`：

- 保留 Windows UTF-8 active code page 声明。
- 明确声明 Windows 程序的 DPI 处理策略。

## 修改原因

让 Windows 高 DPI 兼容行为不再依赖每台机器的默认设置，便于在不同缩放比例和多显示器环境下保持一致表现。

## 代码审查结论

当前 manifest 使用 `dpiAware=false` 和 `dpiAwareness=unaware`，表示采用 DPI-unaware 的 Windows 缩放兼容模式；如果产品目标是让进程真正处于 system-aware，应改为 `true` 和 `system`。这一点已作为测试重点保留在说明中。

## 验证结果

- manifest XML 解析通过。
- `git diff --check` 通过。
- 变更文件和文本均未涉及 Lua。
- GitHub Actions [Windows & Android Test #31263674518](https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/31263674518)（提交 `213fec547a0c591ab0ccf2b8e000bde6c199d22a`）整体成功。
- `Windows Tiles x64 MSVC` job #93118258332：成功；artifact `CDDA-Breeze-windows-msvc-test-85`。
- `Android arm64` job #93118258318：成功；artifact `CDDA-Breeze-android-arm64-test-85`。
- 你已完成对应 Windows 测试包的 PC 验证。

## 测试建议

1. 在高 DPI 显示器上启动 Windows 版本，确认窗口缩放和文字清晰度。
2. 在不同缩放比例的多个显示器之间移动窗口，确认显示行为正常。
3. 对比 Windows 兼容性设置与 manifest 声明是否符合预期。
