### PR TITLE
修复移动预瞄在射击后被清空的问题

### DIFF
--- a/src/avatar.h
+++ b/src/avatar.h
@@ -263,6 +263,7 @@ class avatar : public Character
         std::string preferred_aiming_mode;
 
         void clear_moving_preaim();
+        void apply_moving_preaim_recoil( double recoil );
         void update_moving_preaim( int spent_moves, bool stationary );
         double moving_preaim_recoil( const item &weapon, const Creature &target ) const;
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1143,6 +1143,7 @@ class npc : public Character
         item_location find_usable_ammo( const item_location &weap ) const;
 
         void clear_moving_preaim();
+        void apply_moving_preaim_recoil( double recoil );
         void update_moving_preaim( int spent_moves, bool stationary );
         double moving_preaim_recoil( const item &weapon, const Creature &target ) const;
         void remember_moving_preaim_recoil( const item &weapon, const Creature &target, double recoil );

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -444,10 +444,17 @@ void npc_attack_gun::use( npc &source, const tripoint &location ) const
     if( source.is_hallucination() ) {
         gun_mode mode = source.get_wielded_item()->gun_current_mode();
         source.pretend_fire( &source, mode.qty, *mode );
+        source.clear_moving_preaim();
     } else {
-        source.fire_gun( location );
+        const int shots_fired = source.fire_gun( location );
+        if( shots_fired > 0 ) {
+            if( gun.is_gun() ) {
+                source.apply_moving_preaim_recoil( source.recoil );
+            } else {
+                source.clear_moving_preaim();
+            }
+        }
     }
-    source.clear_moving_preaim();
     add_msg_debug( debugmode::debug_filter::DF_NPC, "%s fires %s", source.disp_name(),
                    gun.display_name() );
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2688,7 +2688,7 @@ void options_manager::add_options_world_default()
        );
 
     add( "MOVING_PREAIM", "world_default", to_translation( "移动射击预瞄" ),
-         to_translation( "开启后，玩家和NPC只有在实际看见敌对目标时才会积累预瞄，移动和等待都可用于预瞄，不同移动姿态具有不同速度和精度上限，目标离开视野后已有预瞄会逐渐衰减。" ),
+         to_translation( "开启后，玩家和NPC只有在实际看见敌对目标时才会积累预瞄，移动和等待都可用于预瞄，不同移动姿态具有不同速度和精度上限，目标离开视野后已有预瞄会逐渐衰减，射击后后坐力会降低已有预瞄稳定度但不会清空目标跟踪。" ),
          true
        );
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -229,6 +229,11 @@ static double improve_moving_preaim( const Character &who, item &weapon,
     // Entering a less stable movement mode immediately sheds aim that the new posture
     // cannot physically maintain.
     double result = std::max( recoil, floor );
+    // Once the posture/range cap is reached there is no reason to replay aim_per_move
+    // for every spent move.  This is especially important when many hostiles are tracked.
+    if( result <= floor ) {
+        return floor;
+    }
     const Target_attributes attributes( who.pos(), target.pos() );
     for( int i = 0; i < effective_moves; ++i ) {
         const double amount = who.aim_per_move( weapon, result, attributes );
@@ -236,6 +241,9 @@ static double improve_moving_preaim( const Character &who, item &weapon,
             break;
         }
         result = std::max( floor, result - amount );
+        if( result <= floor ) {
+            break;
+        }
     }
     return result;
 }
@@ -253,6 +261,21 @@ static double decay_moving_preaim( const double recoil, const int spent_moves )
 void avatar::clear_moving_preaim()
 {
     moving_preaim_targets.clear();
+}
+
+void avatar::apply_moving_preaim_recoil( const double new_recoil )
+{
+    if( !get_option<bool>( "MOVING_PREAIM" ) || moving_preaim_targets.empty() ) {
+        return;
+    }
+
+    // Firing disturbs the weapon, not the shooter's knowledge of tracked targets.
+    // Raise every cached target to at least the real post-shot recoil without doing
+    // any extra LOS, range, or aiming calculations on the firing path.
+    const double recoil_floor = std::clamp( new_recoil, 0.0, static_cast<double>( MAX_RECOIL ) );
+    for( moving_preaim_target_state &state : moving_preaim_targets ) {
+        state.recoil = std::max( state.recoil, recoil_floor );
+    }
 }
 
 void avatar::update_moving_preaim( const int spent_moves, const bool stationary )
@@ -352,6 +375,16 @@ void npc::clear_moving_preaim()
     moving_preaim_target.reset();
     moving_preaim_weapon = itype_id::NULL_ID();
     moving_preaim_recoil_cache = MAX_RECOIL;
+}
+
+void npc::apply_moving_preaim_recoil( const double new_recoil )
+{
+    if( !get_option<bool>( "MOVING_PREAIM" ) || !moving_preaim_target.lock() ) {
+        return;
+    }
+
+    const double recoil_floor = std::clamp( new_recoil, 0.0, static_cast<double>( MAX_RECOIL ) );
+    moving_preaim_recoil_cache = std::max( moving_preaim_recoil_cache, recoil_floor );
 }
 
 void npc::update_moving_preaim( const int spent_moves, const bool stationary )
@@ -1230,10 +1263,6 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun )
     // Use different amounts of time depending on the type of gun and our skill
     moves -= time_to_attack( *this, *gun_id );
 
-    if( curshot > 0 && is_avatar() ) {
-        as_avatar()->clear_moving_preaim();
-    }
-
     // Practice the base gun skill proportionally to number of hits, but always by one.
     if( !gun.has_flag( flag_WONT_TRAIN_MARKSMANSHIP ) ) {
         practice( skill_gun, ( hits + 1 ) * 5 );
@@ -1244,6 +1273,9 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun )
 
     if( !gun.is_gun() ) {
         // If we lose our gun as a side effect of firing it, skip the rest of the function.
+        if( curshot > 0 && is_avatar() ) {
+            as_avatar()->clear_moving_preaim();
+        }
         return curshot;
     }
 
@@ -1265,6 +1297,10 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun )
         }
         // Cap
         recoil = std::min( MAX_RECOIL, recoil );
+    }
+
+    if( curshot > 0 && is_avatar() ) {
+        as_avatar()->apply_moving_preaim_recoil( recoil );
     }
 
     if( is_avatar() ) {


### PR DESCRIPTION
## 变更说明

- 射击后按实际后坐力降低已有移动预瞄稳定度，不再清空目标跟踪
- 玩家和 NPC 使用一致的移动预瞄后坐力处理
- 对姿态/距离精度上限增加提前退出，避免重复计算
- 更新移动射击预瞄选项说明

## 测试

- Windows Tiles x64 MSVC：成功
- Android arm64：成功
- Workflow run：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/31350783306