### PR TITLE
修复MSVC静态链接系统库

### DIFF
--- a/msvc-full-features/Cataclysm-common.props
+++ b/msvc-full-features/Cataclysm-common.props
@@ -46,7 +46,7 @@
       <LinkTimeCodeGeneration>Default</LinkTimeCodeGeneration>
       <LinkStatus>true</LinkStatus>
       <AdditionalOptions>/LTCG:OFF %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>winmm.lib;imm32.lib;version.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;setupapi.lib;shlwapi.lib;ws2_32.lib;crypt32.lib;wldap32.lib;normaliz.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>winmm.lib;imm32.lib;version.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;setupapi.lib;shlwapi.lib;ws2_32.lib;bcrypt.lib;iphlpapi.lib;secur32.lib;crypt32.lib;wldap32.lib;normaliz.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>


### PR DESCRIPTION
## 改动

为 MSVC 静态链接补充 `bcrypt.lib`、`iphlpapi.lib` 和 `secur32.lib`。

## 原因

运行编号 157 的 `Windows & Android Test` 已成功完成 vcpkg 配置和编译，但最终链接阶段的静态 libcurl 报告以下未解析符号：`__imp_if_nametoindex`、`BCryptGenRandom`、`__imp_InitSecurityInterfaceW`。它们分别由上述 Windows 系统库提供。Android job 已成功，说明本次问题限定在 Windows MSVC 链接配置。

运行记录：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/31668800606

## 范围与验证

本 PR 只修改 `msvc-full-features/Cataclysm-common.props`，不包含游戏功能代码。已通过 XML 解析和 `git diff --check`。