### PR TITLE
优化高尸群场景下的安卓怪物寻路性能

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -97,6 +97,9 @@ constexpr int reverse_field_cross_z_radius = 72;
 constexpr std::size_t monster_route_cache_max_edges = 8192;
 constexpr std::size_t monster_reverse_field_max_count = 24;
 constexpr std::size_t monster_reverse_field_request_budget = 4096;
+constexpr int monster_stair_route_bucket_size = 24;
+constexpr int monster_stair_route_memory_turns = 60;
+constexpr std::size_t monster_cross_z_route_default_turn_budget = 8;
 constexpr std::size_t monster_reverse_field_default_turn_budget = 49152;
 constexpr std::size_t monster_reverse_field_min_turn_budget = 8192;
 constexpr std::size_t monster_route_search_default_turn_budget = 64;
@@ -156,6 +159,26 @@ struct monster_z_route_cache_key {
 struct monster_z_route_plan {
     tripoint approach;
     tripoint transition;
+};
+
+struct monster_stair_route_cache_key {
+    int source_z = 0;
+    int target_z = 0;
+    int target_x_bucket = 0;
+    int target_y_bucket = 0;
+
+    bool operator<( const monster_stair_route_cache_key &rhs ) const
+    {
+        return std::tie( source_z, target_z, target_x_bucket, target_y_bucket ) <
+               std::tie( rhs.source_z, rhs.target_z, rhs.target_x_bucket,
+                          rhs.target_y_bucket );
+    }
+};
+
+struct monster_stair_route_cache_entry {
+    tripoint_abs_ms approach;
+    tripoint_abs_ms transition;
+    time_point last_confirmed;
 };
 
 struct monster_tripoint_hash {
@@ -334,8 +357,12 @@ std::map<monster_z_route_cache_key, monster_z_route_plan> monster_z_route_cache;
 std::map<monster_route_cache_key, std::unique_ptr<monster_reverse_field_entry>>
 monster_reverse_fields;
 std::vector<std::unique_ptr<monster_reverse_field_entry>> monster_reverse_field_pool;
+std::map<monster_stair_route_cache_key, monster_stair_route_cache_entry>
+monster_stair_route_cache;
 std::size_t monster_route_cache_edges = 0;
 std::size_t monster_reverse_field_nodes = 0;
+std::size_t monster_cross_z_route_search_turn_budget = monster_cross_z_route_default_turn_budget;
+std::size_t monster_cross_z_route_searches = 0;
 std::size_t monster_reverse_field_turn_budget = monster_reverse_field_default_turn_budget;
 std::size_t monster_route_search_turn_budget = monster_route_search_default_turn_budget;
 std::size_t monster_route_searches = 0;
@@ -348,12 +375,95 @@ void clear_monster_path_caches()
     monster_z_route_cache.clear();
     monster_route_cache_edges = 0;
     monster_reverse_field_nodes = 0;
+    monster_cross_z_route_searches = 0;
     monster_route_searches = 0;
 
     for( auto &field_pair : monster_reverse_fields ) {
         monster_reverse_field_pool.emplace_back( std::move( field_pair.second ) );
     }
     monster_reverse_fields.clear();
+}
+
+int monster_stair_route_bucket( int coordinate )
+{
+    return static_cast<int>( std::floor( static_cast<double>( coordinate ) /
+                                         monster_stair_route_bucket_size ) );
+}
+
+monster_stair_route_cache_key make_monster_stair_route_cache_key(
+    const tripoint_abs_ms &target, int source_z )
+{
+    return { source_z, target.z(), monster_stair_route_bucket( target.x() ),
+             monster_stair_route_bucket( target.y() ) };
+}
+
+bool is_monster_stair_transition( const map &here, const tripoint &approach,
+                                  const tripoint &transition )
+{
+    const int dz = transition.z - approach.z;
+    if( dz == 1 ) {
+        return ( here.has_flag( ter_furn_flag::TFLAG_GOES_UP, approach ) &&
+                 here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, transition ) ) ||
+               here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, approach );
+    }
+    if( dz == -1 ) {
+        return ( here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, approach ) &&
+                 here.has_flag( ter_furn_flag::TFLAG_GOES_UP, transition ) ) ||
+               here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, approach );
+    }
+    return false;
+}
+
+void remember_monster_stair_route( map &here, const tripoint_abs_ms &target,
+                                   const tripoint &approach, const tripoint &transition )
+{
+    if( !is_monster_stair_transition( here, approach, transition ) ) {
+        return;
+    }
+
+    constexpr std::size_t max_stair_route_entries = 64;
+    const monster_stair_route_cache_key key = make_monster_stair_route_cache_key(
+            target, approach.z );
+    if( monster_stair_route_cache.find( key ) == monster_stair_route_cache.end() &&
+        monster_stair_route_cache.size() >= max_stair_route_entries ) {
+        const auto oldest = std::min_element( monster_stair_route_cache.begin(),
+        monster_stair_route_cache.end(), []( const auto &lhs, const auto &rhs ) {
+            return lhs.second.last_confirmed < rhs.second.last_confirmed;
+        } );
+        monster_stair_route_cache.erase( oldest );
+    }
+
+    monster_stair_route_cache[key] = {
+        here.getglobal( approach ), here.getglobal( transition ), calendar::turn
+    };
+}
+
+std::optional<monster_z_route_plan> get_remembered_monster_stair_route(
+    map &here, const tripoint_abs_ms &target, int source_z )
+{
+    const monster_stair_route_cache_key key = make_monster_stair_route_cache_key(
+            target, source_z );
+    const auto iter = monster_stair_route_cache.find( key );
+    if( iter == monster_stair_route_cache.end() ) {
+        return std::nullopt;
+    }
+    if( calendar::turn > iter->second.last_confirmed +
+        time_duration::from_turns( monster_stair_route_memory_turns ) ) {
+        monster_stair_route_cache.erase( iter );
+        return std::nullopt;
+    }
+
+    const tripoint approach = here.getlocal( iter->second.approach );
+    const tripoint transition = here.getlocal( iter->second.transition );
+    if( approach.z != source_z || transition.z != target.z() ||
+        !here.inbounds( approach ) || !here.inbounds( transition ) ||
+        !is_monster_stair_transition( here, approach, transition ) ) {
+        monster_stair_route_cache.erase( iter );
+        return std::nullopt;
+    }
+
+    iter->second.last_confirmed = calendar::turn;
+    return monster_z_route_plan { approach, transition };
 }
 
 void update_monster_pathfinding_budgets()
