### PR TITLE
修复普通道路重复生成与道路堆叠问题

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -5932,10 +5932,6 @@ pf::directed_path<point_om_omt> overmap::lay_out_connection(
     const overmap_connection &connection, const point_om_omt &source, const point_om_omt &dest,
     int z, const bool must_be_unexplored ) const
 {
-    // Existing roads are normally preferred so new connections merge into the road network.
-    // If that preference produces a very large detour, retry without the strong bias.  The
-    // terrain basic_cost still makes an existing road slightly preferable at equal distance.
-    bool prefer_existing_connections = true;
     const pf::two_node_scoring_fn<point_om_omt> estimate =
     [&]( pf::directed_node<point_om_omt> cur, std::optional<pf::directed_node<point_om_omt>> prev ) {
         const oter_id id = ter( tripoint_om_omt( cur.pos, z ) );
@@ -5947,34 +5943,6 @@ pf::directed_path<point_om_omt> overmap::lay_out_connection(
         }
 
         const bool existing_connection = connection.has( id );
-
-        // Keep overmap-wide local-road connections from creating a second road directly
-        // alongside an existing one.  City streets already have this guard in lay_out_street,
-        // but connections between cities and overmap exits use lay_out_connection instead.
-        // Without the same guard here, those connections can form long, parallel double roads
-        // through otherwise empty terrain.
-        if( &connection == &*overmap_connection_local_road && !existing_connection &&
-            cur.dir != om_direction::type::invalid ) {
-            const tripoint_om_omt current_pos( cur.pos, z );
-            const tripoint_om_omt forward_pos = current_pos + om_direction::displace( cur.dir, 1 );
-            const tripoint_om_omt backward_pos = current_pos +
-                    om_direction::displace( om_direction::opposite( cur.dir ), 1 );
-            int parallel_road_neighbors = 0;
-            for( int i = -1; i <= 1; i++ ) {
-                for( int j = -1; j <= 1; j++ ) {
-                    const tripoint_om_omt check_pos = current_pos + tripoint( i, j, 0 );
-                    if( check_pos == current_pos || check_pos == forward_pos || check_pos == backward_pos ) {
-                        continue;
-                    }
-                    if( ter( check_pos )->get_type_id() == oter_type_road ) {
-                        parallel_road_neighbors++;
-                    }
-                }
-            }
-            if( parallel_road_neighbors >= 3 ) {
-                return pf::node_score::rejected;
-            }
-        }
 
         // Only do this check if it needs to be unexplored and there isn't already a connection.
         if( must_be_unexplored && !existing_connection ) {
@@ -6012,37 +5980,12 @@ pf::directed_path<point_om_omt> overmap::lay_out_connection(
         const int dist = subtype->is_orthogonal() ?
                          manhattan_dist( dest, cur.pos ) :
                          trig_dist( dest, cur.pos );
-        const int existency_mult =
-            existing_connection && prefer_existing_connections ? 1 : 5;
+        const int existency_mult = existing_connection ? 1 : 5; // Prefer existing connections.
 
         return pf::node_score( subtype->basic_cost, existency_mult * dist );
     };
 
-    pf::directed_path<point_om_omt> preferred_path =
-        pf::greedy_path( source, dest, point_om_omt( OMAPX, OMAPY ), estimate );
-
-    // Only local roads get the geometric detour guard.  Sewer, subway, forest trail and other
-    // connection types retain their historical pathing behavior.
-    if( &connection != &*overmap_connection_local_road || preferred_path.nodes.empty() ) {
-        return preferred_path;
-    }
-
-    const size_t straight_nodes = static_cast<size_t>( manhattan_dist( source, dest ) ) + 1;
-    const size_t detour_limit = straight_nodes + straight_nodes / 2 + 4;
-    if( preferred_path.nodes.size() <= detour_limit ) {
-        return preferred_path;
-    }
-
-    // The first pass can follow a zero-cost existing road a long way because the historical
-    // greedy scorer gives existing roads a 5:1 distance advantage.  Retry with equal distance
-    // weighting and keep it only when it actually shortens the connection.
-    prefer_existing_connections = false;
-    pf::directed_path<point_om_omt> direct_path =
-        pf::greedy_path( source, dest, point_om_omt( OMAPX, OMAPY ), estimate );
-    if( !direct_path.nodes.empty() && direct_path.nodes.size() < preferred_path.nodes.size() ) {
-        return direct_path;
-    }
-    return preferred_path;
+    return pf::greedy_path( source, dest, point_om_omt( OMAPX, OMAPY ), estimate );
 }
 
 static pf::directed_path<point_om_omt> straight_path( const point_om_omt &source,

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -5948,6 +5948,34 @@ pf::directed_path<point_om_omt> overmap::lay_out_connection(
 
         const bool existing_connection = connection.has( id );
 
+        // Keep overmap-wide local-road connections from creating a second road directly
+        // alongside an existing one.  City streets already have this guard in lay_out_street,
+        // but connections between cities and overmap exits use lay_out_connection instead.
+        // Without the same guard here, those connections can form long, parallel double roads
+        // through otherwise empty terrain.
+        if( &connection == &*overmap_connection_local_road && !existing_connection &&
+            cur.dir != om_direction::type::invalid ) {
+            const tripoint_om_omt current_pos( cur.pos, z );
+            const tripoint_om_omt forward_pos = current_pos + om_direction::displace( cur.dir, 1 );
+            const tripoint_om_omt backward_pos = current_pos +
+                    om_direction::displace( om_direction::opposite( cur.dir ), 1 );
+            int parallel_road_neighbors = 0;
+            for( int i = -1; i <= 1; i++ ) {
+                for( int j = -1; j <= 1; j++ ) {
+                    const tripoint_om_omt check_pos = current_pos + tripoint( i, j, 0 );
+                    if( check_pos == current_pos || check_pos == forward_pos || check_pos == backward_pos ) {
+                        continue;
+                    }
+                    if( ter( check_pos )->get_type_id() == oter_type_road ) {
+                        parallel_road_neighbors++;
+                    }
+                }
+            }
+            if( parallel_road_neighbors >= 3 ) {
+                return pf::node_score::rejected;
+            }
+        }
+
         // Only do this check if it needs to be unexplored and there isn't already a connection.
         if( must_be_unexplored && !existing_connection ) {
             // If this must be unexplored, check if we've already got a submap generated.


### PR DESCRIPTION
## 变更内容

- 修复普通道路生成双排并行、重复道路的问题。
- 恢复 12.2 版本的道路寻路偏好，优先复用已有道路连接，避免道路生成过程中出现不必要的绕行和道路堆叠。
- 移除会在本地道路出现较大绕行时重新计算路径的额外分支，保持道路连接路径逻辑一致。

## 问题原因

道路寻路的额外绕行判断会在首次路径过长时重新计算本地道路，并可能改变原有道路连接偏好，导致普通道路重复生成或形成并行双排道路。

## 测试情况

- 使用 `Windows & Android Test #139` 构建验证。
- 测试分支：`codex/fix-duplicate-local-roads`
- 测试提交：`d03c58c9ee32895cac6bb84da78c196a29b9f8d8`
- PC 测试目录：`D:\Games\CDDA\测试游戏139-修复重复本地道路`
- 已确认道路修复效果符合预期，游戏可以正常启动。

## 影响范围

- 仅修改 `src/overmap.cpp` 中的道路连接寻路逻辑。