### PR TITLE
修复抗菌剂液体上药导致的崩溃

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3334,8 +3334,16 @@ void craft_activity_actor::start( player_activity &act, Character &crafter )
 {
     if( !check_if_craft_okay( craft_item, crafter ) ) {
         act.set_to_null();
+        return;
     }
-    activity_override = craft_item.get_item()->get_making().exertion_level();
+    item *const craft = craft_item.get_item();
+    if( craft == nullptr ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "craft activity target disappeared after validation" );
+        act.set_to_null();
+        return;
+    }
+    activity_override = craft->get_making().exertion_level();
     cached_crafting_speed = 0;
 
   
@@ -6216,6 +6224,13 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
 {
     static const std::string iuse_name_string( "heal" );
 
+    if( act.targets.empty() || !act.targets.front() ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "first aid activity target is no longer available" );
+        act.set_to_null();
+        return;
+    }
+
     item_location it = act.targets.front();
     item *used_tool = it->get_usable_item( iuse_name_string );
     if( used_tool == nullptr ) {
@@ -6225,6 +6240,11 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
     }
 
     const use_function *use_fun = used_tool->get_use( iuse_name_string );
+    if( use_fun == nullptr || use_fun->get_actor_ptr() == nullptr ) {
+        debugmsg( "Lost heal use function" );
+        act.set_to_null();
+        return;
+    }
     const heal_actor *actor = dynamic_cast<const heal_actor *>( use_fun->get_actor_ptr() );
     if( actor == nullptr ) {
         debugmsg( "iuse_actor type descriptor and actual type mismatch" );
@@ -6240,12 +6260,26 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
         act.values.clear();
         return;
     }
+    if( act.str_values.empty() ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "first aid activity has no body part target" );
+        act.set_to_null();
+        return;
+    }
     const bodypart_id healed = bodypart_id( act.str_values[0] );
     int charges_consumed = actor->finish_using( who, *patient,
                            *used_tool, healed );
+    if( !it ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "first aid item disappeared while applying treatment" );
+        act.set_to_null();
+        return;
+    }
     std::list<item>used;
     if( it->use_charges( it->typeId(), charges_consumed, used, it.position() ) ) {
-        it.remove_item();
+        if( it ) {
+            it.remove_item();
+        }
     }
 
     // Erase activity and values.

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <exception>
 #include <functional>
 #include <iterator>
 #include <list>
