### PR TITLE
改进自动驾驶速度控制与路径规划

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3677,6 +3677,7 @@ void vehicle::deserialize( const JsonObject &data )
     data.read( "is_following", is_following );
     data.read( "is_patrolling", is_patrolling );
     data.read( "autodrive_local_target", autodrive_local_target );
+    data.read( "max_autodrive_speed", max_autodrive_speed );
     data.read( "airworthy", flyable );
     data.read( "requested_z_change", requested_z_change );
     data.read( "summon_time_limit", summon_time_limit );
@@ -3859,6 +3860,7 @@ void vehicle::serialize( JsonOut &json ) const
     json.member( "is_following", is_following );
     json.member( "is_patrolling", is_patrolling );
     json.member( "autodrive_local_target", autodrive_local_target );
+    json.member( "max_autodrive_speed", max_autodrive_speed );
     json.member( "airworthy", flyable );
     json.member( "requested_z_change", requested_z_change );
     json.member( "summon_time_limit", summon_time_limit );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3687,7 +3687,7 @@ int vehicle::acceleration( const bool fueled, int at_vel_in_vmi ) const
 {
     if( is_watercraft() ) {
         return water_acceleration( fueled, at_vel_in_vmi );
-    } else if( is_rotorcraft() && is_flying ) {
+    } else if( ( is_rotorcraft() || is_airship() ) && is_flying ) {
         return rotor_acceleration( fueled, at_vel_in_vmi );
     }
     return ground_acceleration( fueled, at_vel_in_vmi );
@@ -3776,7 +3776,7 @@ int vehicle::max_rotor_velocity( const bool fueled ) const
 
 int vehicle::max_velocity( const bool fueled ) const
 {
-    if( is_flying && is_rotorcraft() ) {
+    if( is_flying && ( is_rotorcraft() || is_airship() ) ) {
         return max_rotor_velocity( fueled );
     } else if( is_watercraft() ) {
         return max_water_velocity( fueled );
@@ -3832,7 +3832,7 @@ int vehicle::safe_water_velocity( const bool fueled ) const
 
 int vehicle::safe_velocity( const bool fueled ) const
 {
-    if( is_flying && is_rotorcraft() ) {
+    if( is_flying && ( is_rotorcraft() || is_airship() ) ) {
         return safe_rotor_velocity( fueled );
     } else if( is_watercraft() ) {
         return safe_water_velocity( fueled );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1860,6 +1860,8 @@ class vehicle
         void transform_terrain();
         //main method for the control of individual engines
         void control_engines();
+        // set the per-vehicle maximum speed used by overmap autodrive
+        void set_autodrive_speed();
         //returns whether the engine is enabled or not, and has fueltype
         bool is_engine_type_on( int e, const itype_id &ft ) const;
         //returns whether the engine is enabled or not
@@ -2234,6 +2236,9 @@ class vehicle
         // TODO: change these to a bitset + enum?
         // cruise control on/off
         bool cruise_on = true;
+        // Maximum overmap autodrive speed in tiles per second.  Safe-mode remains fixed at
+        // one tile per second so low visibility and obstacle handling cannot be bypassed.
+        int max_autodrive_speed = 10;
         // at least one engine is on, of any type
         bool engine_on = false;
         // vehicle tracking on/off

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -998,7 +998,7 @@ scored_address vehicle::autodrive_controller::compute_node_score( const node_add
     // TODO: tweak this
     constexpr int cost_mult = 1;
     constexpr int forward_dist_mult = 10;
-    constexpr int side_dist_mult = 8;
+    constexpr int side_dist_mult = 16;
     constexpr int angle_mult = 2;
     constexpr int nearness_penalty = 15;
     scored_address ret{ addr, 0 };
@@ -1033,7 +1033,7 @@ void vehicle::autodrive_controller::compute_next_nodes( const node_address &addr
         std::vector<std::pair<node_address, navigation_node>> &next_nodes )
 const
 {
-    constexpr int move_cost = 10;
+    constexpr int move_cost = 0;
     constexpr int steering_cost = 1;
     const int sign = target_speed_tps > 0 ? 1 : -1;
     const int target_speed = target_speed_tps * VMIPH_PER_TPS;

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -147,8 +147,10 @@ static constexpr int TURNING_INCREMENT = 15;
 static constexpr int NUM_ORIENTATIONS = 360 / TURNING_INCREMENT;
 // min and max speed in tiles/s
 static constexpr int MIN_SPEED_TPS = 1;
-// A* stays conservative around turns.  Straight, visible road can use the vehicle setting.
-static constexpr int MAX_CAUTIOUS_SPEED_TPS = 3;
+// Do not hard-cap ordinary A* at 3 tiles/s (~19 km/h).  Per-vehicle
+// max_autodrive_speed and safe_velocity() already provide the real ceilings.
+// 16 t/s is the highest configurable airborne value; ground/water settings cap lower.
+static constexpr int MAX_CAUTIOUS_SPEED_TPS = 16;
 static constexpr int VMIPH_PER_TPS = static_cast<int>( vehicles::vmiph_per_tile );
 
 /**

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -1284,10 +1284,19 @@ std::optional<navigation_step> vehicle::autodrive_controller::compute_next_step(
 
     if( data.path.empty() ) {
         auto new_path = compute_path( data.max_cautious_speed_tps );
-        while( !new_path && data.max_cautious_speed_tps > MIN_SPEED_TPS ) {
-            // high speed did not work, try a lower speed
-            data.max_cautious_speed_tps /= 2;
-            new_path = compute_path( data.max_cautious_speed_tps );
+        if( !new_path && data.max_cautious_speed_tps > MIN_SPEED_TPS ) {
+            // Try every lower speed in descending order and keep the fastest
+            // path that actually works.  The old halving ladder could skip
+            // viable speeds when adjacent speeds differ in steering geometry.
+            for( int candidate_speed = data.max_cautious_speed_tps - 1;
+                 candidate_speed >= MIN_SPEED_TPS; --candidate_speed ) {
+                auto candidate_path = compute_path( candidate_speed );
+                if( candidate_path ) {
+                    data.max_cautious_speed_tps = candidate_speed;
+                    new_path = std::move( candidate_path );
+                    break;
+                }
+            }
         }
         if( !new_path ) {
             return std::nullopt;

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -147,7 +147,8 @@ static constexpr int TURNING_INCREMENT = 15;
 static constexpr int NUM_ORIENTATIONS = 360 / TURNING_INCREMENT;
 // min and max speed in tiles/s
 static constexpr int MIN_SPEED_TPS = 1;
-static constexpr int MAX_SPEED_TPS = 9;
+// A* stays conservative around turns.  Straight, visible road can use the vehicle setting.
+static constexpr int MAX_CAUTIOUS_SPEED_TPS = 3;
 static constexpr int VMIPH_PER_TPS = static_cast<int>( vehicles::vmiph_per_tile );
 
 /**
@@ -298,8 +299,10 @@ struct auto_navigation_data {
     bool land_ok;
     bool water_ok;
     bool air_ok;
-    // the maximum speed to consider driving at, in tiles/s
-    int max_speed_tps;
+    // maximum speed considered by A*, in tiles/s
+    int max_cautious_speed_tps;
+    // maximum speed used on a completely straight path, in tiles/s
+    int max_greedy_speed_tps;
     // max acceleration
     std::vector<int> acceleration;
     // max amount of steering actions per turn
@@ -379,6 +382,7 @@ class vehicle::autodrive_controller
     private:
         const vehicle &driven_veh;
         const Character &driver;
+        bool in_greedy_mode = false;
         auto_navigation_data data;
 
         void compute_coordinates();
@@ -390,6 +394,7 @@ class vehicle::autodrive_controller
         void compute_valid_positions();
         void compute_goal_zone();
         void precompute_data();
+        bool check_greedy_mode();
         scored_address compute_node_score( const node_address &addr, const navigation_node &node ) const;
         void compute_next_nodes( const node_address &addr, const navigation_node &node,
                                  int target_speed_tps,
@@ -858,7 +863,18 @@ void vehicle::autodrive_controller::compute_obstacles_from_enqueued_ramp_points(
                 data.ground_z[pt_view] = p.z();
             }
             else {
-                data.ground_z[pt_view] = std::min(data.ground_z[pt_view], p.z());
+                // A ramp transition can temporarily expose two drivable surfaces at the same
+                // x/y coordinate.  Always choosing the lower z-level makes the mapping
+                // asymmetric: climbing works, but while descending from a bridge we can switch
+                // to the lower surface too early and the immediate collision check reports a
+                // phantom obstacle.  Prefer the drivable surface closest to the vehicle's
+                // current z-level.  We will still switch levels as soon as the current surface
+                // stops being drivable, which is exactly where the ramp transition happens.
+                const int current_z = data.current_omt.z();
+                if( std::abs( p.z() - current_z ) <
+                    std::abs( data.ground_z[pt_view] - current_z ) ) {
+                    data.ground_z[pt_view] = p.z();
+                }
             }
             data.is_obstacle[pt_view] = false;
             enqueue_if_ramp(ramp_points, here, p);
@@ -938,9 +954,13 @@ void vehicle::autodrive_controller::precompute_data()
         data.land_ok = driven_veh.valid_wheel_config();
         data.water_ok = driven_veh.can_float();
         data.air_ok = driven_veh.has_sufficient_rotorlift() || driven_veh.is_airship();
-        data.max_speed_tps = std::min( MAX_SPEED_TPS, driven_veh.safe_velocity() / VMIPH_PER_TPS );
-        data.acceleration.resize( data.max_speed_tps );
-        for( int speed_tps = 0; speed_tps < data.max_speed_tps; speed_tps++ ) {
+        const int configured_max_tps = std::max( MIN_SPEED_TPS, driven_veh.max_autodrive_speed );
+        const int safe_speed_tps = driven_veh.safe_velocity() / VMIPH_PER_TPS;
+        data.max_cautious_speed_tps = std::min( { MAX_CAUTIOUS_SPEED_TPS,
+                                                  configured_max_tps, safe_speed_tps } );
+        data.max_greedy_speed_tps = std::min( configured_max_tps, safe_speed_tps );
+        data.acceleration.resize( data.max_cautious_speed_tps );
+        for( int speed_tps = 0; speed_tps < data.max_cautious_speed_tps; speed_tps++ ) {
             data.acceleration[speed_tps] = driven_veh.acceleration( true, speed_tps * VMIPH_PER_TPS );
         }
         // TODO: compute from driver's skill and speed stat
@@ -1021,7 +1041,8 @@ const
     int next_speed = target_speed;
     int num_tiles_to_move = std::abs( target_speed_tps );
     if( target_speed_tps > 1 && node.speed < target_speed ) {
-        const int cur_tps = std::min( std::max( node.speed / VMIPH_PER_TPS, 0 ), data.max_speed_tps - 1 );
+        const int cur_tps = std::min( std::max( node.speed / VMIPH_PER_TPS, 0 ),
+                                      data.max_cautious_speed_tps - 1 );
         next_speed = std::min( std::max<int>( node.speed, 0 ) + data.acceleration[cur_tps], target_speed );
         num_tiles_to_move = next_speed / VMIPH_PER_TPS;
     }
@@ -1146,9 +1167,8 @@ void vehicle::autodrive_controller::check_safe_speed()
     // However, sometimes the vehicle's safe speed may drop (e.g. amphibious vehicle entering
     // water), so this extra check is needed to adjust our max speed.
     int safe_speed_tps = driven_veh.safe_velocity() / VMIPH_PER_TPS;
-    if( data.max_speed_tps > safe_speed_tps ) {
-        data.max_speed_tps = safe_speed_tps;
-    }
+    data.max_cautious_speed_tps = std::min( data.max_cautious_speed_tps, safe_speed_tps );
+    data.max_greedy_speed_tps = std::min( data.max_greedy_speed_tps, safe_speed_tps );
 }
 
 collision_check_result vehicle::autodrive_controller::check_collision_zone( orientation turn_dir )
@@ -1221,7 +1241,30 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
 
 void vehicle::autodrive_controller::reduce_speed()
 {
-    data.max_speed_tps = MIN_SPEED_TPS;
+    data.max_cautious_speed_tps = MIN_SPEED_TPS;
+    in_greedy_mode = false;
+}
+
+bool vehicle::autodrive_controller::check_greedy_mode()
+{
+    // Keep aircraft on the ordinary planner.  The greedy mode is meant for long, straight
+    // ground and water routes where the collision look-ahead can safely govern speed.
+    if( driven_veh.is_flying_in_air() ) {
+        return false;
+    }
+    // Slow down near the destination so a fast vehicle cannot skip the finish point.
+    if( driver.omt_path.size() <= 2 ) {
+        return false;
+    }
+    if( data.max_greedy_speed_tps <= data.max_cautious_speed_tps ) {
+        return false;
+    }
+    for( const navigation_step &step : data.path ) {
+        if( step.steering_dir != to_orientation( driven_veh.turn_dir ) ) {
+            return false;
+        }
+    }
+    return true;
 }
 
 std::optional<navigation_step> vehicle::autodrive_controller::compute_next_step()
@@ -1229,23 +1272,39 @@ std::optional<navigation_step> vehicle::autodrive_controller::compute_next_step(
     precompute_data();
     const tripoint_abs_ms veh_pos = driven_veh.global_square_location();
 
-    while( !data.path.empty() && data.path.back().pos != veh_pos ) {
-        data.path.pop_back();
+    if( !in_greedy_mode ) {
+        while( !data.path.empty() && data.path.back().pos != veh_pos ) {
+            data.path.pop_back();
+        }
+        if( !data.path.empty() &&
+            data.path.back().target_speed_tps > data.max_cautious_speed_tps ) {
+            data.path.clear();
+        }
     }
-    if( !data.path.empty() && data.path.back().target_speed_tps > data.max_speed_tps ) {
-        data.path.clear();
-    }
+
     if( data.path.empty() ) {
-        auto new_path = compute_path( data.max_speed_tps );
-        while( !new_path && data.max_speed_tps > MIN_SPEED_TPS ) {
+        auto new_path = compute_path( data.max_cautious_speed_tps );
+        while( !new_path && data.max_cautious_speed_tps > MIN_SPEED_TPS ) {
             // high speed did not work, try a lower speed
-            data.max_speed_tps /= 2;
-            new_path = compute_path( data.max_speed_tps );
+            data.max_cautious_speed_tps /= 2;
+            new_path = compute_path( data.max_cautious_speed_tps );
         }
         if( !new_path ) {
             return std::nullopt;
         }
         data.path.swap( *new_path );
+        in_greedy_mode = check_greedy_mode();
+    }
+
+    if( in_greedy_mode ) {
+        // CCB-style greedy cruise.  A* has already verified that the route through this OMT is
+        // straight.  We can therefore keep steering unchanged and let check_collision_zone()
+        // police visibility and obstacles over a distance proportional to the current speed.
+        navigation_step greedy_step;
+        greedy_step.pos = veh_pos;
+        greedy_step.steering_dir = to_orientation( driven_veh.turn_dir );
+        greedy_step.target_speed_tps = data.max_greedy_speed_tps;
+        return greedy_step;
     }
     return data.path.back();
 }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -130,7 +130,10 @@ void vehicle::set_autodrive_speed()
     // calculated safe velocity.  This keeps bicycles, paddle craft, damaged vehicles, etc.
     // from being assigned a highway-speed target they cannot safely reach.
     constexpr double kph_per_tps = 6.437376;
-    constexpr int max_configurable_tps = 15;
+    // Flying aircraft get the higher airborne autodrive ceiling.  Ground and
+    // water vehicles keep the 15 t/s (~97 km/h) UI ceiling.  safe_velocity()
+    // remains the final physical limit for the actual vehicle.
+    const int max_configurable_tps = is_flying && ( is_rotorcraft() || is_airship() ) ? 16 : 15;
     const int safe_speed_tps = std::max(
                                    1, safe_velocity() / static_cast<int>( vehicles::vmiph_per_tile ) );
     const int max_allowed_tps = std::min( max_configurable_tps, safe_speed_tps );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -141,7 +141,7 @@ void vehicle::set_autodrive_speed()
     const int current_kph = static_cast<int>( std::lround( effective_current_tps * kph_per_tps ) );
     const int safe_kph = static_cast<int>( std::lround( max_allowed_tps * kph_per_tps ) );
     const int requested_kph = string_input_popup()
-                              .title( string_format( _( "设置自动驾驶最高速度，单位公里每小时。当前载具安全上限约 %d 公里每小时。" ),
+                              .title( string_format( _( "设置自动驾驶最高速度，单位公里每小时。当前自动驾驶最高支持约 %d 公里每小时。" ),
                                                    safe_kph ) )
                               .text( std::to_string( current_kph ) )
                               .only_digits( true )
@@ -157,7 +157,7 @@ void vehicle::set_autodrive_speed()
     max_autodrive_speed = std::min( requested_tps, max_allowed_tps );
     const int actual_kph = static_cast<int>( std::lround( max_autodrive_speed * kph_per_tps ) );
     if( requested_tps > max_allowed_tps ) {
-        add_msg( _( "当前载具的安全速度约为 %d 公里每小时，自动驾驶上限已限制为该速度。" ),
+        add_msg( _( "当前自动驾驶最高支持约 %d 公里每小时，已使用该上限。" ),
                  actual_kph );
     } else {
         add_msg( _( "自动驾驶最高速度已设为约 %d 公里每小时。" ), actual_kph );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -123,6 +123,44 @@ void handbrake()
     player_character.moves = 0;
 }
 
+void vehicle::set_autodrive_speed()
+{
+    // One tile per second is 400 vmiph, which is about 6.44 km/h.  The player setting is
+    // a ceiling, not a promise: just like CCB, autodrive is also capped by the vehicle's
+    // calculated safe velocity.  This keeps bicycles, paddle craft, damaged vehicles, etc.
+    // from being assigned a highway-speed target they cannot safely reach.
+    constexpr double kph_per_tps = 6.437376;
+    constexpr int max_configurable_tps = 15;
+    const int safe_speed_tps = std::max(
+                                   1, safe_velocity() / static_cast<int>( vehicles::vmiph_per_tile ) );
+    const int max_allowed_tps = std::min( max_configurable_tps, safe_speed_tps );
+    const int effective_current_tps = std::min( max_autodrive_speed, max_allowed_tps );
+    const int current_kph = static_cast<int>( std::lround( effective_current_tps * kph_per_tps ) );
+    const int safe_kph = static_cast<int>( std::lround( max_allowed_tps * kph_per_tps ) );
+    const int requested_kph = string_input_popup()
+                              .title( string_format( _( "设置自动驾驶最高速度，单位公里每小时。当前载具安全上限约 %d 公里每小时。" ),
+                                                   safe_kph ) )
+                              .text( std::to_string( current_kph ) )
+                              .only_digits( true )
+                              .max_length( 3 )
+                              .query_int();
+    if( requested_kph <= 0 ) {
+        return;
+    }
+
+    const int requested_tps = std::clamp(
+                                  static_cast<int>( std::lround( requested_kph / kph_per_tps ) ),
+                                  1, max_configurable_tps );
+    max_autodrive_speed = std::min( requested_tps, max_allowed_tps );
+    const int actual_kph = static_cast<int>( std::lround( max_autodrive_speed * kph_per_tps ) );
+    if( requested_tps > max_allowed_tps ) {
+        add_msg( _( "当前载具的安全速度约为 %d 公里每小时，自动驾驶上限已限制为该速度。" ),
+                 actual_kph );
+    } else {
+        add_msg( _( "自动驾驶最高速度已设为约 %d 公里每小时。" ), actual_kph );
+    }
+}
+
 void vehicle::control_doors()
 {
     const auto open_or_close_all = [this]( bool new_open, const std::string & require_flag ) {
@@ -1906,6 +1944,10 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
             cruise_on = !cruise_on;
             add_msg( cruise_on ? _( "Cruise control turned on" ) : _( "Cruise control turned off" ) );
         } );
+
+        menu.add( _( "设置自动驾驶速度" ) )
+        .keep_menu_open()
+        .on_submit( [this] { set_autodrive_speed(); } );
     }
 
     if( has_electronic_controls && has_part( "SMART_ENGINE_CONTROLLER" ) ) {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -140,13 +140,20 @@ void vehicle::set_autodrive_speed()
     const int effective_current_tps = std::min( max_autodrive_speed, max_allowed_tps );
     const int current_kph = static_cast<int>( std::lround( effective_current_tps * kph_per_tps ) );
     const int safe_kph = static_cast<int>( std::lround( max_allowed_tps * kph_per_tps ) );
-    const int requested_kph = string_input_popup()
-                              .title( string_format( _( "设置自动驾驶最高速度，单位公里每小时。当前自动驾驶最高支持约 %d 公里每小时。" ),
-                                                   safe_kph ) )
-                              .text( std::to_string( current_kph ) )
-                              .only_digits( true )
-                              .max_length( 3 )
-                              .query_int();
+    string_input_popup speed_input;
+    speed_input.title( _( "设置自动驾驶最高速度，公里每小时" ) )
+    .description( string_format(
+                      _( "当前约 %d 公里每小时，当前自动驾驶最高支持约 %d 公里每小时。输入新的速度，留空确认或按 Esc 取消。" ),
+                      current_kph, safe_kph ) )
+    .width( 6 )
+    .only_digits( true )
+    .max_length( 3 );
+
+    const std::string requested_text = speed_input.query_string();
+    if( speed_input.canceled() || requested_text.empty() ) {
+        return;
+    }
+    const int requested_kph = std::atoi( requested_text.c_str() );
     if( requested_kph <= 0 ) {
         return;
     }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -143,7 +143,7 @@ void vehicle::set_autodrive_speed()
     string_input_popup speed_input;
     speed_input.title( _( "设置自动驾驶最高速度，公里每小时" ) )
     .description( string_format(
-                      _( "当前约 %d 公里每小时，当前自动驾驶最高支持约 %d 公里每小时。输入新的速度，留空确认或按 Esc 取消。" ),
+                      _( "当前约 %d 公里每小时，自动驾驶最高支持约 %d 公里每小时。输入新的速度，留空确认或按 Esc 取消。" ),
                       current_kph, safe_kph ) )
     .width( 6 )
     .only_digits( true )


### PR DESCRIPTION
## 改动概览

- 为每辆载具增加可持久化的自动驾驶最高速度设置，并在载具控制菜单中显示当前速度与车辆可支持上限。
- 将弯道/复杂路况使用的谨慎 A* 规划与长直线路段的高速巡航分开；高速仍受车辆安全速度、视野和碰撞检测约束。
- 移除自动驾驶约 19 km/h 的意外硬上限，优化路径评分，并在高速规划失败时逐级尝试可行的较低速度。
- 扩展空艇自动驾驶所需的飞行加速度与安全速度计算，并改善桥梁、坡道上下层地面的选择。
- 优化自动驾驶速度输入界面及中文提示，删除重复的“当前”。

## 问题原因

原自动驾驶速度由固定规划上限控制，无法按载具单独设置；谨慎路径规划与直线巡航共用同一速度限制，导致长直线路段不能利用车辆的安全速度。空艇和跨坡道场景还存在速度模型及地面层选择不完整的问题。

## 行为与兼容性

- 设置按载具保存，旧存档未提供该字段时使用默认值。
- 地面/水上载具界面上限为 15 格/秒（约 97 km/h），飞行中的旋翼机/空艇为 16 格/秒（约 103 km/h）。
- 实际目标速度始终不超过载具计算出的安全速度；视野不足或前方存在障碍时会退回保守速度。
- 临近目的地、路线转弯或跨越新的 OMT 时会重新进行普通路径规划。

## 验证

- 用户已完成游戏内自动驾驶测试并确认结果正常。
- [Windows & Android Test #31313894714](https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/31313894714)：`Windows Tiles x64 MSVC` 与 `Android arm64` 均成功（提交 `1ccb1fac`）。
- 后续提交 `0c2c0b8b` 仅调整中文提示措辞。
- `git diff --check` 通过；分支仅修改 5 个预期 C++ 文件，无 Lua 内容。