### PR TITLE
修复特殊连接的无效桥梁端点

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1479,8 +1479,24 @@ struct fixed_overmap_special_data : overmap_special_data {
 
             if( ( oter->get_type_id() == oter_type_str_id( con.terrain.str() ) ) ) {
                 ++score; // Found another one satisfied connection.
-            } else if( !oter || con.existing || !con.connection->pick_subtype_for( oter ) ) {
-                return -1;
+            } else {
+                if( !oter || con.existing ) {
+                    return -1;
+                }
+
+                const overmap_connection::subtype *subtype =
+                    con.connection->pick_subtype_for( oter );
+                if( !subtype ) {
+                    return -1;
+                }
+
+                // A special connection may cross water on its way to the special, but its
+                // endpoint must not itself become a straight bridge/bridgehead segment.
+                // Otherwise the later bridgehead pass can create a ramp directly against
+                // a non-road special OMT, leaving an apparently isolated bridgehead.
+                if( subtype->is_orthogonal() && !subtype->allows_turns() ) {
+                    return -1;
+                }
             }
         }
         return score;


### PR DESCRIPTION
## 变更说明

修复特殊地点连接检查中无效桥梁端点的问题。

当特殊连接目标不是预期地形时，新增连接子类型校验：
- 无法匹配有效连接子类型时拒绝该候选位置；
- 拒绝将不允许转弯的正交桥梁段直接作为特殊地点端点；
- 保留正常道路连接、已有连接及允许转弯连接的原有行为。

这样可以避免后续桥头处理在非道路特殊地点旁生成孤立桥头或错误坡道。

## 问题背景

特殊连接可能在前往特殊地点的路径上跨越水域，但特殊地点本身不应成为直线桥梁或桥头段的端点。此前仅校验连接子类型是否存在，可能让无效端点进入后续桥头生成流程。

## 测试结果

- [Windows & Android Test #92](https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/31292765168)：通过
  - Windows Tiles x64 MSVC：通过
  - Android arm64：通过
- 已使用 MSVC 构建产物完成 PC 测试，暂未发现异常。
- 测试提交：03a56bd69b795353b3ce3bae57b270ca2d4c096d

## 影响范围

- 仅修改 src/overmap.cpp 中特殊连接端点的候选校验逻辑。
- 不涉及 Lua、JSON、存档格式或用户配置。
- 正常道路连接和既有连接行为保持不变。