### PR TITLE
修复 NPC 拆解菜单索引错位

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9607,6 +9607,13 @@ void game::butcher()
         }
     }
 
+    // A debug-created bare disassembly can pass can_disassemble even though it
+    // has no recipe and cannot be shown or selected in the disassembly menu.
+    disassembles.erase( std::remove_if( disassembles.begin(), disassembles.end(),
+    []( const map_stack::iterator &it ) {
+        return it->typeId() == itype_disassembly && !it->is_craft();
+    } ), disassembles.end() );
+
     // Clear corpses if butcher and dissect factors are INT_MIN
     if( factor == INT_MIN && factorD == INT_MIN ) {
         corpses.clear();


### PR DESCRIPTION
## 问题
PR 1159 合并后的只读审查发现：无配方的 debug `disassembly` 物品会在菜单生成时被 `add_disassemblables` 跳过，但仍保留在 `disassembly_stacks` 中，导致后续菜单返回值与原始堆栈索引错位。

## 修复
在生成菜单前统一从 `disassembles` 中移除没有配方的 debug `disassembly` 物品，使显示项、批量操作统计和最终选择使用同一组索引。

## 验证
- `git diff --check` 通过。
- 完整差异仅涉及 `src/game.cpp`。
- 尚未执行 Windows MSVC 全量编译或实机测试。