### PR TITLE
修复PC窗口尺寸设置与应用内缩放

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3526,7 +3526,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
             std::stringstream value_conversion( current_opt.getValueName() );
 
             value_conversion >> new_terminal_x;
-            new_window_width = projected_window_width();
+            new_window_width = new_terminal_x * fontwidth;
 
             fold_and_print( w_options_tooltip, point_zero, iMinScreenWidth - 2, c_white,
                             n_gettext( "%s #%s - The window will be %d pixel wide with the selected value.",
@@ -3541,7 +3541,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
             std::stringstream value_conversion( current_opt.getValueName() );
 
             value_conversion >> new_terminal_y;
-            new_window_height = projected_window_height();
+            new_window_height = new_terminal_y * fontheight;
 
             fold_and_print( w_options_tooltip, point_zero, iMinScreenWidth - 2, c_white,
                             n_gettext( "%s #%s -- The window will be %d pixel tall with the selected value.",
@@ -3845,7 +3845,8 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
         get_option( "TERMINAL_Y" ).setValue( set_term.y );
         save();
 
-        resize_term( ::get_option<int>( "TERMINAL_X" ), ::get_option<int>( "TERMINAL_Y" ) );
+        resize_term( ::get_option<int>( "TERMINAL_X" ) / scaling_factor,
+                     ::get_option<int>( "TERMINAL_Y" ) / scaling_factor );
     }
 #else
     ( void ) terminal_size_changed;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3843,6 +3843,9 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
                               std::max( EVEN_MINIMUM_TERM_HEIGHT * scaling_factor, TERM.y ) );
         get_option( "TERMINAL_X" ).setValue( set_term.x );
         get_option( "TERMINAL_Y" ).setValue( set_term.y );
+        // A custom terminal size needs a normal window.  Persist this choice so
+        // the next launch does not restore fullscreen and overwrite the size.
+        get_option( "FULLSCREEN" ).setValue( "no" );
         save();
 
         resize_term( ::get_option<int>( "TERMINAL_X" ) / scaling_factor,

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2155,8 +2155,29 @@ bool handle_resize( int w, int h )
     return true;
 }
 
+static void restore_windowed_for_resize()
+{
+    const Uint32 flags = SDL_GetWindowFlags( window.get() );
+    const bool is_fullscreen = ( flags & SDL_WINDOW_FULLSCREEN ) != 0;
+    const bool is_maximized = ( flags & SDL_WINDOW_MAXIMIZED ) != 0;
+    if( !is_fullscreen && !is_maximized ) {
+        return;
+    }
+
+    if( is_fullscreen && printErrorIf( SDL_SetWindowFullscreen( window.get(), 0 ) != 0,
+                                       "SDL_SetWindowFullscreen failed" ) ) {
+        return;
+    }
+
+    // SDL_SetWindowSize cannot resize a fullscreen or maximized window.  Restore
+    // the normal window state first so the terminal-size option has an effect.
+    SDL_RestoreWindow( window.get() );
+    fullscreen = false;
+}
+
 void resize_term( const int cell_w, const int cell_h )
 {
+    restore_windowed_for_resize();
     int w = cell_w * fontwidth * scaling_factor;
     int h = cell_h * fontheight * scaling_factor;
     SDL_SetWindowSize( window.get(), w, h );
@@ -2166,8 +2187,8 @@ void resize_term( const int cell_w, const int cell_h )
 
 void toggle_fullscreen_window()
 {
-    static int restore_win_w = get_option<int>( "TERMINAL_X" ) * fontwidth * scaling_factor;
-    static int restore_win_h = get_option<int>( "TERMINAL_Y" ) * fontheight * scaling_factor;
+    static int restore_win_w = get_option<int>( "TERMINAL_X" ) * fontwidth;
+    static int restore_win_h = get_option<int>( "TERMINAL_Y" ) * fontheight;
 
     if( fullscreen ) {
         if( printErrorIf( SDL_SetWindowFullscreen( window.get(), 0 ) != 0,


### PR DESCRIPTION
## 摘要
修复 Windows 图形版在全屏、无边框或最大化模式下修改终端尺寸无效，以及 `SCALING_FACTOR` 下窗口尺寸重复放大的问题。

## 改动
- 尺寸提示改为使用当前候选的终端宽高，而不是旧配置值。
- 应用终端尺寸时先恢复普通窗口，再设置 SDL 窗口尺寸。
- 修正缩放因子的单位转换和全屏切回时的恢复尺寸。
- 用户修改终端尺寸后自动保存 `FULLSCREEN=no`，避免重启时重新进入全屏并覆盖尺寸。

## Android 影响
- 终端尺寸处理代码仍受 `!defined(__ANDROID__)` 条件保护；Android 的全屏启动和配置行为不变。
- Android arm64 已在 Windows & Android Test 运行编号 195 中成功构建。

## 验证
- `git diff --check` 通过。
- Windows Tiles x64 MSVC 与 Android arm64 均通过运行编号 195。
- 运行编号 195 head SHA：`04578c310538a87181f4f584e47d1626041a244d`。

修改终端尺寸会切换到普通窗口并持久化该选择；用户仍可手动重新选择全屏模式。