### PR TITLE
修复 NPC 拆解报错并完善 NPC、模组汉化及本地化编译流程

### DIFF
--- a/data/mods/穆尔卡的武器工坊/CBN移植内容/CBN贴图配置.json
+++ b/data/mods/穆尔卡的武器工坊/CBN移植内容/CBN贴图配置.json
@@ -13,7 +13,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {
@@ -125,7 +128,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {
@@ -165,7 +171,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {
@@ -273,7 +282,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {
@@ -397,7 +409,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {
@@ -663,7 +678,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {
@@ -726,7 +744,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {
@@ -794,7 +815,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {

--- a/data/mods/穆尔卡的武器工坊/G版遗留武器贴图配置.json
+++ b/data/mods/穆尔卡的武器工坊/G版遗留武器贴图配置.json
@@ -13,7 +13,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {

--- a/data/mods/穆尔卡的武器工坊/I版手枪贴图配置.json
+++ b/data/mods/穆尔卡的武器工坊/I版手枪贴图配置.json
@@ -13,7 +13,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {

--- a/data/mods/穆尔卡的武器工坊/I版移植内容/I版新增贴图配置.json
+++ b/data/mods/穆尔卡的武器工坊/I版移植内容/I版新增贴图配置.json
@@ -13,7 +13,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {

--- a/data/mods/穆尔卡的武器工坊/变异贴图配置.json
+++ b/data/mods/穆尔卡的武器工坊/变异贴图配置.json
@@ -13,7 +13,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {

--- a/data/mods/穆尔卡的武器工坊/弹药与弹匣贴图配置.json
+++ b/data/mods/穆尔卡的武器工坊/弹药与弹匣贴图配置.json
@@ -13,7 +13,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {

--- a/data/mods/穆尔卡的武器工坊/护具贴图配置.json
+++ b/data/mods/穆尔卡的武器工坊/护具贴图配置.json
@@ -13,7 +13,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {

--- a/data/mods/穆尔卡的武器工坊/武器贴图配置.json
+++ b/data/mods/穆尔卡的武器工坊/武器贴图配置.json
@@ -13,7 +13,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {

--- a/data/mods/穆尔卡的武器工坊/穆尔卡贴图兼容兜底.json
+++ b/data/mods/穆尔卡的武器工坊/穆尔卡贴图兼容兜底.json
@@ -1,0 +1,567 @@
+[
+  {
+    "type": "mod_tileset",
+    "compatibility": [
+      "MshockXottoplus",
+      "MshockXotto+",
+      "MSXotto+",
+      "MshockRealXotto",
+      "MshockXottoplus12",
+      "MSX++DEAD_PEOPLE",
+      "MXplus12_for_cosmetics",
+      "UltimateCataclysm",
+      "UltimateCataclysmDemo",
+      "Ultica",
+      "UlticaShell",
+      "Chibi_Ultica",
+      "UNDEAD_PEOPLE",
+      "UNDEAD_PEOPLE_BASE",
+      "UNDEAD_PEOPLE_LEGACY"
+    ],
+    "tiles-new": [
+      {
+        "file": "tiles_ammo.png",
+        "sprite_width": 32,
+        "sprite_height": 32,
+        "sprite_offset_x": 0,
+        "sprite_offset_y": 0,
+        "tiles": [
+          {
+            "id": "103_stock",
+            "fg": 7
+          },
+          {
+            "id": "103stock_folded",
+            "fg": 7
+          },
+          {
+            "id": "109_stock",
+            "fg": 7
+          },
+          {
+            "id": "109stock_folded",
+            "fg": 7
+          },
+          {
+            "id": "153c_sp",
+            "fg": 7
+          },
+          {
+            "id": "153c_stock",
+            "fg": 7
+          },
+          {
+            "id": "153m_scope",
+            "fg": 7
+          },
+          {
+            "id": "153m_sp",
+            "fg": 7
+          },
+          {
+            "id": "153m_stock",
+            "fg": 7
+          },
+          {
+            "id": "156m_scope",
+            "fg": 7
+          },
+          {
+            "id": "156m_sp",
+            "fg": 7
+          },
+          {
+            "id": "156m_stock",
+            "fg": 7
+          },
+          {
+            "id": "20x66_shot",
+            "fg": 3
+          },
+          {
+            "id": "20x66_slug",
+            "fg": 3
+          },
+          {
+            "id": "25mm_apds",
+            "fg": 3
+          },
+          {
+            "id": "25mm_hei",
+            "fg": 3
+          },
+          {
+            "id": "25mm_slug",
+            "fg": 3
+          },
+          {
+            "id": "38_speedloader",
+            "fg": 2
+          },
+          {
+            "id": "408_ct_ap",
+            "fg": 15
+          },
+          {
+            "id": "410shot_000",
+            "fg": 3
+          },
+          {
+            "id": "410shot_bird",
+            "fg": 3
+          },
+          {
+            "id": "454_speedloader6",
+            "fg": 2
+          },
+          {
+            "id": "45_ap",
+            "fg": 3
+          },
+          {
+            "id": "545",
+            "fg": 3
+          },
+          {
+            "id": "545_7n6",
+            "fg": 3
+          },
+          {
+            "id": "545_ap",
+            "fg": 3
+          },
+          {
+            "id": "556_m193",
+            "fg": 3
+          },
+          {
+            "id": "5C1R",
+            "fg": 11
+          },
+          {
+            "id": "5C2SB",
+            "fg": 11
+          },
+          {
+            "id": "5C3T",
+            "fg": 11
+          },
+          {
+            "id": "6C6TC",
+            "fg": 11
+          },
+          {
+            "id": "6C7DU",
+            "fg": 11
+          },
+          {
+            "id": "737_cta_10",
+            "fg": 2
+          },
+          {
+            "id": "76254_lps",
+            "fg": 3
+          },
+          {
+            "id": "762_25",
+            "fg": 3
+          },
+          {
+            "id": "762_25hot",
+            "fg": 3
+          },
+          {
+            "id": "762_25typeP",
+            "fg": 3
+          },
+          {
+            "id": "762_51_m61",
+            "fg": 3
+          },
+          {
+            "id": "762_m43",
+            "fg": 3
+          },
+          {
+            "id": "762_m87",
+            "fg": 3
+          },
+          {
+            "id": "7x50_binocular",
+            "fg": 7
+          },
+          {
+            "id": "9mm_m39b",
+            "fg": 3
+          },
+          {
+            "id": "9x18mm",
+            "fg": 3
+          },
+          {
+            "id": "9x18mmP2",
+            "fg": 3
+          },
+          {
+            "id": "9x18mmfmj",
+            "fg": 3
+          },
+          {
+            "id": "Leupold",
+            "fg": 7
+          },
+          {
+            "id": "TANGO6T",
+            "fg": 7
+          },
+          {
+            "id": "amb_sp",
+            "fg": 7
+          },
+          {
+            "id": "ar_autopart",
+            "fg": 7
+          },
+          {
+            "id": "bars",
+            "fg": 7
+          },
+          {
+            "id": "bcrf_sp",
+            "fg": 7
+          },
+          {
+            "id": "choke",
+            "fg": 7
+          },
+          {
+            "id": "cmr_scope",
+            "fg": 7
+          },
+          {
+            "id": "cr_part",
+            "fg": 7
+          },
+          {
+            "id": "dhzr_mz",
+            "fg": 7
+          },
+          {
+            "id": "dp28_47",
+            "fg": 2
+          },
+          {
+            "id": "fg422bipod",
+            "fg": 7
+          },
+          {
+            "id": "fg422mag",
+            "fg": 2
+          },
+          {
+            "id": "fsds12",
+            "fg": 3
+          },
+          {
+            "id": "ga_basic",
+            "fg": 7
+          },
+          {
+            "id": "gewscope",
+            "fg": 7
+          },
+          {
+            "id": "grv24_stock",
+            "fg": 7
+          },
+          {
+            "id": "hb_15",
+            "fg": 2
+          },
+          {
+            "id": "honey_badger_sp",
+            "fg": 7
+          },
+          {
+            "id": "jsls_mz",
+            "fg": 7
+          },
+          {
+            "id": "ksg25_aux_shotgun",
+            "fg": 7
+          },
+          {
+            "id": "ksg_aux_shotgun",
+            "fg": 7
+          },
+          {
+            "id": "m1911bigmag",
+            "fg": 2
+          },
+          {
+            "id": "m3_scope",
+            "fg": 7
+          },
+          {
+            "id": "m3c_sp",
+            "fg": 7
+          },
+          {
+            "id": "m3c_stock",
+            "fg": 7
+          },
+          {
+            "id": "match_trigger",
+            "fg": 7
+          },
+          {
+            "id": "mg42mag_250",
+            "fg": 2
+          },
+          {
+            "id": "mg42mag_50",
+            "fg": 2
+          },
+          {
+            "id": "mg42semi",
+            "fg": 7
+          },
+          {
+            "id": "mgbipod",
+            "fg": 7
+          },
+          {
+            "id": "mp5_10_30",
+            "fg": 2
+          },
+          {
+            "id": "mp5mag",
+            "fg": 2
+          },
+          {
+            "id": "pkbipod",
+            "fg": 7
+          },
+          {
+            "id": "recoil_a",
+            "fg": 7
+          },
+          {
+            "id": "recoil_b",
+            "fg": 7
+          },
+          {
+            "id": "reloaded_127108",
+            "fg": 10
+          },
+          {
+            "id": "reloaded_145114",
+            "fg": 9
+          },
+          {
+            "id": "reloaded_939",
+            "fg": 0
+          },
+          {
+            "id": "retool_ar10_308_medium",
+            "fg": 7
+          },
+          {
+            "id": "retool_hk417_308_long",
+            "fg": 7
+          },
+          {
+            "id": "retool_hk417_308_medium",
+            "fg": 7
+          },
+          {
+            "id": "retool_hk417_308_short",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_h_308_17s",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_h_308_cqb_gen3",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_h_308_cqb_mk2",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_h_308_long_gen3",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_h_308_long_mk20",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_h_308_short_gen3",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_h_308_short_mk2",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_l_223_cqc_gen3",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_l_223_cqc_mk2",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_l_223_long_16s",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_l_223_long_gen3",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_l_223_medium_gen3",
+            "fg": 7
+          },
+          {
+            "id": "retool_scar_l_223_medium_mk2",
+            "fg": 7
+          },
+          {
+            "id": "retool_sr25_308_long",
+            "fg": 7
+          },
+          {
+            "id": "retool_sr25_308_medium",
+            "fg": 7
+          },
+          {
+            "id": "retool_sr25_308_short",
+            "fg": 7
+          },
+          {
+            "id": "retool_xm7_227_medium",
+            "fg": 7
+          },
+          {
+            "id": "sgs_sp",
+            "fg": 7
+          },
+          {
+            "id": "shot_00",
+            "fg": 3
+          },
+          {
+            "id": "shot_85mag",
+            "fg": 3
+          },
+          {
+            "id": "shot_bird",
+            "fg": 3
+          },
+          {
+            "id": "shot_flechette",
+            "fg": 3
+          },
+          {
+            "id": "shot_slug",
+            "fg": 3
+          },
+          {
+            "id": "sigsuppressor",
+            "fg": 7
+          },
+          {
+            "id": "svch_20",
+            "fg": 2
+          },
+          {
+            "id": "svt_10",
+            "fg": 2
+          },
+          {
+            "id": "tac_balance",
+            "fg": 7
+          },
+          {
+            "id": "ub_makarov",
+            "fg": 7
+          },
+          {
+            "id": "vss_sp",
+            "fg": 7
+          },
+          {
+            "id": "xm157",
+            "fg": 7
+          },
+          {
+            "id": "zf42",
+            "fg": 7
+          },
+          {
+            "id": "znt2stock_folded",
+            "fg": 7
+          }
+        ]
+      },
+      {
+        "file": "tiles_legacy_g_weapons.png",
+        "sprite_width": 32,
+        "sprite_height": 32,
+        "sprite_offset_x": 0,
+        "sprite_offset_y": 0,
+        "tiles": [
+          {
+            "id": "overlay_wielded_m134",
+            "fg": 106
+          },
+          {
+            "id": "overlay_wielded_m2browning",
+            "fg": 106
+          }
+        ]
+      },
+      {
+        "file": "tiles_weapons.png",
+        "sprite_width": 32,
+        "sprite_height": 32,
+        "sprite_offset_x": 0,
+        "sprite_offset_y": 0,
+        "tiles": [
+          {
+            "id": "overlay_wielded_de_inf",
+            "fg": 50
+          },
+          {
+            "id": "glock_18c",
+            "fg": 51
+          },
+          {
+            "id": "overlay_wielded_glock_18c",
+            "fg": 50
+          },
+          {
+            "id": "overlay_wielded_ksg-25",
+            "fg": 148
+          },
+          {
+            "id": "pringles_launcher",
+            "fg": 51
+          },
+          {
+            "id": "overlay_wielded_pringles_launcher",
+            "fg": 50
+          },
+          {
+            "id": "overlay_wielded_smg_9mm",
+            "fg": 80
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/data/mods/穆尔卡的武器工坊/重武器贴图配置.json
+++ b/data/mods/穆尔卡的武器工坊/重武器贴图配置.json
@@ -13,7 +13,10 @@
       "MshockXottoplus12",
       "MSX++DEAD_PEOPLE",
       "MXplus12_for_cosmetics",
-      "MSXotto+"
+      "MSXotto+",
+      "MshockXotto+",
+      "UltimateCataclysmDemo",
+      "Ultica"
     ],
     "tiles-new": [
       {

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -23,6 +23,15 @@ if(NOT ${XGETTEXT_MSGFMT_EXECUTABLE})
     set(XGETTEXT_MSGFMT_EXECUTABLE xgettext)
 endif()
 
+find_program(GETTEXT_MSGCAT_EXECUTABLE
+    msgcat
+    HINTS
+        ${_path}
+)
+if(NOT GETTEXT_MSGCAT_EXECUTABLE)
+    set(GETTEXT_MSGCAT_EXECUTABLE msgcat)
+endif()
+
 # Generate cataclysm-dda.pot
 add_custom_target(
         translations
@@ -44,12 +53,30 @@ add_custom_command(
 
 foreach (LANG ${LANGUAGES})
     set(_PO ${CMAKE_SOURCE_DIR}/lang/po/${LANG}.po)
+    set(_PO_INPUT ${_PO})
+    set(_PO_DEPENDS ${_PO})
+
+    # Breeze keeps the generated Transifex PO untouched.  Hand-maintained fixes
+    # live in lang/po_overrides and win on duplicate msgids.
+    set(_PO_OVERRIDE ${CMAKE_SOURCE_DIR}/lang/po_overrides/${LANG}.po)
+    if(EXISTS ${_PO_OVERRIDE})
+        set(_MERGED_PO ${CMAKE_CURRENT_BINARY_DIR}/${LANG}.merged.po)
+        add_custom_command(
+                OUTPUT ${_MERGED_PO}
+                COMMAND ${GETTEXT_MSGCAT_EXECUTABLE} --use-first ${_PO_OVERRIDE} ${_PO} -o ${_MERGED_PO}
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                DEPENDS ${_PO_OVERRIDE} ${_PO}
+        )
+        set(_PO_INPUT ${_MERGED_PO})
+        list(APPEND _PO_DEPENDS ${_MERGED_PO})
+    endif()
+
     set(_MO ${CMAKE_SOURCE_DIR}/lang/mo/${LANG}/LC_MESSAGES/cataclysm-dda.mo)
     add_custom_command(
             OUTPUT ${_MO}
-            COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -f ${_PO} -o ${_MO}
+            COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -f ${_PO_INPUT} -o ${_MO}
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-            DEPENDS ${_PO} translations_prepare
+            DEPENDS ${_PO_DEPENDS} translations_prepare
     )
     list(APPEND _MO_FILES ${_MO})
     if (RELEASE)

--- a/lang/Makefile
+++ b/lang/Makefile
@@ -1,4 +1,5 @@
 PO_DIR := ./po
+PO_OVERRIDE_DIR := ./po_overrides
 MO_DIR := ./mo
 
 ifndef LANGUAGES
@@ -14,6 +15,10 @@ endif
 MO := $(patsubst %,$(MO_DIR)/%/LC_MESSAGES/cataclysm-dda.mo,$(PO))
 
 all: $(MO)
+
+$(MO_DIR)/zh_CN/LC_MESSAGES/cataclysm-dda.mo: $(PO_DIR)/zh_CN.po $(PO_OVERRIDE_DIR)/zh_CN.po
+	mkdir -p $$(dirname $@)
+	msgcat --use-first $(PO_OVERRIDE_DIR)/zh_CN.po $(PO_DIR)/zh_CN.po | msgfmt -f -o $@ -
 
 $(MO_DIR)/%/LC_MESSAGES/cataclysm-dda.mo: $(PO_DIR)/%.po
 	mkdir -p $$(dirname $@)

--- a/lang/compile_mo.sh
+++ b/lang/compile_mo.sh
@@ -20,23 +20,32 @@ then
     LOCALE_DIR="lang/mo"
 fi
 
-os="$(uname -s)"
+compile_lang()
+{
+    n="$1"
+    f="lang/po/${n}.po"
+    override="lang/po_overrides/${n}.po"
+    mkdir -p "$LOCALE_DIR/${n}/LC_MESSAGES"
+    if [ -f "$override" ]
+    then
+        msgcat --use-first "$override" "$f" | msgfmt -f -o "$LOCALE_DIR/${n}/LC_MESSAGES/cataclysm-dda.mo" -
+    else
+        msgfmt -f -o "$LOCALE_DIR/${n}/LC_MESSAGES/cataclysm-dda.mo" "$f"
+    fi
+}
 
 # compile .mo file for each specified language
 if [ $# -gt 0 ] && [ $1 != "all" ]
 then
     for n in $@
     do
-        f="lang/po/${n}.po"
-        mkdir -p $LOCALE_DIR/${n}/LC_MESSAGES
-        msgfmt -f -o $LOCALE_DIR/${n}/LC_MESSAGES/cataclysm-dda.mo ${f}
+        compile_lang "$n"
     done
 else
     # if nothing specified, compile .mo file for every .po file in lang/po
     for f in lang/po/*.po
     do
         n=`basename $f .po`
-        mkdir -p $LOCALE_DIR/${n}/LC_MESSAGES
-        msgfmt -f -o $LOCALE_DIR/${n}/LC_MESSAGES/cataclysm-dda.mo ${f}
+        compile_lang "$n"
     done
 fi

--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -464834,3 +464834,28 @@ msgstr "你将当前套装收纳进了收纳包。"
 #: src/iuse.cpp:3003
 msgid "You change outfits."
 msgstr "你换上了另一套衣物。"
+
+#. ~ Clause text of UI widget "bodypart_status_indicator_template"
+#: data/json/ui/bodypart_status.json
+msgid "bitten"
+msgstr "咬伤"
+
+#. ~ Clause text of UI widget "bodypart_status_indicator_template"
+#: data/json/ui/bodypart_status.json
+msgid "infected"
+msgstr "感染"
+
+#. ~ Clause text of UI widget "bodypart_status_indicator_template"
+#: data/json/ui/bodypart_status.json
+msgid "splinted"
+msgstr "夹板固定"
+
+#. ~ Clause text of UI widget "bodypart_status_indicator_template"
+#: data/json/ui/bodypart_status.json
+msgid "bandaged"
+msgstr "已包扎"
+
+#. ~ Clause text of UI widget "bodypart_status_indicator_template"
+#: data/json/ui/bodypart_status.json
+msgid "disinfected"
+msgstr "已消毒"

--- a/lang/po_overrides/zh_CN.po
+++ b/lang/po_overrides/zh_CN.po
@@ -243,3 +243,31 @@ msgstr "你想教授哪种武术"
 
 msgid "Which style would you like to learn?"
 msgstr "你想学习哪种武术"
+
+# 穆尔卡枪械模组槽位运行时别名，仅补 12.4 未汉化字符串
+msgid "bayonet_lug"
+msgstr "刺刀座"
+
+# 穆尔卡枪械模组槽位运行时别名，仅补 12.4 未汉化字符串
+msgid "grip_mount"
+msgstr "握把底座"
+
+# 穆尔卡枪械模组槽位运行时别名，仅补 12.4 未汉化字符串
+msgid "loading_port"
+msgstr "装弹口"
+
+# 穆尔卡枪械模组槽位运行时别名，仅补 12.4 未汉化字符串
+msgid "rail_mount"
+msgstr "导轨底座"
+
+# 穆尔卡枪械模组槽位运行时别名，仅补 12.4 未汉化字符串
+msgid "stock_accessory"
+msgstr "枪托配件"
+
+# 穆尔卡枪械模组槽位运行时别名，仅补 12.4 未汉化字符串
+msgid "stock_mount"
+msgstr "枪托底座"
+
+# 穆尔卡枪械模组槽位运行时别名，仅补 12.4 未汉化字符串
+msgid "underbarrel_mount"
+msgstr "管下底座"

--- a/lang/po_overrides/zh_CN.po
+++ b/lang/po_overrides/zh_CN.po
@@ -394,3 +394,41 @@ msgstr "未知"
 
 msgid "Unknown"
 msgstr "未知"
+
+# Exact skill names used by data/json/skills.json
+msgid "dodging"
+msgstr "闪避"
+
+msgid "piercing weapons"
+msgstr "刺击武器"
+
+msgid "applied science"
+msgstr "应用科学"
+
+msgid "weapon"
+msgstr "武器"
+
+# NPC seminar UI and selection prompts
+msgid "Which skill would you like to teach?"
+msgstr "你想教授哪项技能"
+
+msgid "Which skill would you like to learn?"
+msgstr "你想学习哪项技能"
+
+msgid "Which style would you like to teach?"
+msgstr "你想教授哪种武术"
+
+msgid "Which style would you like to learn?"
+msgstr "你想学习哪种武术"
+
+msgid "Who should participate in the training seminar?"
+msgstr "谁来参加这次训练"
+
+msgid "Finish selection"
+msgstr "完成选择"
+
+msgid "Start a training seminar"
+msgstr "开始集体训练"
+
+msgid "Start a training seminar (You've already taught enough for now)"
+msgstr "开始集体训练，当前已经教得够多了"

--- a/lang/po_overrides/zh_CN.po
+++ b/lang/po_overrides/zh_CN.po
@@ -1,0 +1,396 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: CDDA-Breeze zh_CN manual overrides\n"
+"Language: zh_CN\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+# NPC training UI
+msgid "What skill do you want to teach?"
+msgstr "你想教什么技能？"
+
+msgid "What skill do you want to learn?"
+msgstr "你想学习什么技能？"
+
+msgid "What style do you want to teach?"
+msgstr "你想教授哪种武术？"
+
+msgid "What style do you want to learn?"
+msgstr "你想学习哪种武术？"
+
+msgid "driving"
+msgstr "驾驶"
+
+msgid "speech"
+msgstr "交涉"
+
+msgid "swimming"
+msgstr "运动"
+
+msgid "electronics"
+msgstr "电子学"
+
+msgid "computer"
+msgstr "计算机"
+
+msgid "computers"
+msgstr "计算机"
+
+msgid "mechanics"
+msgstr "机械学"
+
+msgid "fabrication"
+msgstr "制造"
+
+msgid "cooking"
+msgstr "烹饪"
+
+msgid "tailoring"
+msgstr "裁缝"
+
+msgid "survival"
+msgstr "生存"
+
+msgid "first aid"
+msgstr "急救"
+
+msgid "health care"
+msgstr "医疗"
+
+msgid "devices"
+msgstr "装置"
+
+msgid "vehicles"
+msgstr "驾驶"
+
+msgid "athletics"
+msgstr "运动"
+
+msgid "social"
+msgstr "交涉"
+
+msgid "food handling"
+msgstr "食品处理"
+
+msgid "marksmanship"
+msgstr "射击"
+
+msgid "handguns"
+msgstr "手枪"
+
+msgid "rifles"
+msgstr "步枪"
+
+msgid "shotguns"
+msgstr "霰弹枪"
+
+msgid "submachine guns"
+msgstr "冲锋枪"
+
+msgid "launchers"
+msgstr "发射器"
+
+msgid "archery"
+msgstr "弓术"
+
+msgid "melee"
+msgstr "近战"
+
+msgid "bashing weapons"
+msgstr "钝击武器"
+
+msgid "cutting weapons"
+msgstr "斩击武器"
+
+msgid "stabbing weapons"
+msgstr "刺击武器"
+
+msgid "unarmed combat"
+msgstr "徒手格斗"
+
+msgid "dodge"
+msgstr "闪避"
+
+msgid "throwing"
+msgstr "投掷"
+
+# Gun modification slots and attachment UI
+msgid "accessories"
+msgstr "附件"
+
+msgid "accessory"
+msgstr "附件"
+
+msgid "barrel"
+msgstr "枪管"
+
+msgid "barrel extension"
+msgstr "枪管延长件"
+
+msgid "bore"
+msgstr "膛口"
+
+msgid "brass catcher"
+msgstr "弹壳收集器"
+
+msgid "grip"
+msgstr "握把"
+
+msgid "handguard"
+msgstr "护木"
+
+msgid "magazine"
+msgstr "弹匣"
+
+msgid "magazine well"
+msgstr "弹匣井"
+
+msgid "mechanism"
+msgstr "机匣机构"
+
+msgid "muzzle"
+msgstr "枪口"
+
+msgid "rail"
+msgstr "导轨"
+
+msgid "sights"
+msgstr "瞄具"
+
+msgid "sight"
+msgstr "瞄具"
+
+msgid "stock"
+msgstr "枪托"
+
+msgid "underbarrel"
+msgstr "下挂"
+
+msgid "underbarrel mount"
+msgstr "下挂接口"
+
+msgid "top rail"
+msgstr "顶部导轨"
+
+msgid "side rail"
+msgstr "侧面导轨"
+
+msgid "bottom rail"
+msgstr "底部导轨"
+
+msgid "optic"
+msgstr "光学瞄具"
+
+msgid "optics"
+msgstr "光学瞄具"
+
+msgid "scope"
+msgstr "瞄准镜"
+
+msgid "suppressor"
+msgstr "消音器"
+
+msgid "sling"
+msgstr "枪带"
+
+msgid "bayonet"
+msgstr "刺刀"
+
+msgid "bipod"
+msgstr "两脚架"
+
+msgid "foregrip"
+msgstr "前握把"
+
+msgid "laser sight"
+msgstr "激光瞄具"
+
+msgid "flashlight"
+msgstr "战术灯"
+
+msgid "choke"
+msgstr "喉缩"
+
+msgid "conversion"
+msgstr "改装套件"
+
+msgid "receiver"
+msgstr "机匣"
+
+msgid "charging handle"
+msgstr "拉机柄"
+
+msgid "trigger"
+msgstr "扳机"
+
+msgid "fire control group"
+msgstr "击发机构"
+
+msgid "mod location"
+msgstr "插件槽位"
+
+msgid "mod locations"
+msgstr "插件槽位"
+
+msgid "Gunmod location"
+msgstr "枪械插件槽位"
+
+msgid "Gunmod locations"
+msgstr "枪械插件槽位"
+
+msgid "Location:"
+msgstr "槽位："
+
+msgid "Install gunmod"
+msgstr "安装枪械插件"
+
+msgid "Remove gunmod"
+msgstr "拆卸枪械插件"
+
+msgid "This gun cannot accept that modification."
+msgstr "这把枪无法安装该插件。"
+
+msgid "This modification cannot be installed on this gun."
+msgstr "该插件无法安装到这把枪上。"
+
+msgid "There is no free slot for this modification."
+msgstr "没有可用于安装该插件的空余槽位。"
+
+msgid "You cannot install any more modifications of this type."
+msgstr "无法继续安装更多此类插件。"
+
+msgid "You install the %s on your %s."
+msgstr "你将%s安装到了%s上。"
+
+msgid "You remove the %s from your %s."
+msgstr "你从%s上拆下了%s。"
+
+# Common gun/item info labels
+msgid "Damage:"
+msgstr "伤害："
+
+msgid "Armor-pierce:"
+msgstr "穿甲："
+
+msgid "Range:"
+msgstr "射程："
+
+msgid "Dispersion:"
+msgstr "散布："
+
+msgid "Recoil:"
+msgstr "后坐力："
+
+msgid "Reload time:"
+msgstr "装填耗时："
+
+msgid "Aim speed:"
+msgstr "瞄准速度："
+
+msgid "Handling:"
+msgstr "操控："
+
+msgid "Capacity:"
+msgstr "容量："
+
+msgid "Ammo:"
+msgstr "弹药："
+
+msgid "Compatible magazines:"
+msgstr "兼容弹匣："
+
+msgid "Compatible ammunition:"
+msgstr "兼容弹药："
+
+msgid "Firing modes:"
+msgstr "射击模式："
+
+msgid "Default mod locations:"
+msgstr "默认插件槽位："
+
+msgid "Mod locations:"
+msgstr "插件槽位："
+
+msgid "Mods:"
+msgstr "插件："
+
+msgid "Requirements:"
+msgstr "需求："
+
+msgid "Skill required:"
+msgstr "所需技能："
+
+msgid "Skills required:"
+msgstr "所需技能："
+
+# Recent branch-visible strings
+msgid "View local files and logs"
+msgstr "查看本地文件与日志"
+
+msgid "You can view local files stored on this laptop."
+msgstr "你可以查看这台笔记本电脑中保存的本地文件。"
+
+msgid "You can view local files stored on this smartphone."
+msgstr "你可以查看这部智能手机中保存的本地文件。"
+
+msgid "The laptop's batteries need more charge."
+msgstr "笔记本电脑的电量不足。"
+
+msgid "The smartphone's charge is too low."
+msgstr "智能手机的电量过低。"
+
+msgid "You found nothing interesting in the local files."
+msgstr "你没有在本地文件里发现什么有趣的内容。"
+
+msgid "Shattered Armor"
+msgstr "护甲碎裂"
+
+msgid "Your armor has been shattered by a heavy attack."
+msgstr "你的护甲被猛烈攻击击碎了。"
+
+msgid "Your armor has been shattered."
+msgstr "你的护甲已经碎裂。"
+
+msgid "The armor is shattered!"
+msgstr "护甲碎裂了！"
+
+msgid "the shattered armor plating"
+msgstr "碎裂的装甲板"
+
+msgid "the body armor"
+msgstr "躯干护甲"
+
+# Frequently exposed UI actions
+msgid "Start training"
+msgstr "开始培训"
+
+msgid "Train"
+msgstr "培训"
+
+msgid "Training"
+msgstr "培训"
+
+msgid "Teach"
+msgstr "教授"
+
+msgid "Learn"
+msgstr "学习"
+
+msgid "Cancel"
+msgstr "取消"
+
+msgid "Back"
+msgstr "返回"
+
+msgid "Confirm"
+msgstr "确认"
+
+msgid "None"
+msgstr "无"
+
+msgid "unknown"
+msgstr "未知"
+
+msgid "Unknown"
+msgstr "未知"

--- a/lang/po_overrides/zh_CN.po
+++ b/lang/po_overrides/zh_CN.po
@@ -19,156 +19,38 @@ msgstr "你想教授哪种武术？"
 msgid "What style do you want to learn?"
 msgstr "你想学习哪种武术？"
 
-msgid "driving"
-msgstr "驾驶"
-
 msgid "speech"
 msgstr "交涉"
 
 msgid "swimming"
 msgstr "运动"
 
-msgid "electronics"
-msgstr "电子学"
-
 msgid "computer"
 msgstr "计算机"
-
-msgid "computers"
-msgstr "计算机"
-
-msgid "mechanics"
-msgstr "机械学"
-
-msgid "fabrication"
-msgstr "制造"
 
 msgid "cooking"
 msgstr "烹饪"
 
-msgid "tailoring"
-msgstr "裁缝"
-
-msgid "survival"
-msgstr "生存"
-
 msgid "first aid"
 msgstr "急救"
-
-msgid "health care"
-msgstr "医疗"
-
-msgid "devices"
-msgstr "装置"
-
-msgid "vehicles"
-msgstr "驾驶"
-
-msgid "athletics"
-msgstr "运动"
-
-msgid "social"
-msgstr "交涉"
-
-msgid "food handling"
-msgstr "食品处理"
-
-msgid "marksmanship"
-msgstr "射击"
-
-msgid "handguns"
-msgstr "手枪"
-
-msgid "rifles"
-msgstr "步枪"
-
-msgid "shotguns"
-msgstr "霰弹枪"
-
-msgid "submachine guns"
-msgstr "冲锋枪"
-
-msgid "launchers"
-msgstr "发射器"
-
-msgid "archery"
-msgstr "弓术"
-
-msgid "melee"
-msgstr "近战"
-
-msgid "bashing weapons"
-msgstr "钝击武器"
-
-msgid "cutting weapons"
-msgstr "斩击武器"
 
 msgid "stabbing weapons"
 msgstr "刺击武器"
 
-msgid "unarmed combat"
-msgstr "徒手格斗"
-
 msgid "dodge"
 msgstr "闪避"
-
-msgid "throwing"
-msgstr "投掷"
-
-# Gun modification slots and attachment UI
-msgid "accessories"
-msgstr "附件"
 
 msgid "accessory"
 msgstr "附件"
 
-msgid "barrel"
-msgstr "枪管"
-
 msgid "barrel extension"
 msgstr "枪管延长件"
-
-msgid "bore"
-msgstr "膛口"
-
-msgid "brass catcher"
-msgstr "弹壳收集器"
-
-msgid "grip"
-msgstr "握把"
 
 msgid "handguard"
 msgstr "护木"
 
-msgid "magazine"
-msgstr "弹匣"
-
 msgid "magazine well"
 msgstr "弹匣井"
-
-msgid "mechanism"
-msgstr "机匣机构"
-
-msgid "muzzle"
-msgstr "枪口"
-
-msgid "rail"
-msgstr "导轨"
-
-msgid "sights"
-msgstr "瞄具"
-
-msgid "sight"
-msgstr "瞄具"
-
-msgid "stock"
-msgstr "枪托"
-
-msgid "underbarrel"
-msgstr "下挂"
-
-msgid "underbarrel mount"
-msgstr "下挂接口"
 
 msgid "top rail"
 msgstr "顶部导轨"
@@ -188,18 +70,6 @@ msgstr "光学瞄具"
 msgid "scope"
 msgstr "瞄准镜"
 
-msgid "suppressor"
-msgstr "消音器"
-
-msgid "sling"
-msgstr "枪带"
-
-msgid "bayonet"
-msgstr "刺刀"
-
-msgid "bipod"
-msgstr "两脚架"
-
 msgid "foregrip"
 msgstr "前握把"
 
@@ -208,12 +78,6 @@ msgstr "激光瞄具"
 
 msgid "flashlight"
 msgstr "战术灯"
-
-msgid "choke"
-msgstr "喉缩"
-
-msgid "conversion"
-msgstr "改装套件"
 
 msgid "receiver"
 msgstr "机匣"
@@ -238,9 +102,6 @@ msgstr "枪械插件槽位"
 
 msgid "Gunmod locations"
 msgstr "枪械插件槽位"
-
-msgid "Location:"
-msgstr "槽位："
 
 msgid "Install gunmod"
 msgstr "安装枪械插件"
@@ -334,12 +195,6 @@ msgstr "你可以查看这台笔记本电脑中保存的本地文件。"
 msgid "You can view local files stored on this smartphone."
 msgstr "你可以查看这部智能手机中保存的本地文件。"
 
-msgid "The laptop's batteries need more charge."
-msgstr "笔记本电脑的电量不足。"
-
-msgid "The smartphone's charge is too low."
-msgstr "智能手机的电量过低。"
-
 msgid "You found nothing interesting in the local files."
 msgstr "你没有在本地文件里发现什么有趣的内容。"
 
@@ -377,40 +232,8 @@ msgstr "教授"
 msgid "Learn"
 msgstr "学习"
 
-msgid "Cancel"
-msgstr "取消"
-
-msgid "Back"
-msgstr "返回"
-
 msgid "Confirm"
 msgstr "确认"
-
-msgid "None"
-msgstr "无"
-
-msgid "unknown"
-msgstr "未知"
-
-msgid "Unknown"
-msgstr "未知"
-
-# Exact skill names used by data/json/skills.json
-msgid "dodging"
-msgstr "闪避"
-
-msgid "piercing weapons"
-msgstr "刺击武器"
-
-msgid "applied science"
-msgstr "应用科学"
-
-msgid "weapon"
-msgstr "武器"
-
-# NPC seminar UI and selection prompts
-msgid "Which skill would you like to teach?"
-msgstr "你想教授哪项技能"
 
 msgid "Which skill would you like to learn?"
 msgstr "你想学习哪项技能"
@@ -420,15 +243,3 @@ msgstr "你想教授哪种武术"
 
 msgid "Which style would you like to learn?"
 msgstr "你想学习哪种武术"
-
-msgid "Who should participate in the training seminar?"
-msgstr "谁来参加这次训练"
-
-msgid "Finish selection"
-msgstr "完成选择"
-
-msgid "Start a training seminar"
-msgstr "开始集体训练"
-
-msgid "Start a training seminar (You've already taught enough for now)"
-msgstr "开始集体训练，当前已经教得够多了"

--- a/lang/po_overrides/zh_CN.po
+++ b/lang/po_overrides/zh_CN.po
@@ -248,6 +248,10 @@ msgstr "你想学习哪种武术"
 msgid "bayonet_lug"
 msgstr "刺刀座"
 
+# 穆尔卡枪械模组使用空格形式的英文槽位名
+msgid "bayonet lug"
+msgstr "刺刀座"
+
 # 穆尔卡枪械模组槽位运行时别名，仅补 12.4 未汉化字符串
 msgid "grip_mount"
 msgstr "握把底座"

--- a/lang/string_extractor/parsers/widget.py
+++ b/lang/string_extractor/parsers/widget.py
@@ -15,3 +15,11 @@ def parse_widget(json, origin):
             comment = "Text in portion of UI widget \"{}\"".format(id)
             if "text" in phrase:
                 write_text(phrase["text"], origin, comment=comment)
+    if "default_clause" in json and "text" in json["default_clause"]:
+        write_text(json["default_clause"]["text"], origin,
+                   comment="Default clause of UI widget \"{}\"".format(id))
+    if "clauses" in json:
+        for clause in json["clauses"]:
+            if "text" in clause:
+                write_text(clause["text"], origin,
+                           comment="Clause text of UI widget \"{}\"".format(id))

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4847,12 +4847,21 @@ static bool check_if_disassemble_okay( item_location target, Character &who )
                "<npcname> stops disassembling." ) );
         return false;
     }
+    if( disassembly->typeId() == itype_disassembly &&
+        ( !disassembly->is_craft() || disassembly->components.empty() ) ) {
+        who.add_msg_if_player( _( "You cannot disassemble this." ) );
+        return false;
+    }
     return true;
 }
 
 void disassemble_activity_actor::start( player_activity &act, Character &who )
 {
     if( act.targets.empty() ) {
+        act.set_to_null();
+        return;
+    }
+    if( !check_if_disassemble_okay( act.targets.back(), who ) ) {
         act.set_to_null();
         return;
     }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2719,6 +2719,13 @@ ret_val<void> Character::can_disassemble( const item &obj, const read_only_visit
         return ret_val<void>::make_failure( _( "You cannot disassemble this." ) );
     }
 
+    // Debug-created `disassembly` items may have no original item or recipe.
+    // They are not valid resumable disassemblies and must not reach front() or
+    // get_making() below.
+    if( obj.typeId() == itype_disassembly && ( !obj.is_craft() || obj.components.empty() ) ) {
+        return ret_val<void>::make_failure( _( "You cannot disassemble this." ) );
+    }
+
     const recipe &r = recipe_dictionary::get_uncraft( ( obj.typeId() == itype_disassembly ) ?
                       obj.components.front().typeId() : obj.typeId() );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9251,6 +9251,10 @@ static void add_disassemblables( uilist &menu,
                                                     it.tname(), stack.second );
             recipe uncraft_recipe;
             if( it.typeId() == itype_disassembly ) {
+                // A debug-created bare disassembly has no recipe to display.
+                if( !it.is_craft() ) {
+                    continue;
+                }
                 uncraft_recipe = it.get_making();
             } else {
                 uncraft_recipe = recipe_dictionary::get_uncraft( it.typeId() );
@@ -9680,6 +9684,10 @@ void game::butcher()
             for( const auto &stack : disassembly_stacks ) {
                 recipe uncraft_recipe;
                 if( stack.first->typeId() == itype_disassembly ) {
+                    // Ignore malformed debug-only disassembly items without a recipe.
+                    if( !stack.first->is_craft() ) {
+                        continue;
+                    }
                     uncraft_recipe = stack.first->get_making();
                 } else {
                     uncraft_recipe = recipe_dictionary::get_uncraft( stack.first->typeId() );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6107,6 +6107,12 @@ void item::disassembly_info( std::vector<iteminfo> &info, const iteminfo_query *
         return;
     }
 
+    // A bare `disassembly` item can be spawned by debug tools without the
+    // recipe data normally attached to an in-progress disassembly.  It still
+    // has the disassembly item type, so do not call get_making() on it.
+    if( typeId() == itype_disassembly && ( !craft_data_ || !craft_data_->making ) ) {
+        return;
+    }
     const recipe &dis = ( typeId() == itype_disassembly ) ? get_making() :
                         recipe_dictionary::get_uncraft( typeId() );
     const requirement_data &req = dis.disassembly_requirements();
@@ -11524,7 +11530,9 @@ bool item::is_disassemblable() const
 
 bool item::is_craft() const
 {
-    return craft_data_ != nullptr;
+    // A craft_data object without its recipe is malformed and cannot be used
+    // as an in-progress craft or disassembly.
+    return craft_data_ != nullptr && craft_data_->making != nullptr;
 }
 
 bool item::is_funnel_container( units::volume &bigger_than ) const

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1020,7 +1020,7 @@ static skill_id skill_select_menu( const Character &c, const std::string &prompt
     nmenu.text = prompt;
     for( const std::pair<const skill_id, SkillLevel> &s : *c._skills ) {
         bool enabled = s.second.level() > 0;
-        std::string entry = string_format( "%s (%d)", s.first.str(), s.second.level() );
+        std::string entry = string_format( "%s (%d)", s.first->name(), s.second.level() );
         nmenu.addentry( i, enabled, MENU_AUTOASSIGN, entry );
         i++;
     }


### PR DESCRIPTION
## 完整改动

本 PR 汇总 `fix/npc-disassembly-debug` 相对 `main` 的完整差异：

- 修复无配方物品进入 NPC 拆解调试路径时的报错。
- 补充 NPC 界面、技能训练菜单、widget 子句和状态文本的简体中文覆盖，并恢复 12.4 NPC 翻译。
- 修复穆尔卡武器工坊汉化与贴图兼容，补充相关模组数据。
- 完善 `lang/po_overrides` 的合并与 MO 编译流程。
- 补充英文模组枪械槽位 `bayonet lug` 的中文翻译“刺刀座”，避免截图中的英文槽位名残留。

## 历史说明

前两次直接合并到 `main` 的 PR 后来均被撤销：

- [PR 1155：修复 NPC 制作与拆解进度溢出](https://github.com/BreezeDevTeam/CDDA-Breeze/pull/1155) 直接合并为 `72b5d191`，随后由 [`61356e85`](https://github.com/BreezeDevTeam/CDDA-Breeze/commit/61356e85df1bb18e523753a1e07ed3e824b46b4a) Revert。
- [PR 1156：移植五项 DDA 功能并完善多层显示](https://github.com/BreezeDevTeam/CDDA-Breeze/pull/1156) 直接合并为 `c0e8176c`，随后由 [`d92cdd6a`](https://github.com/BreezeDevTeam/CDDA-Breeze/commit/d92cdd6a8238224b2ac06663077f828449c8288d) Revert。

本 PR 基于当前 `main`，目标是提交 NPC 拆解与相关汉化修复，不直接恢复上述已撤销提交。

## 验证

- `git diff --check` 通过。
- 已核对完整分支差异和目标分支：`main`。
- 尚未执行 Windows MSVC 全量编译或实机测试。