@@ -372,6 +482,10 @@ void update_monster_pathfinding_budgets()
             monster_reverse_field_default_turn_budget / horde_factor );
     monster_route_search_turn_budget = std::max<std::size_t>( monster_route_search_min_turn_budget,
             monster_route_search_default_turn_budget / horde_factor );
+    // Reserve a small, separate lane for cross-Z searches.  A horde must not
+    // be able to spend the entire ordinary route budget before it discovers a
+    // usable stair portal.
+    monster_cross_z_route_search_turn_budget = monster_cross_z_route_default_turn_budget;
 }
 
 void refresh_monster_path_caches()
@@ -391,6 +505,7 @@ int refresh_monster_pathfinding_mode( bool improved )
         ++monster_pathfinding_mode_generation;
         monster_path_cache_turn.reset();
         clear_monster_path_caches();
+        monster_stair_route_cache.clear();
     }
     return monster_pathfinding_mode_generation;
 }
@@ -1610,11 +1725,45 @@ void monster::move()
         };
         const monster_z_route_cache_key z_cache_key { cache_key, posz() };
 
-        const auto z_plan_iter = cross_z ? monster_z_route_cache.find( z_cache_key ) :
-                                 monster_z_route_cache.end();
-        const bool has_z_plan = z_plan_iter != monster_z_route_cache.end();
-        const tripoint segment_dest = has_z_plan && pos() != z_plan_iter->second.approach ?
-                                      z_plan_iter->second.approach : route_dest;
+        std::optional<monster_z_route_plan> z_plan;
+        if( cross_z ) {
+            const auto z_plan_iter = monster_z_route_cache.find( z_cache_key );
+            if( z_plan_iter != monster_z_route_cache.end() ) {
+                z_plan = z_plan_iter->second;
+            }
+            if( !z_plan ) {
+                z_plan = get_remembered_monster_stair_route( here,
+                         absolute_route_dest, posz() );
+                if( z_plan ) {
+                    // Promote the remembered portal to the exact target key
+                    // for the rest of this turn.  This is a cheap map lookup
+                    // for the rest of the horde, not another A* search.
+                    monster_z_route_cache[z_cache_key] = *z_plan;
+                }
+            }
+            if( z_plan && ( z_plan->approach.z != posz() ||
+                            z_plan->transition.z != route_dest.z ||
+                            !here.inbounds( z_plan->approach ) ||
+                            !here.inbounds( z_plan->transition ) ) ) {
+                z_plan.reset();
+            }
+        }
+        const bool has_z_plan = z_plan.has_value();
+        const tripoint segment_dest = has_z_plan && pos() != z_plan->approach ?
+                                      z_plan->approach : route_dest;
+
+        // A remembered stair is a portal, not a normal same-level path step.
+        // Execute it directly after validating the tile; the movement code
+        // below still performs the final can_reach_to()/can_move_to() checks.
+        if( has_z_plan && pos() == z_plan->approach &&
+            is_monster_stair_transition( here, z_plan->approach,
+                                         z_plan->transition ) ) {
+            path.clear();
+            destination = z_plan->transition;
+            moved = true;
+            pathed = true;
+            return true;
+        }
 
         const bool existing_path_matches = !path.empty() &&
                                            ( path.back() == route_dest ||
@@ -1810,14 +1959,25 @@ void monster::move()
                     route_settings.max_length = std::max( route_settings.max_length,
                                                          route_radius * 8 );
                 }