@@ -195,9 +196,9 @@ static bool get_liquid_target(Character& character, item &liquid, const item *co
         std::vector<item_location> containers_locations;
 
         for (item_location &loc : character.get_eligible_containers_locations_for_crafting()) {
-            item *i = loc.get_item();
-            if (i->get_remaining_capacity_for_liquid(liquid_copy,true)>0) {
-                containers_locations.push_back(loc);
+            item *const i = loc.get_item();
+            if( i != nullptr && i->get_remaining_capacity_for_liquid( liquid_copy, true ) > 0 ) {
+                containers_locations.push_back( loc );
             }
         }
 
@@ -229,8 +230,12 @@ static bool get_liquid_target(Character& character, item &liquid, const item *co
         menu.text = string_format( pgettext( "liquid", "What to do with the %s?" ), liquid_name );
     }
     std::vector<std::function<void()>> actions;
-    // Allow consuming freshly crafted liquids while still excluding monster-source liquids.
-    if( character.can_consume_as_is( liquid ) && !source_mon ) {
+    // Allow consuming freshly crafted liquids while still excluding monster-source and
+    // explicitly non-ingestible liquids (such as antiseptic).  Non-ingestible liquids
+    // may have use actions that require a persistent item location; passing a temporary
+    // liquid copy to consume_activity_actor would leave those activities with a dangling
+    // target and could crash when they finish.
+    if( character.can_consume_as_is( liquid ) && !liquid.has_flag( flag_NO_INGEST ) && !source_mon ) {
         menu.addentry( -1, true, 'e', _( "Consume it" ) );
         actions.emplace_back( [&]() {
             target.dest_opt = LD_CONSUME;
@@ -495,21 +500,34 @@ bool handle_liquid( item &liquid, const item *const source, const int radius,
     }
     struct liquid_dest_opt liquid_target;
 
-    Character* character = nullptr;
-    if (liquid.has_var("crafter_id")) {
-        character = overmap_buffer.find_npc(character_id(std::stoi(liquid.get_var("crafter_id"))))->as_character();
-    }
-    else {
+    Character *character = nullptr;
+    if( liquid.has_var( "crafter_id" ) ) {
+        try {
+            const character_id crafter_id( std::stoi( liquid.get_var( "crafter_id" ) ) );
+            if( npc *const crafter = overmap_buffer.find_npc( crafter_id ) ) {
+                character = crafter->as_character();
+            }
+        } catch( const std::exception & ) {
+            add_msg_debug( debugmode::DF_ACTIVITY,
+                           "liquid has an invalid crafter id" );
+        }
+    } else {
         character = &get_player_character();
     }
-        
 
-    if( get_liquid_target(*character,liquid, source, radius, source_pos, source_veh, source_mon,
-                           liquid_target) ) {
-        success = perform_liquid_transfer(*character, liquid, source_pos, source_veh, part_num, source_mon,
-                                           liquid_target );
-        if( success && ( ( liquid_target.dest_opt == LD_ITEM &&
-                           liquid_target.item_loc->is_watertight_container() ) || liquid_target.dest_opt == LD_KEG ) ) {
+    if( character == nullptr ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "liquid crafter is no longer available" );
+        return false;
+    }
+
+    if( get_liquid_target( *character, liquid, source, radius, source_pos, source_veh, source_mon,
+                           liquid_target ) ) {
+        success = perform_liquid_transfer( *character, liquid, source_pos, source_veh, part_num,
+                                           source_mon, liquid_target );
+        if( success && ( ( liquid_target.dest_opt == LD_ITEM && liquid_target.item_loc &&
+                           liquid_target.item_loc->is_watertight_container() ) ||
+                         liquid_target.dest_opt == LD_KEG ) ) {
             liquid.unset_flag( flag_id( json_flag_FROM_FROZEN_LIQUID ) );
         }
         return success;

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -21,6 +21,7 @@
 #include "color.h"
 #include "debug.h"
 #include "enums.h"
+#include "flag.h"
 #include "game.h"
 #include "game_inventory.h"
 #include "iexamine.h"
@@ -504,7 +505,7 @@ bool handle_liquid( item &liquid, const item *const source, const int radius,
     if( liquid.has_var( "crafter_id" ) ) {
         try {
             const character_id crafter_id( std::stoi( liquid.get_var( "crafter_id" ) ) );
-            if( npc *const crafter = overmap_buffer.find_npc( crafter_id ) ) {
+            if( const auto crafter = overmap_buffer.find_npc( crafter_id ) ) {
                 character = crafter->as_character();
             }
         } catch( const std::exception & ) {


### PR DESCRIPTION
## 核心改动
修复抗菌剂等不可入口液体在液体处理流程中被误选为“直接饮用”，导致临时物品副本创建上药活动、活动结束时访问失效 `item_location` 并卡死闪退的问题。

## 完整改动范围
- `src/handle_liquid.cpp`
  - `NO_INGEST` 液体不再进入直接饮用选项，仍可倒入容器或倒在地上。
  - 为 NPC 候选容器、异常/失效 `crafter_id` 和液体目标位置增加有效性检查。
- `src/activity_actor.cpp`
  - 为上药活动补充目标、使用函数、身体部位和治疗后物品位置检查。
  - 防止制造活动验证失败后继续解引用失效物品位置。
- 未修改 JSON、翻译或玩家可见文本。

## 使用方式
- 烧开/制造出的 `water_clean` 不带 `NO_INGEST`，仍可在液体处理菜单中选择直接饮用。
- 抗菌剂应通过物品使用/激活菜单选择“上药”；液体处理菜单仍可选择倒入容器或倒在地上。

## 测试
- Windows & Android Test 运行编号 197：成功
- 提交 SHA：`3284300c4d7ee833b6474f310182bc7381858253`
- [Actions 运行链接](https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/32020955570)