### PR TITLE
修复存储满载时的物品安全搬运

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3650,17 +3650,47 @@ void drop_or_stash_item_info::deserialize( const JsonObject &jsobj )
     jsobj.read( "count", _count );
 }
 
+// ACT_DROP removes items from their source before trying to place them.  If the map is at
+// MAX_ITEM_IN_SQUARE and overflow has nowhere legal to go, map::add_item_or_charges returns
+// the null item.  Keep failed drops alive by restoring them to the character.  The normal
+// path still uses the original fast batch handling; this recovery path only runs on failure.
+static void restore_failed_ground_drop( Character &who, const item &failed )
+{
+    item_location restored = who.i_add( failed, true, nullptr, nullptr,
+                                        /*allow_drop=*/false,
+                                        /*allow_wield=*/true,
+                                        /*ignore_pkt_settings=*/true );
+    if( restored ) {
+        return;
+    }
+
+    // A failed drop may have originated as worn equipment.  Taking it off can leave no
+    // pocket large enough to put it back into, so try restoring it as worn equipment.
+    if( failed.is_armor() && who.wear_item( failed, false ).has_value() ) {
+        return;
+    }
+
+    // Absolute data-loss guard.  This bypasses normal square capacity only when both the
+    // legal ground placement and character restoration failed.  One over-limit recovery
+    // item is preferable to silently deleting player equipment.
+    item &forced = get_map().add_item( who.pos(), failed );
+    if( forced.is_null() ) {
+        debugmsg( "Failed to restore item '%s' after a full-ground drop failure", failed.tname() );
+    }
+}
+
 void drop_activity_actor::do_turn( player_activity &, Character &who )
 {
     const tripoint_bub_ms pos = placement + who.pos_bub();
 
     // Do not spend another turn taking items out if the target cargo is already full.
+    map &here = get_map();
+    std::optional<vpart_reference> cargo;
     if( !force_ground ) {
-        map &here = get_map();
-        const std::optional<vpart_reference> vp = here.veh_at( pos ).part_with_feature( "CARGO", false );
-        if( vp ) {
-            vehicle &veh = vp->vehicle();
-            const int part = vp->part_index();
+        cargo = here.veh_at( pos ).part_with_feature( "CARGO", false );
+        if( cargo ) {
+            vehicle &veh = cargo->vehicle();
+            const int part = cargo->part_index();
             if( veh.free_volume( part ) <= 0_ml ||
                 veh.get_items( part ).size() >= MAX_ITEM_IN_VEHICLE_STORAGE ) {
                 who.add_msg_if_player( m_info,
@@ -3672,11 +3702,24 @@ void drop_activity_actor::do_turn( player_activity &, Character &who )
     }
 
     who.invalidate_weight_carried_cache();
-    const bool vehicle_full = put_into_vehicle_or_drop(
-                                  who, item_drop_reason::deliberate,
-                                  obtain_activity_items( items, handler, who ),
-                                  pos, force_ground );
-    if( vehicle_full ) {
+    std::list<item> obtained = obtain_activity_items( items, handler, who );
+    std::list<item> failed_items;
+    bool destination_full = false;
+
+    if( cargo ) {
+        destination_full = put_into_vehicle_or_drop(
+                               who, item_drop_reason::deliberate, obtained, pos, false );
+    } else {
+        destination_full = put_into_vehicle_or_drop(
+                               who, item_drop_reason::deliberate, obtained, pos, true, &failed_items );
+        if( !failed_items.empty() ) {
+            for( const item &failed : failed_items ) {
+                restore_failed_ground_drop( who, failed );
+            }
+        }
+    }
+
+    if( destination_full ) {
         who.add_msg_if_player( m_info, _( "Destination area is full.  Remove some items first." ) );
         who.cancel_activity();
         return;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1883,6 +1883,7 @@ std::unique_ptr<activity_actor> read_activity_actor::deserialize( JsonValue &jsi
 void move_items_activity_actor::do_turn( player_activity &act, Character &who )
 {
     const tripoint_bub_ms dest = relative_destination + who.pos_bub();
+    map &here = get_map();
 
     while( who.moves > 0 && !target_items.empty() ) {
         item_location target = std::move( target_items.back() );
@@ -1897,9 +1898,9 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
 
         // Check that we can pick it up.
         if( target->made_of_from_type( phase_id::SOLID ) ) {
-            item &leftovers = *target;
-            // Make a copy to be put in the destination location
-            item newit = leftovers;
+            // Keep the source untouched until destination placement succeeds.
+            item newit = *target;
+            item leftovers = newit;
 
             if( newit.is_owned_by( who, true ) ) {
                 newit.set_owner( who );
@@ -1907,10 +1908,12 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
                 continue;
             }
 
-            // Handle charges, quantity == 0 means move all
+            // Handle charges, quantity == 0 means move all.
+            // Work on copies so failed placement cannot consume source charges.
             if( quantity != 0 && newit.count_by_charges() ) {
-                newit.charges = std::min( newit.charges, quantity );
-                leftovers.charges -= quantity;
+                const int moved_charges = std::min( newit.charges, quantity );
+                newit.charges = moved_charges;
+                leftovers.charges -= moved_charges;
             } else {
                 leftovers.charges = 0;
             }
@@ -1919,17 +1922,72 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
             // is no longer teleportation
             const tripoint_bub_ms src = target.pos_bub();
             const int distance = src.z() == dest.z() ? std::max( rl_dist( src, dest ), 1 ) : 1;
-            // Yuck, I'm sticking weariness scaling based on activity level here
+
+            bool placement_succeeded = false;
+            bool destination_full_after_partial = false;
+
+            if( to_vehicle ) {
+                // ACT_MOVE_ITEMS must be transactional.  Do not use
+                // put_into_vehicle_or_drop here: that helper may partially fill cargo and then
+                // retain, wield or drop the remainder, which makes it impossible to know how
+                // much of the source can safely be committed afterwards.
+                const std::optional<vpart_reference> cargo =
+                    here.veh_at( dest ).part_with_feature( "CARGO", false );
+
+                if( cargo ) {
+                    vehicle &veh = cargo->vehicle();
+                    const int part = cargo->part_index();
+
+                    // vehicle::add_item is all-or-nothing.  For charge-counted items,
+                    // fall back to add_charges so that "move as much as possible" can
+                    // still fill the remaining cargo capacity without duplicating items.
+                    if( veh.add_item( part, newit ).has_value() ) {
+                        placement_succeeded = true;
+                    } else if( newit.count_by_charges() ) {
+                        const int requested_charges = newit.charges;
+                        const int charges_added = veh.add_charges( part, newit );
+                        if( charges_added > 0 ) {
+                            placement_succeeded = true;
+                            destination_full_after_partial = charges_added < requested_charges;
+
+                            // Commit only the charges that really entered the cargo.
+                            newit.charges = charges_added;
+                            leftovers = *target;
+                            leftovers.charges -= charges_added;
+                        }
+                    }
+                }
+            } else {
+                placement_succeeded = drop_on_map( who, item_drop_reason::deliberate, { newit }, dest );
+            }
+
+            if( !placement_succeeded ) {
+                who.add_msg_if_player( m_info,
+                                       _( "Destination area is full.  Remove some items first." ) );
+                act.set_to_null();
+                return;
+            }
+
+            // Charge movement cost only after destination placement succeeded, using the
+            // exact amount that was really transferred for partially filled vehicle cargo.
             const float weary_mult = who.exertion_adjusted_move_multiplier( exertion_level() );
             who.mod_moves( -Pickup::cost_to_move_item( who, newit ) * distance * weary_mult );
-            if( to_vehicle ) {
-                put_into_vehicle_or_drop( who, item_drop_reason::deliberate, { newit }, dest );
+
+            // Commit source changes only after the destination accepted the item.
+            if( leftovers.charges > 0 ) {
+                *target = std::move( leftovers );
             } else {
-                drop_on_map( who, item_drop_reason::deliberate, { newit }, dest );
-            }
-            // If we picked up a whole stack, remove the leftover item
-            if( leftovers.charges <= 0 ) {
                 target.remove_item();
+            }
+
+            // A charge stack may have partially filled the final bit of vehicle cargo.
+            // The successful portion is already committed, leave the remainder at source
+            // and stop once, rather than repeatedly retrying and spamming messages.
+            if( destination_full_after_partial ) {
+                who.add_msg_if_player( m_info,
+                                       _( "Destination area is full.  Remove some items first." ) );
+                act.set_to_null();
+                return;
             }
         }
     }
@@ -1937,7 +1995,7 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
     if( target_items.empty() ) {
         // Nuke the current activity, leaving the backlog alone.
         act.set_to_null();
-        if( who.is_hauling() && !get_map().has_haulable_items( who.pos() ) ) {
+        if( who.is_hauling() && !here.has_haulable_items( who.pos() ) ) {
             who.stop_hauling();
         }
     }

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -146,8 +146,9 @@ bool put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list
 bool put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items,
                                const tripoint_bub_ms &where, bool force_ground = false,
                                std::list<item> *failed_items = nullptr );
-// Returns true only when every item was successfully placed on the map.
-// When failed_items is provided, copies that could not be placed are returned to the caller.
+// Returns false only when map capacity prevented at least one item from being placed.
+// Items intentionally handled by drop_action or rejected by map rules retain their legacy behavior.
+// When failed_items is provided, capacity-blocked copies are returned to the caller.
 bool drop_on_map( Character &you, item_drop_reason reason, const std::list<item> &items,
                   const tripoint_bub_ms &where, std::list<item> *failed_items = nullptr );
 // used in unit tests to avoid triggering user input

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -145,7 +145,8 @@ enum class item_drop_reason : int {
 bool put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items );
 bool put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items,
                                const tripoint_bub_ms &where, bool force_ground = false );
-void drop_on_map( Character &you, item_drop_reason reason, const std::list<item> &items,
+// Returns true only when every item was successfully placed on the map.
+bool drop_on_map( Character &you, item_drop_reason reason, const std::list<item> &items,
                   const tripoint_bub_ms &where );
 // used in unit tests to avoid triggering user input
 void repair_item_finish( player_activity *act, Character *you, bool no_menu );

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -144,10 +144,12 @@ enum class item_drop_reason : int {
 // Returns true when vehicle cargo was targeted but at least one item did not fit.
 bool put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items );
 bool put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items,
-                               const tripoint_bub_ms &where, bool force_ground = false );
+                               const tripoint_bub_ms &where, bool force_ground = false,
+                               std::list<item> *failed_items = nullptr );
 // Returns true only when every item was successfully placed on the map.
+// When failed_items is provided, copies that could not be placed are returned to the caller.
 bool drop_on_map( Character &you, item_drop_reason reason, const std::list<item> &items,
-                  const tripoint_bub_ms &where );
+                  const tripoint_bub_ms &where, std::list<item> *failed_items = nullptr );
 // used in unit tests to avoid triggering user input
 void repair_item_finish( player_activity *act, Character *you, bool no_menu );
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -430,14 +430,15 @@ static bool put_into_vehicle( Character &c, item_drop_reason reason, const std::
     return retained_count > 0 || fallen_count > 0;
 }
 
-void drop_on_map( Character &you, item_drop_reason reason, const std::list<item> &items,
+bool drop_on_map( Character &you, item_drop_reason reason, const std::list<item> &items,
                   const tripoint_bub_ms &where )
 {
     you.invalidate_weight_carried_cache();
     if( items.empty() ) {
-        return;
+        return true;
     }
     map &here = get_map();
+    bool all_placed = true;
     const std::string ter_name = here.name( where );
     const bool can_move_there = here.passable( where );
 
@@ -515,11 +516,16 @@ void drop_on_map( Character &you, item_drop_reason reason, const std::list<item>
         }
     }
     for( const item &it : items ) {
-        here.add_item_or_charges( where, it );
+        item &dropped_item = here.add_item_or_charges( where, it );
+        if( &dropped_item == &null_item_reference() ) {
+            all_placed = false;
+            continue;
+        }
         item( it ).handle_pickup_ownership( you );
     }
 
     you.recoil = MAX_RECOIL;
+    return all_placed;
 }
 
 bool put_into_vehicle_or_drop( Character &you, item_drop_reason reason,

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -273,11 +273,44 @@ static bool handle_spillable_contents( Character &c, item &it, map &m )
                 _( "To avoid spilling its contents, <npcname> sets their %1$s on the %2$s." ),
                 it.display_name(), m.name( c.pos() )
             );
-            m.add_item_or_charges( c.pos(), it );
+            map_item_add_result add_result = map_item_add_result::rejected;
+            item &placed = m.add_item_or_charges( c.pos(), it, true, &add_result );
+            if( placed.is_null() && add_result == map_item_add_result::no_space &&
+                m.can_put_items_ter_furn( c.pos() ) ) {
+                // This path has already detached/spilled the container state.  Preserve it
+                // over the square limit rather than silently losing it.
+                m.add_item( c.pos(), it );
+            }
             return true;
         }
     }
 
+    return false;
+}
+
+// Capacity overflow is the one map-placement failure that must never silently delete an item.
+// Keep normal NO_DROP, destructive-terrain and drop_action semantics intact, but if every legal
+// square is simply full, preserve the item by bypassing only the normal square capacity limit.
+static bool force_preserve_capacity_drop( Character &c, map &here,
+        const tripoint &preferred, const item &it )
+{
+    const auto force_at = [&]( const tripoint & p ) {
+        if( !here.can_put_items_ter_furn( p ) ) {
+            return false;
+        }
+        item &forced = here.add_item( p, it );
+        if( forced.is_null() ) {
+            return false;
+        }
+        forced.handle_pickup_ownership( c );
+        return true;
+    };
+
+    if( force_at( preferred ) || ( preferred != c.pos() && force_at( c.pos() ) ) ) {
+        return true;
+    }
+
+    debugmsg( "Failed to preserve item '%s' after a capacity-blocked drop", it.tname() );
     return false;
 }
 
@@ -303,7 +336,11 @@ static bool put_into_vehicle( Character &c, item_drop_reason reason, const std::
         }
 
         if( it.made_of( phase_id::LIQUID ) ) {
-            here.add_item_or_charges( c.pos(), it );
+            map_item_add_result add_result = map_item_add_result::rejected;
+            item &spilled = here.add_item_or_charges( c.pos(), it, true, &add_result );
+            if( spilled.is_null() && add_result == map_item_add_result::no_space ) {
+                force_preserve_capacity_drop( c, here, c.pos(), it );
+            }
             it.charges = 0;
         }
 
@@ -324,8 +361,17 @@ static bool put_into_vehicle( Character &c, item_drop_reason reason, const std::
                     retained_count += it.count();
                     c.wield( it );
                 } else {
-                    here.add_item_or_charges( where, it );
-                    fallen_count += it.count();
+                    map_item_add_result add_result = map_item_add_result::rejected;
+                    item &fallen = here.add_item_or_charges( where, it, true, &add_result );
+                    if( !fallen.is_null() ) {
+                        fallen_count += it.count();
+                    } else if( add_result == map_item_add_result::no_space &&
+                               force_preserve_capacity_drop( c, here, where, it ) ) {
+                        // The cargo and legal ground overflow are both full.  Keep the item on
+                        // the map even if that means one exceptional over-limit square.
+                        fallen_count += it.count();
+                    }
+                    // handled/rejected outcomes intentionally keep their previous semantics.
                 }
             }
         }
@@ -516,15 +562,18 @@ bool drop_on_map( Character &you, item_drop_reason reason, const std::list<item>
         }
     }
     for( const item &it : items ) {
-        item &dropped_item = here.add_item_or_charges( where, it );
-        if( &dropped_item == &null_item_reference() ) {
+        map_item_add_result add_result = map_item_add_result::rejected;
+        item &dropped_item = here.add_item_or_charges( where, it, true, &add_result );
+        if( dropped_item.is_null() && add_result == map_item_add_result::no_space ) {
             all_placed = false;
             if( failed_items != nullptr ) {
                 failed_items->push_back( it );
             }
             continue;
         }
-        item( it ).handle_pickup_ownership( you );
+        if( !dropped_item.is_null() ) {
+            dropped_item.handle_pickup_ownership( you );
+        }
     }
 
     you.recoil = MAX_RECOIL;
@@ -547,7 +596,18 @@ bool put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
     if( vp && !force_ground ) {
         return put_into_vehicle( you, reason, items, vp->vehicle(), vp->part_index() );
     }
-    const bool all_placed = drop_on_map( you, reason, items, where, failed_items );
+    // Legacy callers often pass a temporary copy and ignore the return value.  Preserve those
+    // copies on a capacity failure instead of letting them vanish.  ACT_DROP supplies its own
+    // failed_items list and restores the original character item itself, while ACT_MOVE_ITEMS
+    // calls drop_on_map directly and therefore remains fully transactional.
+    std::list<item> local_failed_items;
+    std::list<item> *failure_sink = failed_items != nullptr ? failed_items : &local_failed_items;
+    const bool all_placed = drop_on_map( you, reason, items, where, failure_sink );
+    if( failed_items == nullptr ) {
+        for( const item &failed : local_failed_items ) {
+            force_preserve_capacity_drop( you, here, where.raw(), failed );
+        }
+    }
 
 
     if (get_option<bool>("AUTO_NOTES_DROPPED_FAVORITES") && you.is_avatar()) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -431,7 +431,7 @@ static bool put_into_vehicle( Character &c, item_drop_reason reason, const std::
 }
 
 bool drop_on_map( Character &you, item_drop_reason reason, const std::list<item> &items,
-                  const tripoint_bub_ms &where )
+                  const tripoint_bub_ms &where, std::list<item> *failed_items )
 {
     you.invalidate_weight_carried_cache();
     if( items.empty() ) {
@@ -519,6 +519,9 @@ bool drop_on_map( Character &you, item_drop_reason reason, const std::list<item>
         item &dropped_item = here.add_item_or_charges( where, it );
         if( &dropped_item == &null_item_reference() ) {
             all_placed = false;
+            if( failed_items != nullptr ) {
+                failed_items->push_back( it );
+            }
             continue;
         }
         item( it ).handle_pickup_ownership( you );
@@ -536,14 +539,15 @@ bool put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
 
 bool put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
                                const std::list<item> &items,
-                               const tripoint_bub_ms &where, bool force_ground )
+                               const tripoint_bub_ms &where, bool force_ground,
+                               std::list<item> *failed_items )
 {
     map &here = get_map();
     const std::optional<vpart_reference> vp = here.veh_at( where ).part_with_feature( "CARGO", false );
     if( vp && !force_ground ) {
         return put_into_vehicle( you, reason, items, vp->vehicle(), vp->part_index() );
     }
-    drop_on_map( you, reason, items, where );
+    const bool all_placed = drop_on_map( you, reason, items, where, failed_items );
 
 
     if (get_option<bool>("AUTO_NOTES_DROPPED_FAVORITES") && you.is_avatar()) {
@@ -594,7 +598,7 @@ bool put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
 
     }
 
-    return false;
+    return !all_placed;
 }
 
 static std::list<act_item> convert_to_act_item( const player_activity &act, Character &guy )

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1104,10 +1104,11 @@ bool advanced_inventory::move_all_items()
 
         } else {
             // Vehicle and map destinations are handled the same.
-            // Check first if the destination area still have enough room for moving all.
+            // Match modern DDA behavior: warn once, then attempt as much as will fit.
             const units::volume &src_volume = spane.in_vehicle() ? sarea.volume_veh : sarea.volume;
-            if( !is_processing() && src_volume > darea.free_volume( dpane.in_vehicle() ) &&
-                !query_yn( _( "There isn't enough room, do you really want to move all?" ) ) ) {
+            const bool destination_limited = src_volume > darea.free_volume( dpane.in_vehicle() );
+            if( !is_processing() && destination_limited &&
+                !query_yn( _( "There isn't enough room.  Attempt to move as much as you can?" ) ) ) {
                 return false;
             }
 
@@ -1169,6 +1170,26 @@ bool advanced_inventory::move_all_items()
             // move all the favorite items only if there are no other items.
             if( target_items.empty() ) {
                 target_items = target_items_favorites;
+            }
+
+            if( destination_limited && target_items.size() > 1 ) {
+                // move_items_activity_actor consumes from the back, so order large-to-small
+                // and let smaller items be attempted first. Cache each item's volume once so
+                // large move-all jobs do not repeatedly recalculate container volume during sort.
+                std::vector<std::pair<units::volume, item_location>> size_order;
+                size_order.reserve( target_items.size() );
+                for( item_location &loc : target_items ) {
+                    size_order.emplace_back( loc->volume(), std::move( loc ) );
+                }
+                std::stable_sort( size_order.begin(), size_order.end(),
+                []( const auto &lhs, const auto &rhs ) {
+                    return lhs.first > rhs.first;
+                } );
+                target_items.clear();
+                target_items.reserve( size_order.size() );
+                for( auto &entry : size_order ) {
+                    target_items.push_back( std::move( entry.second ) );
+                }
             }
 
             do_return_entry();

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -203,6 +203,26 @@ item_location Character::try_add( item it, const item *avoid, const item *origin
     return ret;
 }
 
+// add_item_or_charges returns a null item both for intentional drop actions and for a full map
+// square.  Only the latter should trigger an over-limit preservation fallback.
+static item *add_to_ground_preserving_capacity( map &here, const tripoint &where, const item &it,
+        map_item_add_result &result )
+{
+    item &dropped = here.add_item_or_charges( where, it, true, &result );
+    if( !dropped.is_null() ) {
+        return &dropped;
+    }
+
+    if( result == map_item_add_result::no_space && here.can_put_items_ter_furn( where ) ) {
+        item &forced = here.add_item( where, it );
+        if( !forced.is_null() ) {
+            result = map_item_add_result::placed;
+            return &forced;
+        }
+    }
+    return nullptr;
+}
+
 item_location Character::i_add( item it, bool /* should_stack */, const item *avoid,
                                 const item *original_inventory_item, const bool allow_drop,
                                 const bool allow_wield, bool ignore_pkt_settings )
@@ -214,7 +234,12 @@ item_location Character::i_add( item it, bool /* should_stack */, const item *av
     if( added == item_location::nowhere ) {
         if( !allow_wield || !wield( it ) ) {
             if( allow_drop ) {
-                return item_location( map_cursor( pos() ), &get_map().add_item_or_charges( pos(), it ) );
+                map &here = get_map();
+                map_item_add_result add_result = map_item_add_result::rejected;
+                if( item *dropped = add_to_ground_preserving_capacity( here, pos(), it, add_result ) ) {
+                    return item_location( map_cursor( pos() ), dropped );
+                }
+                return item_location::nowhere;
             } else {
                 return added;
             }
@@ -246,7 +271,11 @@ ret_val<item_location> Character::i_add_or_fill( item &it, bool should_stack, co
         if( new_charge >= 1 ) {
             if( !allow_wield || !wield( it ) ) {
                 if( allow_drop ) {
-                    loc = item_location( map_cursor( pos() ), &get_map().add_item_or_charges( pos(), it ) );
+                    map &here = get_map();
+                    map_item_add_result add_result = map_item_add_result::rejected;
+                    if( item *dropped = add_to_ground_preserving_capacity( here, pos(), it, add_result ) ) {
+                        loc = item_location( map_cursor( pos() ), dropped );
+                    }
                 }
             } else {
                 loc = item_location( *this, &weapon );
@@ -311,7 +340,9 @@ bool Character::i_add_or_drop( item &it, int qty, const item *avoid,
     for( int i = 0; i < qty; ++i ) {
         drop |= !can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) || !can_pickVolume( it );
         if( drop ) {
-            retval &= !here.add_item_or_charges( pos(), it ).is_null();
+            map_item_add_result add_result = map_item_add_result::rejected;
+            item *dropped = add_to_ground_preserving_capacity( here, pos(), it, add_result );
+            retval &= dropped != nullptr || add_result == map_item_add_result::handled;
         } else if( add ) {
             i_add( it, true, avoid,
                    original_inventory_item, /*allow_drop=*/true, /*allow_wield=*/!has_wield_conflicts( it ) );
@@ -326,7 +357,9 @@ bool Character::i_drop_at( item &it, int qty )
     bool retval = true;
     map &here = get_map();
     for( int i = 0; i < qty; ++i ) {
-        retval &= !here.add_item_or_charges( pos(), it ).is_null();
+        map_item_add_result add_result = map_item_add_result::rejected;
+        item *dropped = add_to_ground_preserving_capacity( here, pos(), it, add_result );
+        retval &= dropped != nullptr || add_result == map_item_add_result::handled;
     }
 
     return retval;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5546,8 +5546,17 @@ units::volume map::free_volume( const tripoint_bub_ms &p )
     return free_volume( p.raw() );
 }
 
-item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
+item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow,
+                                map_item_add_result *result )
 {
+    const auto set_result = [result]( map_item_add_result value ) {
+        if( result != nullptr ) {
+            *result = value;
+        }
+    };
+    set_result( map_item_add_result::rejected );
+    bool capacity_limited = false;
+
     // Checks if item would not be destroyed if added to this tile
     auto valid_tile = [&]( const tripoint & e ) {
         if( !inbounds( e ) ) {
@@ -5579,13 +5588,17 @@ item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
         {
             for( item &e : i_at( tile ) ) {
                 if( e.merge_charges( obj ) ) {
+                    set_result( map_item_add_result::placed );
                     return e;
                 }
             }
         }
 
         support_dirty( tile );
-        return add_item( tile, obj );
+        item &placed = add_item( tile, obj );
+        set_result( placed.is_null() ? map_item_add_result::rejected :
+                    map_item_add_result::placed );
+        return placed;
     };
 
     if( item_is_blacklisted( obj.typeId() ) ) {
@@ -5602,12 +5615,14 @@ item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
         return null_item_reference();
     }
 
-    if( ( !has_flag( ter_furn_flag::TFLAG_NOITEM, pos ) ||
-          ( has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, pos ) && obj.made_of( phase_id::LIQUID ) ) )
-        && valid_limits( pos ) ) {
+    const bool target_accepts_items =
+        !has_flag( ter_furn_flag::TFLAG_NOITEM, pos ) ||
+        ( has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, pos ) && obj.made_of( phase_id::LIQUID ) );
+    if( target_accepts_items && valid_limits( pos ) ) {
         // Pass map into on_drop, because this map may not be the global map object (in mapgen, for instance).
         if( obj.made_of( phase_id::LIQUID ) || !obj.has_flag( flag_DROP_ACTION_ONLY_IF_LIQUID ) ) {
             if( obj.on_drop( pos, *this ) ) {
+                set_result( map_item_add_result::handled );
                 return null_item_reference();
             }
 
@@ -5616,6 +5631,7 @@ item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
         return place_item( pos );
 
     } else if( overflow ) {
+        capacity_limited = target_accepts_items;
         // ...otherwise try to overflow to adjacent tiles (if permitted)
         const int max_dist = 2;
         std::vector<tripoint> tiles = closest_points_first( pos, max_dist );
@@ -5633,25 +5649,34 @@ item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
             }
             if( obj.made_of( phase_id::LIQUID ) || !obj.has_flag( flag_DROP_ACTION_ONLY_IF_LIQUID ) ) {
                 if( obj.on_drop( e, *this ) ) {
+                    set_result( map_item_add_result::handled );
                     return null_item_reference();
                 }
             }
 
-            if( !valid_tile( e ) || !valid_limits( e ) ||
-                has_flag( ter_furn_flag::TFLAG_NOITEM, e ) || has_flag( ter_furn_flag::TFLAG_SEALED, e ) ) {
+            if( !valid_tile( e ) || has_flag( ter_furn_flag::TFLAG_NOITEM, e ) ||
+                has_flag( ter_furn_flag::TFLAG_SEALED, e ) ) {
+                continue;
+            }
+            if( !valid_limits( e ) ) {
+                capacity_limited = true;
                 continue;
             }
             return place_item( e );
         }
+    } else if( target_accepts_items ) {
+        capacity_limited = true;
     }
 
-    // failed due to lack of space at target tile (+/- overflow tiles)
+    set_result( capacity_limited ? map_item_add_result::no_space :
+                map_item_add_result::rejected );
     return null_item_reference();
 }
 
-item &map::add_item_or_charges( const tripoint_bub_ms &pos, item obj, bool overflow )
+item &map::add_item_or_charges( const tripoint_bub_ms &pos, item obj, bool overflow,
+                                map_item_add_result *result )
 {
-    return add_item_or_charges( pos.raw(), std::move( obj ), overflow );
+    return add_item_or_charges( pos.raw(), std::move( obj ), overflow, result );
 }
 
 item &map::add_item( const tripoint &p, item new_item )

--- a/src/map.h
+++ b/src/map.h
@@ -90,6 +90,14 @@ using VehicleList = std::vector<wrapped_vehicle>;
 class map;
 
 enum class ter_furn_flag : int;
+
+// Detailed outcome for map::add_item_or_charges.  A null item reference alone is
+// ambiguous because a drop action may intentionally consume the item.  Callers
+// that must distinguish a handled drop from a capacity failure can request this.
+enum class map_item_add_result : int {
+    placed, handled, rejected, no_space
+};
+
 struct pathfinding_cache;
 struct pathfinding_settings;
 template<typename T>
@@ -1318,12 +1326,15 @@ class map
          *  @param pos Where to add item
          *  @param obj Item to add
          *  @param overflow if destination is full attempt to drop on adjacent tiles
+         *  @param result optional detailed outcome; no_space uniquely identifies a capacity failure
          *  @return reference to dropped (and possibly stacked) item or null item on failure
          *  @warning function is relatively expensive and meant for user initiated actions, not mapgen
          */
         // TODO: fix point types (remove the first overload)
-        item &add_item_or_charges( const tripoint &pos, item obj, bool overflow = true );
-        item &add_item_or_charges( const tripoint_bub_ms &pos, item obj, bool overflow = true );
+        item &add_item_or_charges( const tripoint &pos, item obj, bool overflow = true,
+                                   map_item_add_result *result = nullptr );
+        item &add_item_or_charges( const tripoint_bub_ms &pos, item obj, bool overflow = true,
+                                   map_item_add_result *result = nullptr );
         item &add_item_or_charges( const point &p, const item &obj, bool overflow = true ) {
             return add_item_or_charges( tripoint( p, abs_sub.z() ), obj, overflow );
         }

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -709,6 +709,22 @@ static bool wishitem_put_in_vehicle( Character &you, item &it )
     return false;
 }
 
+static void wishitem_put_on_map( const tripoint &pos, const item &it )
+{
+    map &here = get_map();
+    map_item_add_result add_result = map_item_add_result::rejected;
+    item &placed = here.add_item_or_charges( pos, it, true, &add_result );
+    if( !placed.is_null() || add_result != map_item_add_result::no_space ) {
+        return;
+    }
+
+    // Debug wishes should never silently vanish merely because MAX_ITEM_IN_SQUARE was reached.
+    // Bypass only the capacity limit; ordinary NO_DROP/destructive-tile rules remain unchanged.
+    if( here.can_put_items_ter_furn( pos ) && here.add_item( pos, it ).is_null() ) {
+        debugmsg( "Failed to preserve wished item '%s' on a full map square", it.tname() );
+    }
+}
+
 class wish_item_callback: public uilist_callback
 {
     public:
@@ -999,7 +1015,7 @@ void debug_menu::wishitem( Character *you, const tripoint &pos )
                             if( you->can_stash( granted ) ) {
                                 you->i_add( granted );
                             } else if( !wishitem_put_in_vehicle( *you, granted ) ) {
-                                get_map().add_item_or_charges( you->pos(), granted );
+                                wishitem_put_on_map( you->pos(), granted );
                             }
                         }
                     } else {
@@ -1007,13 +1023,13 @@ void debug_menu::wishitem( Character *you, const tripoint &pos )
                             if( you->can_stash( granted ) ) {
                                 you->i_add( granted );
                             } else if( !wishitem_put_in_vehicle( *you, granted ) ) {
-                                get_map().add_item_or_charges( you->pos(), granted );
+                                wishitem_put_on_map( you->pos(), granted );
                             }
                         }
                     }
                     you->invalidate_crafting_inventory();
                 } else if( pos.x >= 0 && pos.y >= 0 ) {
-                    get_map().add_item_or_charges( pos, granted );
+                    wishitem_put_on_map( pos, granted );
                     wmenu.ret = -1;
                 }
                 if( amount > 0 ) {


### PR DESCRIPTION
## 变更内容

- 让 `map::add_item_or_charges` 区分真正放置、被正常处理、被规则拒绝和目标容量不足四种结果。
- 让 `ACT_MOVE_ITEMS` 采用事务式搬运，只有目标确认接收物品后才修改源物品。
- 按实际成功进入目标的数量扣减 charges，避免物品丢失或复制。
- 处理地面、载具货舱和角色库存满载时的安全回退。
- 保留 `MAX_ITEM_IN_SQUARE = 4096` 与载具储物上限；只有物品否则会永久丢失时，才允许最后的数据保护措施临时突破限制。

## 修复原因

此前部分搬运路径会把“正常处理物品”和“目标容量不足”混为一谈，导致满载场景下可能吞掉物品、错误恢复物品或产生复制。本次统一区分结果，并让搬运过程在确认目标接收后再提交源物品变化。

## 验证结果

- 已从最新 `origin/main` 干净同步，无冲突。
- `git diff --check`：通过。
- 已验证地面达到 4096 个物品、载具货舱满载、角色库存无法回收、调试生成物和 charges 部分搬运等场景。
- 自动化检查第 107 次运行：
  - Windows x64 MSVC：通过
  - Android arm64：通过

未包含无关修改，也未加入 Lua 内容。