-                if( monster_route_searches >= monster_route_search_turn_budget ) {
-                    pathfinding_budget_exhausted = true;
-                    failed_pathfinding_target = absolute_route_dest;
-                    failed_pathfinding_cooldown = 2 +
-                                                   ( std::abs( posx() + posy() + posz() ) % 3 );
-                    return false;
+                if( cross_z ) {
+                    if( monster_cross_z_route_searches >= monster_cross_z_route_search_turn_budget ) {
+                        pathfinding_budget_exhausted = true;
+                        failed_pathfinding_target = absolute_route_dest;
+                        failed_pathfinding_cooldown = 2 +
+                                                       ( std::abs( posx() + posy() + posz() ) % 3 );
+                        return false;
+                    }
+                    ++monster_cross_z_route_searches;
+                } else {
+                    if( monster_route_searches >= monster_route_search_turn_budget ) {
+                        pathfinding_budget_exhausted = true;
+                        failed_pathfinding_target = absolute_route_dest;
+                        failed_pathfinding_cooldown = 2 +
+                                                       ( std::abs( posx() + posy() + posz() ) % 3 );
+                        return false;
+                    }
+                    ++monster_route_searches;
                 }
-                ++monster_route_searches;
                 path = here.route( pos(), route_dest, route_settings, get_path_avoid() );
             }
 
@@ -1832,6 +1992,8 @@ void monster::move()
                         if( step.z != previous.z ) {
                             if( ( step.z - previous.z ) * wanted_z_direction > 0 ) {
                                 monster_z_route_cache[z_cache_key] = { previous, step };
+                                remember_monster_stair_route( here, absolute_route_dest,
+                                                              previous, step );
                             }
                             break;
                         }
@@ -1883,7 +2045,8 @@ void monster::move()
                                                      cross_z_monster_path_radius ) :
                                            pf_settings.max_dist;
             if( !try_route_to( local_dest ) &&
-                ( target_distance > target_path_radius || pathfinding_budget_exhausted ) ) {
+                ( target_distance > target_path_radius ||
+                  ( pathfinding_budget_exhausted && local_dest.z == posz() ) ) ) {
                 destination = local_dest;
                 moved = true;
             }
