### PR TITLE
修复 MSVC 工作流卡死超时

### DIFF
--- a/.github/workflows/msvc-test.yml
+++ b/.github/workflows/msvc-test.yml
@@ -21,6 +21,8 @@ jobs:
   msvc:
     name: Windows Tiles x64 MSVC
     runs-on: windows-2022
+    # Keep a hung toolchain or runner from occupying Actions indefinitely.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout selected branch
@@ -122,6 +124,8 @@ jobs:
   android:
     name: Android arm64
     runs-on: ubuntu-latest
+    # Keep a hung package mirror or Gradle process from occupying Actions indefinitely.
+    timeout-minutes: 60
 
     steps:
       - name: Checkout selected branch
@@ -135,9 +139,12 @@ jobs:
           cache: 'gradle'
 
       - name: Install Android build dependencies
+        shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gettext
+          set -euo pipefail
+          # Apt can wait indefinitely when a package mirror is unavailable.
+          timeout --signal=TERM --kill-after=30s 10m sudo apt-get update
+          timeout --signal=TERM --kill-after=30s 5m sudo apt-get install -y gettext
 
       - name: Resolve Android Gradle dependencies
         working-directory: ./android


### PR DESCRIPTION
## 背景
`Windows & Android Test` 的 Android 作业在 `sudo apt-get update` / `sudo apt-get install -y gettext` 阶段发生网络或软件源卡死时，没有步骤级或作业级超时。运行编号 218 和 220 均因此长时间占用 runner；此前成功运行中该步骤通常只需数秒。

## 改动
- 为 Windows Tiles x64 MSVC 和 Android arm64 作业增加 60 分钟 `timeout-minutes`。
- 为 Android apt 更新增加 10 分钟超时，为 gettext 安装增加 5 分钟超时，并在 30 秒后强制终止残留进程。
- 保留现有 Gradle 重试与网络超时配置。

## 验证
- `git diff --check` 通过。
- 已确认完整分支差异仅涉及 `.github/workflows/msvc-test.yml`。
- 尚未用修复分支重新启动完整工作流；本次修复针对运行编号 218、220 暴露的公共基础设施卡死问题。