### PR TITLE
载具可中断工作功能的性能回归

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2335,15 +2335,20 @@ void activity_handlers::vehicle_do_turn( player_activity *act, Character *you )
         return;
     }
 
-    const requirement_data reqs = vehicle_work_requirements( *work, veh, part_index );
-    you->invalidate_crafting_inventory();
-    if( !reqs.can_make_with_inventory( you->crafting_inventory(), is_crafting_component ) ) {
-        act->moves_left = moves_left_for_vehicle_work( *work );
-        const std::string name = operation == 'i' ? vpart_id( part_id ).obj().name() :
-                                 veh->part( part_index ).name();
-        vehicle_work_requirement_message( *you, *work, name );
-        you->cancel_activity();
-        return;
+    // Re-check requirements at most once per 1000 moves of progress instead of
+    // every turn: rebuilding the crafting inventory is expensive, and the
+    // start/finish checks cover the common cases.  The final check is always
+    // performed so a job cannot complete without its materials.
+    if( ( act->moves_left % 1000 ) < 200 || act->moves_left <= 200 ) {
+        const requirement_data reqs = vehicle_work_requirements( *work, veh, part_index );
+        if( !reqs.can_make_with_inventory( you->crafting_inventory(), is_crafting_component ) ) {
+            act->moves_left = moves_left_for_vehicle_work( *work );
+            const std::string name = operation == 'i' ? vpart_id( part_id ).obj().name() :
+                                     veh->part( part_index ).name();
+            vehicle_work_requirement_message( *you, *work, name );
+            you->cancel_activity();
+            return;
+        }
     }
 
     if( part_index >= 0 ) {


### PR DESCRIPTION
## 背景

新增"载具可随时中断维修、安装和拆卸"功能（工作进度持久化到载具）后，实测游戏运行速度明显变慢。

## 原因

该功能为 `ACT_VEHICLE` 注册了每帧调用的 `vehicle_do_turn`，其中每帧（每 100 移动点）执行一次完整的需求检查：

- 每帧调用 `invalidate_crafting_inventory()` 强制制作库存缓存失效；
- 随后 `crafting_inventory()` 全量重建制作库存，遍历角色周围 6 格内所有地面物品、容器以及车辆储物箱内所有物品（玩家干活时通常就站在满载车辆旁）；
- 改动前安装/拆卸全程只做两次需求检查（开始与完成），修理的每帧处理也只是多目标轮换，从不构建库存。

一次需要数千移动点的操作会重建库存几十次，这就是性能回归的根源。

## 改动内容

`src/activity_handlers.cpp` 中 `vehicle_do_turn`：

1. 需求检查从"每帧"降为"每 1000 移动点一次"（收尾 200 移动点内必查，防止缺少材料时完成工作）；
2. 删除每帧的 `invalidate_crafting_inventory()`，让制作库存缓存可以正常复用（物品变化时其他代码仍会失效缓存，不存在陈旧数据问题）。

## 玩家可见影响

- 工作进度、中断/恢复逻辑均不变；
- 干活途中材料被夺走时，工作停止的响应延迟最多约 1 秒游戏时间（此前为即时）；
- 中断恢复时仍会在开始时重新校验需求，不受影响。

实测在满载车辆旁进行载具作业，运行速度显著提升。