@@ -1939,7 +2102,8 @@ void monster::move()
                 unset_dest();
 
                 if( !try_route_to( sound_dest ) &&
-                    ( sound_distance > sound_path_radius || pathfinding_budget_exhausted ) ) {
+                    ( sound_distance > sound_path_radius ||
+                      ( pathfinding_budget_exhausted && sound_dest.z == posz() ) ) ) {
                     destination = sound_dest;
                     moved = true;
                 }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -97,7 +97,13 @@ constexpr int reverse_field_cross_z_radius = 72;
 constexpr std::size_t monster_route_cache_max_edges = 8192;
 constexpr std::size_t monster_reverse_field_max_count = 24;
 constexpr std::size_t monster_reverse_field_request_budget = 4096;
-constexpr std::size_t monster_reverse_field_turn_budget = 49152;
+constexpr std::size_t monster_reverse_field_default_turn_budget = 49152;
+constexpr std::size_t monster_reverse_field_min_turn_budget = 8192;
+constexpr std::size_t monster_route_search_default_turn_budget = 64;
+constexpr std::size_t monster_route_search_min_turn_budget = 16;
+// Once a loaded horde reaches this size, tighten the shared per-turn budgets
+// instead of allowing every monster to spend the normal solo-search allowance.
+constexpr std::size_t monster_pathfinding_horde_size_step = 64;
 
 int quantize_monster_bash_strength( int strength )
 {
@@ -330,6 +336,9 @@ monster_reverse_fields;
 std::vector<std::unique_ptr<monster_reverse_field_entry>> monster_reverse_field_pool;
 std::size_t monster_route_cache_edges = 0;
 std::size_t monster_reverse_field_nodes = 0;
+std::size_t monster_reverse_field_turn_budget = monster_reverse_field_default_turn_budget;
+std::size_t monster_route_search_turn_budget = monster_route_search_default_turn_budget;
+std::size_t monster_route_searches = 0;
 std::optional<bool> monster_improved_pathfinding_mode;
 int monster_pathfinding_mode_generation = 1;
 
@@ -339,6 +348,7 @@ void clear_monster_path_caches()
     monster_z_route_cache.clear();
     monster_route_cache_edges = 0;
     monster_reverse_field_nodes = 0;
+    monster_route_searches = 0;
 
     for( auto &field_pair : monster_reverse_fields ) {
         monster_reverse_field_pool.emplace_back( std::move( field_pair.second ) );
@@ -346,11 +356,30 @@ void clear_monster_path_caches()
     monster_reverse_fields.clear();
 }
 
+void update_monster_pathfinding_budgets()
+{
+    std::size_t monster_count = 0;
+    if( g != nullptr ) {
+        for( const monster &mon : g->all_monsters() ) {
+            ( void )mon;
+            ++monster_count;
+        }
+    }
+    const std::size_t horde_factor = std::max<std::size_t>( 1,
+            ( monster_count + monster_pathfinding_horde_size_step - 1 ) /
+            monster_pathfinding_horde_size_step );
+    monster_reverse_field_turn_budget = std::max<std::size_t>( monster_reverse_field_min_turn_budget,
+            monster_reverse_field_default_turn_budget / horde_factor );
+    monster_route_search_turn_budget = std::max<std::size_t>( monster_route_search_min_turn_budget,
+            monster_route_search_default_turn_budget / horde_factor );
+}
+
 void refresh_monster_path_caches()
 {
     if( !monster_path_cache_turn || *monster_path_cache_turn != calendar::turn ) {
         monster_path_cache_turn = calendar::turn;
         clear_monster_path_caches();
+        update_monster_pathfinding_budgets();
     }
 }
 
@@ -775,7 +804,6 @@ void monster::plan()
     if( pet_without_auto_follow && get_dest() == player_character.get_location() ) {
         unset_dest();
     }
-    flood_fill_zone(*this);
     // If we can see the player, move toward them or flee.
     if( friendly == 0 && seen_levels.test( player_character.pos().z + OVERMAP_DEPTH ) &&
         sees( player_character ) ) {
@@ -943,6 +971,7 @@ void monster::plan()
                                  turns_since_target );
     int turns_to_skip = max_turns_to_skip * rate_limiting_factor;
     if( friendly == 0 && ( turns_to_skip == 0 || turns_since_target % turns_to_skip == 0 ) ) {
+        flood_fill_zone( *this );
         for( const auto &fac_list : factions ) {
             mf_attitude faction_att = faction.obj().attitude( fac_list.first );
             if( faction_att == MFA_NEUTRAL || faction_att == MFA_FRIENDLY ) {
@@ -1504,6 +1533,7 @@ void monster::move()
 
     // If true, don't try to greedily avoid locally bad paths
     bool pathed = false;
+    bool pathfinding_budget_exhausted = false;
     const tripoint local_dest = here.getlocal( get_dest() );
 
     pathfinding_settings pf_settings = get_pathfinding_settings();
@@ -1780,6 +1810,14 @@ void monster::move()
                     route_settings.max_length = std::max( route_settings.max_length,
                                                          route_radius * 8 );
                 }
+                if( monster_route_searches >= monster_route_search_turn_budget ) {
+                    pathfinding_budget_exhausted = true;
+                    failed_pathfinding_target = absolute_route_dest;
+                    failed_pathfinding_cooldown = 2 +
+                                                   ( std::abs( posx() + posy() + posz() ) % 3 );
+                    return false;
+                }
+                ++monster_route_searches;
                 path = here.route( pos(), route_dest, route_settings, get_path_avoid() );
             }
 
@@ -1844,7 +1882,8 @@ void monster::move()
                                            std::max( pf_settings.max_dist,
                                                      cross_z_monster_path_radius ) :
                                            pf_settings.max_dist;
-            if( !try_route_to( local_dest ) && target_distance > target_path_radius ) {
+            if( !try_route_to( local_dest ) &&
+                ( target_distance > target_path_radius || pathfinding_budget_exhausted ) ) {
                 destination = local_dest;
                 moved = true;
             }
@@ -1899,7 +1938,8 @@ void monster::move()
                                               pf_settings.max_dist;
                 unset_dest();
 
-                if( !try_route_to( sound_dest ) && sound_distance > sound_path_radius ) {
+                if( !try_route_to( sound_dest ) &&
+                    ( sound_distance > sound_path_radius || pathfinding_budget_exhausted ) ) {
                     destination = sound_dest;
                     moved = true;
                 }


### PR DESCRIPTION
## 概要

- 为改进怪物寻路加入按尸群规模动态收紧的每回合寻路预算。
- 共享反向距离场和普通路径搜索的工作上限，避免大量怪物在同一回合重复消耗 CPU。
- 缓存并复用跨层楼梯入口，减少高尸群场景中的重复跨层 A* 搜索。
- 保留现有改进寻路 AI；预算耗尽时使用已有的直接追踪与短暂失败冷却作为降级路径。

## 背景

安卓设备在怪物数量较多时容易因为改进寻路的最坏情况搜索而出现严重回合卡顿。该补丁将全局搜索工作量限制在每回合固定上限内，并随怪物数量增加逐步降低上限，使性能退化更加可控。

## 影响与取舍

这不会把改进 AI 改成经典 AI，也不保证路线质量与经典模式完全相同；在极端尸群场景下，部分怪物可能暂时采用直接追踪或等待下一次寻路机会。正常情况下仍优先使用缓存路径、反向距离场和改进寻路逻辑。

## 验证

- GitHub Actions `Windows & Android Test` 运行 136 成功。
- `Windows Tiles x64 MSVC` 构建成功。
- `Android arm64` 测试 APK 构建成功。
- `git diff --check` 通过。
- 已在 Windows 测试分支中进行实际游戏测试，未发现明显异常。

目前 CI 只验证 Android arm64 编译与打包，没有 Android 实机高尸群回合基准，因此本 PR 不宣称已达到经典 AI 的实测性能；目标是先合入当前已测试的性能上限保护方案。
