### PR TITLE
改进物品交易检测、自动采集分类、抓扯掉落提示及载具交互

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3592,6 +3592,23 @@
   },
   {
     "type": "keybinding",
+    "id": "TRADE_ALL_VEHICLES",
+    "category": "INVENTORY",
+    "name": "Toggle all reality bubble vehicle cargo in trade",
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "SELECT_TRADE_VEHICLE",
+    "category": "INVENTORY",
+    "name": "Toggle selected vehicle cargo sources in trade",
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
+    ]
+  },
+  {
+    "type": "keybinding",
     "id": "DECREASE_COUNT",
     "category": "INVENTORY",
     "name": "Decrease selected amount for the highlighted item",

--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -412639,6 +412639,16 @@ msgstr "用高亮物品自动平衡交易"
 
 #. ~ Key binding name
 #: data/raw/keybindings.json
+msgid "Toggle all reality bubble vehicle cargo in trade"
+msgstr "切换交易中的现实气泡全部载具货物"
+
+#. ~ Key binding name
+#: data/raw/keybindings.json
+msgid "Toggle selected vehicle cargo sources in trade"
+msgstr "切换交易中的指定载具货物来源"
+
+#. ~ Key binding name
+#: data/raw/keybindings.json
 msgid "Decrease selected amount for the highlighted item"
 msgstr "减少高亮物品选择数量"
 
@@ -450477,6 +450487,25 @@ msgstr "并且把它扔在地上！"
 msgid "but you break its grip!"
 msgstr "但你挣脱了它的束缚！"
 
+#: src/monattack.cpp:5690
+msgid "under your feet"
+msgstr "脚下"
+
+#: src/monattack.cpp:5690
+#, c-format
+msgid "at %1$s, %2$d squares away"
+msgstr "%1$s方向%2$d格处"
+
+#: src/monattack.cpp:5690
+#, c-format
+msgid "The %1$s tore away your %2$s; it landed %3$s on %4$s."
+msgstr "%1$s扯掉了你的%2$s，物品掉在%4$s的%3$s。"
+
+#: src/monattack.cpp:5697
+#, c-format
+msgid "The %1$s grabbed your %2$s, but you broke free."
+msgstr "%1$s抓住了你的%2$s，但你挣脱了它的抓扯。"
+
 #: src/monattack.cpp:5847
 #, c-format
 msgid "The %s lights up menacingly."
@@ -454513,12 +454542,12 @@ msgstr "自动采集"
 #: src/options.cpp:1449
 msgid ""
 "Action to perform when 'Auto foraging' is enabled.  Bushes: Only forage "
-"bushes.  - Trees: Only forage trees.  - Crops: Only forage crops.  - "
-"Everything: Forage bushes, trees, crops, and everything else including "
-"flowers, cattails etc."
+"bushes.  - Trees: Only forage trees.  - Crops: Only forage planted crops.  - "
+"Flowers and herbs: Only forage flowers, herbs, cattails and other wild "
+"harvestables.  - Everything: Forage every category."
 msgstr ""
-"启用\"自动采集\"时进行的操作。灌木：只搜寻并采集灌木。- 树木：只搜寻并采集树木。- 作物：只搜寻并采集作物。- "
-"所有：搜寻并采集一切可采集的物品，例如灌木和树木、作物、花朵、香蒲草等。"
+"启用\"自动采集\"时进行的操作。灌木：只搜寻并采集灌木。- 树木：只搜寻并采集树木。- 作物：只搜寻并采集种植的作物。- "
+"花卉与药草：只搜寻并采集花卉、药草、香蒲和其他野生可采集物。- 所有：搜寻并采集所有类别。"
 
 #: src/options.cpp:1450
 msgid "Bushes"
@@ -454535,6 +454564,10 @@ msgstr "所有"
 #: src/options.cpp:1450
 msgid "Trees"
 msgstr "树木"
+
+#: src/options.cpp:1450
+msgid "Flowers and herbs"
+msgstr "花卉与药草"
 
 #: src/options.cpp:1458
 msgid "Dangerous pickups"
@@ -460623,6 +460656,33 @@ msgstr "%s 切换面板"
 #, c-format
 msgid "%s to auto balance with highlighted item"
 msgstr "按 %s 用高亮物品自动平衡交易"
+
+#: src/trade_ui.cpp:391
+msgid "There are no eligible vehicles in the reality bubble."
+msgstr "现实气泡内没有可用于交易的载具。"
+
+#: src/trade_ui.cpp:398
+msgid "Select trade vehicles (Esc to finish)"
+msgstr "选择交易载具（按 Esc 完成）"
+
+#: src/trade_ui.cpp:445
+msgid "You"
+msgstr "你"
+
+#: src/trade_ui.cpp:449
+#, c-format
+msgid "You, %s"
+msgstr "你，%s"
+
+#: src/trade_ui.cpp:451
+#, c-format
+msgid "You, %d vehicles"
+msgstr "你，%d辆载具"
+
+#: src/trade_ui.cpp:533
+#, c-format
+msgid "%1$s to switch panes, %2$s all vehicles, %3$s select vehicles"
+msgstr "%1$s 切换面板，%2$s 全部载具，%3$s 选择载具"
 
 #: src/trade_ui.h:29
 msgid "TRADE OFFER"

--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -460665,10 +460665,6 @@ msgstr "现实气泡内没有可用于交易的载具。"
 msgid "Select trade vehicles (Esc to finish)"
 msgstr "选择交易载具（按 Esc 完成）"
 
-#: src/trade_ui.cpp:445
-msgid "You"
-msgstr "你"
-
 #: src/trade_ui.cpp:449
 #, c-format
 msgid "You, %s"

--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -420414,20 +420414,30 @@ msgstr "你试着挣脱，但是失败了！"
 msgid "<npcname> tries to break out of the grab, but fails!"
 msgstr "<npcname> 试着挣脱但是失败了！"
 
-#: src/character_escape.cpp:228 src/character_escape.cpp:231
+#: src/character_escape.cpp:253
 msgid "As you escape the grab something comes loose and falls to the ground!"
 msgstr "你没被抓住，但有个东西被抓掉在了地上！"
 
-#: src/character_escape.cpp:229
+#: src/character_escape.cpp:254
 msgid ""
 "<npcname> escapes the grab something comes loose and falls to the ground!"
 msgstr "<npcname> 没被抓住，但有个东西被抓掉在了地上！"
 
-#: src/character_escape.cpp:236
+#: src/character_escape.cpp:258 src/mattack_actors.cpp:673
+#, c-format
+msgid "Dropped items: %1$s, at your feet on the %2$s."
+msgstr "掉落物，%1$s，脚下的%2$s。"
+
+#: src/character_escape.cpp:261 src/mattack_actors.cpp:676
+#, c-format
+msgid "Dropped items: %1$s, on the %2$s side of the %3$s."
+msgstr "掉落物，%1$s，%2$s侧%3$s。"
+
+#: src/character_escape.cpp:270
 msgid "You break out of the grab!"
 msgstr "你挣脱了！"
 
-#: src/character_escape.cpp:237
+#: src/character_escape.cpp:271
 msgid "<npcname> breaks out of the grab!"
 msgstr "<npcname> 挣脱了！"
 
@@ -445926,7 +445936,7 @@ msgstr "%s 的强力一击击飞了 <npcname>！"
 msgid "Something"
 msgstr "某物"
 
-#: src/mattack_actors.cpp:658 src/mattack_actors.cpp:659
+#: src/mattack_actors.cpp:670
 msgid ""
 "As you hit the ground something comes loose and is knocked away from you!"
 msgstr "当你落地时，有些物品松动了，从你身上掉下来了！"

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -255,12 +255,18 @@ bool Character::try_remove_grab()
 
                     if( is_avatar() && !grab_dropped_items.empty() ) {
                         if( drop_pos == pos() ) {
+                            popup( _( "Dropped items: %1$s, at your feet on the %2$s." ),
+                                   grab_dropped_items, drop_terrain );
                             add_msg( m_bad, _( "Dropped items: %1$s, at your feet on the %2$s." ),
                                      grab_dropped_items, drop_terrain );
                         } else {
+                            popup( _( "Dropped items: %1$s, on the %2$s side of the %3$s." ),
+                                   grab_dropped_items,
+                                   direction_name( direction_from( pos(), drop_pos ) ),
+                                   drop_terrain );
                             add_msg( m_bad, _( "Dropped items: %1$s, on the %2$s side of the %3$s." ),
                                      grab_dropped_items,
-                                     direction_name_short( direction_from( pos(), drop_pos ) ),
+                                     direction_name( direction_from( pos(), drop_pos ) ),
                                      drop_terrain );
                         }
                     }

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -231,7 +231,20 @@ bool Character::try_remove_grab()
                 int sturdiness = rng( 0, pd[index]->get_pocket_data()->ripoff );
                 // the item is ripped off your character
                 if( sturdiness < chance ) {
+                    std::string grab_dropped_items;
+                    for( const item *drop : pd[index]->all_items_top() ) {
+                        if( drop == nullptr ) {
+                            continue;
+                        }
+                        if( !grab_dropped_items.empty() ) {
+                            grab_dropped_items += "，";
+                        }
+                        grab_dropped_items += drop->tname();
+                    }
                     pd[index]->spill_contents( adjacent_tile() );
+                    if( !grab_dropped_items.empty() ) {
+                        add_msg_if_player( m_bad, _( "掉落物，%s。" ), grab_dropped_items );
+                    }
                     add_msg_player_or_npc( m_bad,
                                            _( "As you escape the grab something comes loose and falls to the ground!" ),
                                            _( "<npcname> escapes the grab something comes loose and falls to the ground!" ) );

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -1,3 +1,5 @@
+#include <string>
+
 #include "character.h"
 #include "creature_tracker.h"
 #include "flag.h"
@@ -241,15 +243,26 @@ bool Character::try_remove_grab()
                         }
                         grab_dropped_items += drop->tname();
                     }
-                    pd[index]->spill_contents( adjacent_tile() );
-                    if( !grab_dropped_items.empty() ) {
-                        add_msg_if_player( m_bad, _( "掉落物，%s。" ), grab_dropped_items );
-                    }
-                    add_msg_player_or_npc( m_bad,
-                                           _( "As you escape the grab something comes loose and falls to the ground!" ),
-                                           _( "<npcname> escapes the grab something comes loose and falls to the ground!" ) );
-                    if( is_avatar() ) {
-                        popup( _( "As you escape the grab something comes loose and falls to the ground!" ) );
+
+                    const tripoint drop_pos = adjacent_tile();
+                    const std::string drop_terrain = here.name( drop_pos );
+                    pd[index]->spill_contents( drop_pos );
+
+                    add_msg_player_or_npc(
+                        m_bad,
+                        _( "As you escape the grab something comes loose and falls to the ground!" ),
+                        _( "<npcname> escapes the grab something comes loose and falls to the ground!" ) );
+
+                    if( is_avatar() && !grab_dropped_items.empty() ) {
+                        if( drop_pos == pos() ) {
+                            add_msg( m_bad, _( "Dropped items: %1$s, at your feet on the %2$s." ),
+                                     grab_dropped_items, drop_terrain );
+                        } else {
+                            add_msg( m_bad, _( "Dropped items: %1$s, on the %2$s side of the %3$s." ),
+                                     grab_dropped_items,
+                                     direction_name_short( direction_from( pos(), drop_pos ) ),
+                                     drop_terrain );
+                        }
                     }
                 }
             }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -346,6 +346,31 @@ static const efftype_id effect_just_trade("just_trade");
 
 #define dbg(x) DebugLog((x),D_GAME) << __FILE__ << ":" << __LINE__ << ": "
 
+static void auto_forage_position( map &here, Character &you, const tripoint &pos )
+{
+    const ter_t &terrain = *here.ter( pos );
+    const furn_t &furniture = *here.furn( pos );
+    if( !terrain.can_examine( pos ) && !furniture.can_examine( pos ) ) {
+        return;
+    }
+    if( !iexamine::auto_forage_matches( pos ) ) {
+        return;
+    }
+    if( terrain.has_examine( iexamine::shrub_marloss ) ||
+        terrain.has_examine( iexamine::shrub_wildveggies ) ||
+        terrain.has_examine( iexamine::harvest_ter_nectar ) ||
+        terrain.has_examine( iexamine::tree_marloss ) ||
+        terrain.has_examine( iexamine::harvest_ter ) ||
+        terrain.has_examine( iexamine::harvest_ter_nectar ) ||
+        terrain.has_examine( iexamine::harvest_plant_ex ) ) {
+        terrain.examine( you, pos );
+    } else if( furniture.has_examine( iexamine::harvest_furn ) ||
+               furniture.has_examine( iexamine::harvest_furn_nectar ) ||
+               furniture.has_examine( iexamine::harvest_plant_ex ) ) {
+        furniture.examine( you, pos );
+    }
+}
+
 static constexpr int DANGEROUS_PROXIMITY = 5;
 
 
@@ -10903,33 +10928,10 @@ point game::place_player( const tripoint &dest_loc, bool quick )
             direction::SOUTH, direction::SOUTHWEST, direction::WEST, direction::NORTHWEST
         };
 
-        const auto forage = [&]( const tripoint & pos ) {
-            const ter_t &xter_t = *m.ter( pos );
-            const furn_t &xfurn_t = *m.furn( pos );
 
-            if( !xter_t.can_examine( pos ) && !xfurn_t.can_examine( pos ) ) {
-                return;
-            }
-            if( !iexamine::auto_forage_matches( pos ) ) {
-                return;
-            }
-            if( xter_t.has_examine( iexamine::shrub_marloss ) ||
-                xter_t.has_examine( iexamine::shrub_wildveggies ) ||
-                xter_t.has_examine( iexamine::harvest_ter_nectar ) ||
-                xter_t.has_examine( iexamine::tree_marloss ) ||
-                xter_t.has_examine( iexamine::harvest_ter ) ||
-                xter_t.has_examine( iexamine::harvest_ter_nectar ) ||
-                xter_t.has_examine( iexamine::harvest_plant_ex ) ) {
-                xter_t.examine( u, pos );
-            } else if( xfurn_t.has_examine( iexamine::harvest_furn ) ||
-                       xfurn_t.has_examine( iexamine::harvest_furn_nectar ) ||
-                       xfurn_t.has_examine( iexamine::harvest_plant_ex ) ) {
-                xfurn_t.examine( u, pos );
-            }
-        };
 
         for( const direction &elem : adjacentDir ) {
-            forage( u.pos() + displace_XY( elem ) );
+            auto_forage_position( m, u, u.pos() + displace_XY( elem ) );
         }
 
         const std::string pulp_butcher = get_option<std::string>( "AUTO_PULP_BUTCHER" );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10903,37 +10903,33 @@ point game::place_player( const tripoint &dest_loc, bool quick )
             direction::SOUTH, direction::SOUTHWEST, direction::WEST, direction::NORTHWEST
         };
 
-        const std::string forage_type = get_option<std::string>( "AUTO_FORAGING" );
-        if( forage_type != "off" ) {
-            const auto forage = [&]( const tripoint & pos ) {
-                const ter_t &xter_t = *m.ter( pos );
-                const furn_t &xfurn_t = *m.furn( pos );
-                const bool forage_everything = forage_type == "all";
-                const bool forage_bushes = forage_everything || forage_type == "bushes";
-                const bool forage_trees = forage_everything || forage_type == "trees";
-                const bool forage_crops = forage_everything || forage_type == "crops";
-                if( !xter_t.can_examine( pos ) && !xfurn_t.can_examine( pos ) ) {
-                    return;
-                } else if( ( forage_bushes && xter_t.has_examine( iexamine::shrub_marloss ) ) ||
-                           ( forage_bushes && xter_t.has_examine( iexamine::shrub_wildveggies ) ) ||
-                           ( forage_bushes && xter_t.has_examine( iexamine::harvest_ter_nectar ) ) ||
-                           ( forage_trees && xter_t.has_examine( iexamine::tree_marloss ) ) ||
-                           ( forage_trees && xter_t.has_examine( iexamine::harvest_ter ) ) ||
-                           ( forage_trees && xter_t.has_examine( iexamine::harvest_ter_nectar ) ) ||
-                           ( forage_crops && xter_t.has_examine( iexamine::harvest_plant_ex ) )
-                         ) {
-                    xter_t.examine( u, pos );
-                } else if( ( forage_everything && xfurn_t.has_examine( iexamine::harvest_furn ) ) ||
-                           ( forage_everything && xfurn_t.has_examine( iexamine::harvest_furn_nectar ) ) ||
-                           ( forage_crops && xfurn_t.has_examine( iexamine::harvest_plant_ex ) )
-                         ) {
-                    xfurn_t.examine( u, pos );
-                }
-            };
+        const auto forage = [&]( const tripoint & pos ) {
+            const ter_t &xter_t = *m.ter( pos );
+            const furn_t &xfurn_t = *m.furn( pos );
 
-            for( const direction &elem : adjacentDir ) {
-                forage( u.pos() + displace_XY( elem ) );
+            if( !xter_t.can_examine( pos ) && !xfurn_t.can_examine( pos ) ) {
+                return;
             }
+            if( !iexamine::auto_forage_matches( pos ) ) {
+                return;
+            }
+            if( xter_t.has_examine( iexamine::shrub_marloss ) ||
+                xter_t.has_examine( iexamine::shrub_wildveggies ) ||
+                xter_t.has_examine( iexamine::harvest_ter_nectar ) ||
+                xter_t.has_examine( iexamine::tree_marloss ) ||
+                xter_t.has_examine( iexamine::harvest_ter ) ||
+                xter_t.has_examine( iexamine::harvest_ter_nectar ) ||
+                xter_t.has_examine( iexamine::harvest_plant_ex ) ) {
+                xter_t.examine( u, pos );
+            } else if( xfurn_t.has_examine( iexamine::harvest_furn ) ||
+                       xfurn_t.has_examine( iexamine::harvest_furn_nectar ) ||
+                       xfurn_t.has_examine( iexamine::harvest_plant_ex ) ) {
+                xfurn_t.examine( u, pos );
+            }
+        };
+
+        for( const direction &elem : adjacentDir ) {
+            forage( u.pos() + displace_XY( elem ) );
         }
 
         const std::string pulp_butcher = get_option<std::string>( "AUTO_PULP_BUTCHER" );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2334,7 +2334,7 @@ static bool query_pick( Character &who, const tripoint &target )
     return true;
 }
 
-static bool auto_forage_matches( const tripoint &examp )
+bool iexamine::auto_forage_matches( const tripoint &examp )
 {
     if( !get_option<bool>( "AUTO_FEATURES" ) ) {
         return false;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2334,10 +2334,40 @@ static bool query_pick( Character &who, const tripoint &target )
     return true;
 }
 
+static bool auto_forage_matches( const tripoint &examp )
+{
+    if( !get_option<bool>( "AUTO_FEATURES" ) ) {
+        return false;
+    }
+
+    const std::string mode = get_option<std::string>( "AUTO_FORAGING" );
+    if( mode == "off" ) {
+        return false;
+    }
+    if( mode == "all" ) {
+        return true;
+    }
+
+    map &here = get_map();
+    if( here.has_flag( ter_furn_flag::TFLAG_TREE, examp ) ) {
+        return mode == "trees";
+    }
+    if( here.has_flag( ter_furn_flag::TFLAG_SHRUB, examp ) ) {
+        return mode == "bushes";
+    }
+    if( here.has_flag( ter_furn_flag::TFLAG_PLANT, examp ) ) {
+        return mode == "crops";
+    }
+    if( here.has_flag( ter_furn_flag::TFLAG_FLOWER, examp ) ) {
+        return mode == "flowers";
+    }
+
+    return mode == "flowers";
+}
+
 void iexamine::harvest_furn_nectar( Character &you, const tripoint &examp )
 {
-    bool auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
-                       get_option<std::string>( "AUTO_FORAGING" ) == "both";
+    const bool auto_forage = auto_forage_matches( examp );
     if( !auto_forage && !query_pick( you, examp ) ) {
         return;
     }
@@ -2346,8 +2376,7 @@ void iexamine::harvest_furn_nectar( Character &you, const tripoint &examp )
 
 void iexamine::harvest_furn( Character &you, const tripoint &examp )
 {
-    bool auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
-                       get_option<std::string>( "AUTO_FORAGING" ) == "all";
+    const bool auto_forage = auto_forage_matches( examp );
     if( !auto_forage && !query_pick( you, examp ) ) {
         return;
     }
@@ -2356,10 +2385,7 @@ void iexamine::harvest_furn( Character &you, const tripoint &examp )
 
 void iexamine::harvest_ter_nectar( Character &you, const tripoint &examp )
 {
-    bool auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
-                       ( get_option<std::string>( "AUTO_FORAGING" ) == "all" ||
-                         get_option<std::string>( "AUTO_FORAGING" ) == "bushes" ||
-                         get_option<std::string>( "AUTO_FORAGING" ) == "trees" );
+    const bool auto_forage = auto_forage_matches( examp );
     if( !auto_forage && !query_pick( you, examp ) ) {
         return;
     }
@@ -2368,9 +2394,7 @@ void iexamine::harvest_ter_nectar( Character &you, const tripoint &examp )
 
 void iexamine::harvest_ter( Character &you, const tripoint &examp )
 {
-    bool auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
-                       ( get_option<std::string>( "AUTO_FORAGING" ) == "all" ||
-                         get_option<std::string>( "AUTO_FORAGING" ) == "trees" );
+    const bool auto_forage = auto_forage_matches( examp );
     if( !auto_forage && !query_pick( you, examp ) ) {
         return;
     }
@@ -3826,8 +3850,7 @@ static void pick_plant( Character &you, const tripoint &examp,
                         const itype_id &itemType, ter_id new_ter, bool seeds = false )
 {
     map &here = get_map();
-    bool auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
-                       get_option<std::string>( "AUTO_FORAGING" ) != "off";
+    const bool auto_forage = auto_forage_matches( examp );
     if( you.is_avatar() && !auto_forage &&
         !query_yn( _( "Harvest the %s?" ), here.tername( examp ) ) ) {
         iexamine::none( you, examp );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3850,7 +3850,7 @@ static void pick_plant( Character &you, const tripoint &examp,
                         const itype_id &itemType, ter_id new_ter, bool seeds = false )
 {
     map &here = get_map();
-    const bool auto_forage = auto_forage_matches( examp );
+    const bool auto_forage = iexamine::auto_forage_matches( examp );
     if( you.is_avatar() && !auto_forage &&
         !query_yn( _( "Harvest the %s?" ), here.tername( examp ) ) ) {
         iexamine::none( you, examp );

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -80,6 +80,7 @@ void pit_covered( Character &you, const tripoint &examp );
 void slot_machine( Character &you, const tripoint &examp );
 void safe( Character &you, const tripoint &examp );
 void gunsafe_el( Character &you, const tripoint &examp );
+bool auto_forage_matches( const tripoint &examp );
 void harvest_furn_nectar( Character &you, const tripoint &examp );
 void harvest_furn( Character &you, const tripoint &examp );
 void harvest_ter_nectar( Character &you, const tripoint &examp );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -359,6 +359,7 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "list_item_filter_active", list_item_filter_active );
     json.member( "list_item_downvote_active", list_item_downvote_active );
     json.member( "list_item_priority_active", list_item_priority_active );
+    json.member( "trade_all_vehicle_cargo", trade_all_vehicle_cargo );
     json.member( "construction_filter", construction_filter );
     json.member( "last_construction", last_construction );
     json.member( "construction_tab", construction_tab );
@@ -429,6 +430,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "overmap_show_city_labels", overmap_show_city_labels );
     jo.read( "overmap_show_hordes", overmap_show_hordes );
     jo.read( "overmap_show_forest_trails", overmap_show_forest_trails );
+    jo.read( "trade_all_vehicle_cargo", trade_all_vehicle_cargo );
     jo.read( "hidden_recipes", hidden_recipes );
     jo.read( "favorite_recipes", favorite_recipes );
     jo.read( "expanded_recipes", expanded_recipes );
@@ -4222,11 +4224,15 @@ trade_selector::trade_selector( trade_ui *parent, Character &u,
     _ctxt_trade.register_action( ACTION_TRADE_CANCEL );
     _ctxt_trade.register_action( ACTION_TRADE_OK );
     _ctxt_trade.register_action( ACTION_AUTOBALANCE );
+    _ctxt_trade.register_action( ACTION_TRADE_ALL_VEHICLES );
+    _ctxt_trade.register_action( ACTION_SELECT_TRADE_VEHICLE );
     _ctxt_trade.register_action( "ANY_INPUT" );
     // duplicate this action in the parent ctxt so it shows up in the keybindings menu
     // CANCEL and OK are already set in inventory_selector
     ctxt.register_action( ACTION_SWITCH_PANES );
     ctxt.register_action( ACTION_AUTOBALANCE );
+    ctxt.register_action( ACTION_TRADE_ALL_VEHICLES );
+    ctxt.register_action( ACTION_SELECT_TRADE_VEHICLE );
     resize( size, origin );
     _ui = create_or_get_ui_adaptor();
     set_invlet_type( inventory_selector::SELECTOR_INVLET_ALPHA );
@@ -4235,6 +4241,27 @@ trade_selector::trade_selector( trade_ui *parent, Character &u,
 trade_selector::select_t trade_selector::to_trade() const
 {
     return to_use;
+}
+
+void trade_selector::clear_trade_items()
+{
+    to_use.clear();
+    clear_items();
+}
+
+void trade_selector::restore_trade_selection( const select_t &selection )
+{
+    std::map<inventory_entry *, size_t> restored_counts;
+    for( const entry_t &previous : selection ) {
+        item_location loc = previous.first;
+        if( inventory_entry *entry = find_entry_by_location( loc ) ) {
+            restored_counts[entry] += static_cast<size_t>( previous.second );
+        }
+    }
+    for( const auto &restored : restored_counts ) {
+        set_chosen_count( *restored.first,
+                          std::min( restored.second, restored.first->get_available_count() ) );
+    }
 }
 
 void trade_selector::execute()
@@ -4260,6 +4287,10 @@ void trade_selector::execute()
             exit = true;
         } else if( action == ACTION_AUTOBALANCE ) {
             _parent->autobalance();
+        } else if( action == ACTION_TRADE_ALL_VEHICLES ) {
+            _parent->toggle_all_vehicle_sources();
+        } else if( action == ACTION_SELECT_TRADE_VEHICLE ) {
+            _parent->toggle_vehicle_source();
         } else {
             input_event const iev = _ctxt_trade.get_raw_input();
             inventory_input const input =

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -4251,16 +4251,17 @@ void trade_selector::clear_trade_items()
 
 void trade_selector::restore_trade_selection( const select_t &selection )
 {
-    std::map<inventory_entry *, size_t> restored_counts;
+    std::map<inventory_entry *, int> restored_counts;
     for( const entry_t &previous : selection ) {
         item_location loc = previous.first;
         if( inventory_entry *entry = find_entry_by_location( loc ) ) {
-            restored_counts[entry] += static_cast<size_t>( previous.second );
+            restored_counts[entry] += previous.second;
         }
     }
-    for( const auto &restored : restored_counts ) {
+    for( std::map<inventory_entry *, int>::const_reference restored : restored_counts ) {
+        const int available_count = static_cast<int>( restored.first->get_available_count() );
         set_chosen_count( *restored.first,
-                          std::min( restored.second, restored.first->get_available_count() ) );
+                          static_cast<size_t>( std::min( restored.second, available_count ) ) );
     }
 }
 

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -634,8 +634,6 @@ bool melee_actor::call( monster &z ) const
         g->fling_creature(target, coord_to_angle(z.pos(), target->pos()),
             throw_strength);
         
-        target->add_msg_player_or_npc( m_bad, throw_msg_u, throw_msg_npc, mon_name );
-
         // Items strapped to you may fall off as you hit the ground
         // when you break out of a grab you have a chance to lose some things from your pockets
         // that are hanging off your character
@@ -664,15 +662,28 @@ bool melee_actor::call( monster &z ) const
                         }
                         grab_dropped_items += drop->tname();
                     }
-                    pd[index]->spill_contents( z.pos() + vector );
-                    if( !grab_dropped_items.empty() ) {
-                        add_msg( m_bad, _( "掉落物，%s。" ), grab_dropped_items );
-                    }
+
+                    const tripoint drop_pos = z.pos() + vector;
+                    const std::string drop_terrain = get_map().name( drop_pos );
+                    pd[index]->spill_contents( drop_pos );
+
                     add_msg( m_bad, _( "As you hit the ground something comes loose and is knocked away from you!" ) );
-                    popup( _( "As you hit the ground something comes loose and is knocked away from you!" ) );
+                    if( !grab_dropped_items.empty() ) {
+                        if( drop_pos == target->pos() ) {
+                            add_msg( m_bad, _( "Dropped items: %1$s, at your feet on the %2$s." ),
+                                     grab_dropped_items, drop_terrain );
+                        } else {
+                            add_msg( m_bad, _( "Dropped items: %1$s, on the %2$s side of the %3$s." ),
+                                     grab_dropped_items,
+                                     direction_name_short( direction_from( target->pos(), drop_pos ) ),
+                                     drop_terrain );
+                        }
+                    }
                 }
             }
         }
+
+        target->add_msg_player_or_npc( m_bad, throw_msg_u, throw_msg_npc, mon_name );
     }
 
     return true;

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -670,12 +670,18 @@ bool melee_actor::call( monster &z ) const
                     add_msg( m_bad, _( "As you hit the ground something comes loose and is knocked away from you!" ) );
                     if( !grab_dropped_items.empty() ) {
                         if( drop_pos == target->pos() ) {
+                            popup( _( "Dropped items: %1$s, at your feet on the %2$s." ),
+                                   grab_dropped_items, drop_terrain );
                             add_msg( m_bad, _( "Dropped items: %1$s, at your feet on the %2$s." ),
                                      grab_dropped_items, drop_terrain );
                         } else {
+                            popup( _( "Dropped items: %1$s, on the %2$s side of the %3$s." ),
+                                   grab_dropped_items,
+                                   direction_name( direction_from( target->pos(), drop_pos ) ),
+                                   drop_terrain );
                             add_msg( m_bad, _( "Dropped items: %1$s, on the %2$s side of the %3$s." ),
                                      grab_dropped_items,
-                                     direction_name_short( direction_from( target->pos(), drop_pos ) ),
+                                     direction_name( direction_from( target->pos(), drop_pos ) ),
                                      drop_terrain );
                         }
                     }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -654,7 +654,20 @@ bool melee_actor::call( monster &z ) const
                     float path_distance = rng_float( 0, 1.0 );
                     tripoint vector = target->pos() - z.pos();
                     vector = tripoint( vector.x * path_distance, vector.y * path_distance, vector.z * path_distance );
+                    std::string grab_dropped_items;
+                    for( const item *drop : pd[index]->all_items_top() ) {
+                        if( drop == nullptr ) {
+                            continue;
+                        }
+                        if( !grab_dropped_items.empty() ) {
+                            grab_dropped_items += "，";
+                        }
+                        grab_dropped_items += drop->tname();
+                    }
                     pd[index]->spill_contents( z.pos() + vector );
+                    if( !grab_dropped_items.empty() ) {
+                        add_msg( m_bad, _( "掉落物，%s。" ), grab_dropped_items );
+                    }
                     add_msg( m_bad, _( "As you hit the ground something comes loose and is knocked away from you!" ) );
                     popup( _( "As you hit the ground something comes loose and is knocked away from you!" ) );
                 }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -5678,15 +5678,25 @@ bool mattack::bio_op_disarm( monster *z )
     their_roll *= foe->get_limb_score( limb_score_reaction );
 
     item_location it = foe->get_wielded_item();
-
-    target->add_msg_if_player( m_bad, _( "The zombie grabs your %s…" ), it->tname() );
+    const std::string grabbed_item_name = it->tname();
 
     if( my_roll >= their_roll && !it->has_flag( flag_NO_UNWIELD ) ) {
-        target->add_msg_if_player( m_bad, _( "and throws it to the ground!" ) );
         const tripoint tp = foe->pos() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
+        const int drop_distance = rl_dist( foe->pos(), tp );
+        const std::string drop_where = drop_distance == 0
+                                       ? _( "under your feet" )
+                                       : string_format( _( "at %1$s, %2$d squares away" ),
+                                               direction_name_short( direction_from( foe->pos(), tp ) ),
+                                               drop_distance );
+        const std::string drop_terrain = get_map().name( tp );
         get_map().add_item_or_charges( tp, foe->i_rem( &*it ) );
+        target->add_msg_if_player(
+            m_bad, _( "The %1$s tore away your %2$s; it landed %3$s on %4$s." ),
+            z->name(), grabbed_item_name, drop_where, drop_terrain );
     } else {
-        target->add_msg_if_player( m_good, _( "but you break its grip!" ) );
+        target->add_msg_if_player(
+            m_good, _( "The %1$s grabbed your %2$s, but you broke free." ),
+            z->name(), grabbed_item_name );
     }
 
     return true;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1580,8 +1580,8 @@ void options_manager::add_options_general()
     get_option( "AUTO_MOPPING" ).setPrerequisite( "AUTO_FEATURES" );
 
     add( "AUTO_FORAGING", "general", to_translation( "Auto foraging" ),
-         to_translation( "Action to perform when 'Auto foraging' is enabled.  Bushes: Only forage bushes.  - Trees: Only forage trees.  - Crops: Only forage crops.  - Everything: Forage bushes, trees, crops, and everything else including flowers, cattails etc." ),
-    { { "off", to_translation( "options", "Disabled" ) }, { "bushes", to_translation( "Bushes" ) }, { "trees", to_translation( "Trees" ) }, { "crops", to_translation( "Crops" ) }, { "all", to_translation( "Everything" ) } },
+         to_translation( "Action to perform when 'Auto foraging' is enabled.  Bushes: Only forage bushes.  - Trees: Only forage trees.  - Crops: Only forage planted crops.  - Flowers and herbs: Only forage flowers, herbs, cattails and other wild harvestables.  - Everything: Forage every category." ),
+    { { "off", to_translation( "options", "Disabled" ) }, { "bushes", to_translation( "Bushes" ) }, { "trees", to_translation( "Trees" ) }, { "crops", to_translation( "Crops" ) }, { "flowers", to_translation( "Flowers and herbs" ) }, { "all", to_translation( "Everything" ) } },
     "off"
        );
 

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -1,6 +1,7 @@
 
 #include "trade_ui.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <memory>
@@ -12,13 +13,19 @@
 #include "game_constants.h"
 #include "inventory_ui.h"
 #include "item.h"
+#include "map.h"
+#include "map_iterator.h"
+#include "messages.h"
 #include "npc.h"
 #include "npctrade.h"
 #include "npctrade_utils.h"
 #include "output.h"
 #include "point.h"
+#include "safe_reference.h"
 #include "string_formatter.h"
 #include "type_id.h"
+#include "ui.h"
+#include "uistate.h"
 #include "vehicle.h"
 
 static const faction_id faction_your_followers( "your_followers" );
@@ -37,6 +44,57 @@ point _pane_orig( int side )
 point _pane_size()
 {
     return { TERMX / 2, TERMY - _pane_orig( 0 ).y };
+}
+
+struct trade_vehicle_source_state {
+    std::vector<safe_reference<vehicle>> selected;
+};
+
+trade_vehicle_source_state persistent_trade_vehicle_sources;
+
+void prune_invalid_trade_vehicle_sources()
+{
+    persistent_trade_vehicle_sources.selected.erase(
+        std::remove_if(
+            persistent_trade_vehicle_sources.selected.begin(),
+            persistent_trade_vehicle_sources.selected.end(),
+            []( const safe_reference<vehicle> &ref ) {
+                return !ref;
+            } ),
+        persistent_trade_vehicle_sources.selected.end() );
+}
+
+bool persistent_trade_vehicle_selected( const vehicle *veh )
+{
+    return std::any_of(
+               persistent_trade_vehicle_sources.selected.begin(),
+               persistent_trade_vehicle_sources.selected.end(),
+    [veh]( const safe_reference<vehicle> &ref ) {
+        return ref.get() == veh;
+    } );
+}
+
+void set_persistent_trade_vehicle_selected( vehicle *veh, const bool selected )
+{
+    if( veh == nullptr ) {
+        return;
+    }
+
+    prune_invalid_trade_vehicle_sources();
+    auto &sources = persistent_trade_vehicle_sources.selected;
+    const auto found = std::find_if(
+                           sources.begin(), sources.end(),
+    [veh]( const safe_reference<vehicle> &ref ) {
+        return ref.get() == veh;
+    } );
+
+    if( selected ) {
+        if( found == sources.end() ) {
+            sources.emplace_back( veh->get_safe_reference() );
+        }
+    } else if( found != sources.end() ) {
+        sources.erase( found );
+    }
 }
 
 } // namespace
@@ -114,7 +172,9 @@ trade_ui::trade_ui( party_t &you, npc &trader, currency_t cost, std::string titl
 
 {
     _panes[_you]->add_character_items( you );
-    _panes[_you]->add_nearby_items( 1 );
+    _add_nearby_ground_items();
+    _refresh_active_trade_vehicles();
+    _add_active_vehicle_items();
     _panes[_trader]->add_character_items( trader );
     if( trader.is_shopkeeper() ) {
         _panes[_trader]->categorize_map_items( true );
@@ -141,15 +201,6 @@ trade_ui::trade_ui( party_t &you, npc &trader, currency_t cost, std::string titl
         }
     } else if( !trader.is_player_ally() ) {
         _panes[_trader]->add_nearby_items( 1 );
-    }
-
-    map &here = get_map();
-    for( const wrapped_vehicle &wrapped_veh : here.get_vehicles() ) {
-        if( wrapped_veh.v->owner == faction_your_followers ) {
-            for( const tripoint &veh_point : wrapped_veh.v->get_points() ) {
-                _panes[_you]->add_vehicle_items( veh_point );
-            }
-        }
     }
 
     if( trader.will_exchange_items_freely() ) {
@@ -237,6 +288,164 @@ void trade_ui::autobalance()
     }
 }
 
+std::vector<vehicle *> trade_ui::_reality_bubble_trade_vehicles() const
+{
+    std::vector<vehicle *> result;
+    for( const wrapped_vehicle &wrapped : get_map().get_vehicles() ) {
+        vehicle *veh = wrapped.v;
+        if( veh == nullptr || veh->get_owner() != faction_your_followers || veh->is_appliance() ) {
+            continue;
+        }
+        result.push_back( veh );
+    }
+    return result;
+}
+
+void trade_ui::_refresh_active_trade_vehicles()
+{
+    prune_invalid_trade_vehicle_sources();
+    const std::vector<vehicle *> available = _reality_bubble_trade_vehicles();
+
+    _active_trade_vehicles.clear();
+    _active_trade_vehicles.reserve( available.size() );
+
+    if( uistate.trade_all_vehicle_cargo ) {
+        _active_trade_vehicles = available;
+        return;
+    }
+
+    for( vehicle *veh : available ) {
+        if( persistent_trade_vehicle_selected( veh ) ) {
+            _active_trade_vehicles.push_back( veh );
+        }
+    }
+}
+
+void trade_ui::_add_nearby_ground_items()
+{
+    map &here = get_map();
+    const tripoint origin = _parties[_you]->pos();
+    for( const tripoint &pos : closest_points_first( origin, 1 ) ) {
+        if( origin != pos && !here.clear_path( origin, pos, rl_dist( origin, pos ), 1, 100 ) ) {
+            continue;
+        }
+        _panes[_you]->add_map_items( pos );
+    }
+}
+
+void trade_ui::_add_active_vehicle_items()
+{
+    for( vehicle *veh : _active_trade_vehicles ) {
+        if( veh == nullptr ) {
+            continue;
+        }
+        for( const tripoint &veh_point : veh->get_points() ) {
+            _panes[_you]->add_vehicle_items( veh_point );
+        }
+    }
+}
+
+void trade_ui::_rebuild_you_pane()
+{
+    const select_t previous = _panes[_you]->to_trade();
+
+    _refresh_active_trade_vehicles();
+    _panes[_you]->clear_trade_items();
+    _panes[_you]->add_character_items( *_parties[_you] );
+    _add_nearby_ground_items();
+    _add_active_vehicle_items();
+    _panes[_you]->restore_trade_selection( previous );
+
+    _trade_values[_you] = 0;
+    for( const entry_t &it : _panes[_you]->to_trade() ) {
+        _trade_values[_you] +=
+            npc_trading::trading_price( *_parties[_trader], *_parties[_you], it );
+    }
+
+    npc const &np = *_parties[_trader]->as_npc();
+    _balance = np.will_exchange_items_freely()
+               ? 0
+               : _cost + _trade_values[_you] - _trade_values[_trader];
+
+    _panes[_you]->get_ui()->invalidate_ui();
+    _header_ui.invalidate_ui();
+}
+
+void trade_ui::toggle_all_vehicle_sources()
+{
+    uistate.trade_all_vehicle_cargo =
+        !uistate.trade_all_vehicle_cargo;
+    _rebuild_you_pane();
+}
+
+void trade_ui::toggle_vehicle_source()
+{
+    const std::vector<vehicle *> vehicles = _reality_bubble_trade_vehicles();
+    if( vehicles.empty() ) {
+        add_msg( m_info, _( "There are no eligible vehicles in the reality bubble." ) );
+        return;
+    }
+
+    bool changed = false;
+    while( true ) {
+        uilist menu;
+        menu.text = _( "Select trade vehicles (Esc to finish)" );
+
+        for( size_t i = 0; i < vehicles.size(); ++i ) {
+            vehicle *veh = vehicles[i];
+            const bool active = uistate.trade_all_vehicle_cargo ||
+                                persistent_trade_vehicle_selected( veh );
+            menu.addentry(
+                static_cast<int>( i ), true, MENU_AUTOASSIGN,
+                string_format( "%s %s", active ? "[x]" : "[ ]", veh->name ) );
+        }
+
+        menu.query();
+        if( menu.ret < 0 ) {
+            break;
+        }
+
+        const size_t selected_index = static_cast<size_t>( menu.ret );
+        if( selected_index >= vehicles.size() ) {
+            continue;
+        }
+
+        // Editing C while c-all mode is active means "customize the current all set".
+        // Materialize the current reality-bubble vehicles as manual selections first,
+        // then toggle the chosen vehicle off.  The list stays open so several
+        // noisy cargo vehicles can be excluded in one visit.
+        if( uistate.trade_all_vehicle_cargo ) {
+            persistent_trade_vehicle_sources.selected.clear();
+            for( vehicle *veh : vehicles ) {
+                set_persistent_trade_vehicle_selected( veh, true );
+            }
+            uistate.trade_all_vehicle_cargo = false;
+        }
+
+        vehicle *selected_vehicle = vehicles[selected_index];
+        set_persistent_trade_vehicle_selected(
+            selected_vehicle,
+            !persistent_trade_vehicle_selected( selected_vehicle ) );
+        changed = true;
+    }
+
+    if( changed ) {
+        _rebuild_you_pane();
+    }
+}
+
+std::string trade_ui::_you_source_name() const
+{
+    if( _active_trade_vehicles.empty() ) {
+        return _( "You" );
+    }
+    if( _active_trade_vehicles.size() == 1 && _active_trade_vehicles.front() != nullptr ) {
+        return string_format( _( "You, %s" ), _active_trade_vehicles.front()->name );
+    }
+    return string_format( _( "You, %d vehicles" ),
+                          static_cast<int>( _active_trade_vehicles.size() ) );
+}
+
 void trade_ui::resize()
 {
     _panes[_you]->resize( _pane_size(), _pane_orig( 1 ) );
@@ -313,11 +522,15 @@ void trade_ui::_draw_header()
     }
     center_print( _header_w, 2, trade_color, cost_str );
     mvwprintz( _header_w, { 1, 3 }, c_white, _parties[_trader]->get_name() );
-    right_print( _header_w, 3, 1, c_white, _( "You" ) );
+    right_print( _header_w, 3, 1, c_white, _you_source_name() );
     center_print( _header_w, header_size - 1, c_white,
-                  string_format( _( "%s to switch panes" ),
+                  string_format( _( "%1$s to switch panes, %2$s all vehicles, %3$s select vehicles" ),
                                  colorize( _panes[_you]->get_ctxt()->get_desc(
-                                         trade_selector::ACTION_SWITCH_PANES ),
+                                         trade_selector::ACTION_SWITCH_PANES ), c_yellow ),
+                                 colorize( _panes[_you]->get_ctxt()->get_desc(
+                                         trade_selector::ACTION_TRADE_ALL_VEHICLES ), c_yellow ),
+                                 colorize( _panes[_you]->get_ctxt()->get_desc(
+                                         trade_selector::ACTION_SELECT_TRADE_VEHICLE ),
                                            c_yellow ) ) );
     center_print( _header_w, header_size - 2, c_white,
                   string_format( _( "%s to auto balance with highlighted item" ),

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -81,8 +81,8 @@ void set_persistent_trade_vehicle_selected( vehicle *veh, const bool selected )
     }
 
     prune_invalid_trade_vehicle_sources();
-    auto &sources = persistent_trade_vehicle_sources.selected;
-    const auto found = std::find_if(
+    std::vector<safe_reference<vehicle>> &sources = persistent_trade_vehicle_sources.selected;
+    std::vector<safe_reference<vehicle>>::iterator const found = std::find_if(
                            sources.begin(), sources.end(),
     [veh]( const safe_reference<vehicle> &ref ) {
         return ref.get() == veh;
@@ -323,12 +323,8 @@ void trade_ui::_refresh_active_trade_vehicles()
 
 void trade_ui::_add_nearby_ground_items()
 {
-    map &here = get_map();
     const tripoint origin = _parties[_you]->pos();
     for( const tripoint &pos : closest_points_first( origin, 1 ) ) {
-        if( origin != pos && !here.clear_path( origin, pos, rl_dist( origin, pos ), 1, 100 ) ) {
-            continue;
-        }
         _panes[_you]->add_map_items( pos );
     }
 }
@@ -391,7 +387,7 @@ void trade_ui::toggle_vehicle_source()
         uilist menu;
         menu.text = _( "Select trade vehicles (Esc to finish)" );
 
-        for( size_t i = 0; i < vehicles.size(); ++i ) {
+        for( int i = 0; i < static_cast<int>( vehicles.size() ); ++i ) {
             vehicle *veh = vehicles[i];
             const bool active = uistate.trade_all_vehicle_cargo ||
                                 persistent_trade_vehicle_selected( veh );
@@ -405,8 +401,8 @@ void trade_ui::toggle_vehicle_source()
             break;
         }
 
-        const size_t selected_index = static_cast<size_t>( menu.ret );
-        if( selected_index >= vehicles.size() ) {
+        const int selected_index = menu.ret;
+        if( selected_index >= static_cast<int>( vehicles.size() ) ) {
             continue;
         }
 

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -383,6 +383,7 @@ void trade_ui::toggle_vehicle_source()
     }
 
     bool changed = false;
+    int last_selected = 0;
     while( true ) {
         uilist menu;
         menu.text = _( "Select trade vehicles (Esc to finish)" );
@@ -396,7 +397,9 @@ void trade_ui::toggle_vehicle_source()
                 string_format( "%s %s", active ? "[x]" : "[ ]", veh->name ) );
         }
 
+        menu.selected = last_selected;
         menu.query();
+        last_selected = menu.selected;
         if( menu.ret < 0 ) {
             break;
         }

--- a/src/trade_ui.h
+++ b/src/trade_ui.h
@@ -19,6 +19,7 @@
 
 class npc;
 class trade_ui;
+class vehicle;
 struct point;
 
 class trade_selector : public inventory_drop_selector
@@ -34,11 +35,15 @@ class trade_selector : public inventory_drop_selector
         void execute();
         void on_toggle() override;
         select_t to_trade() const;
+        void clear_trade_items();
+        void restore_trade_selection( const select_t &selection );
         void resize( point const &size, point const &origin );
         shared_ptr_fast<ui_adaptor> get_ui() const;
         input_context const *get_ctxt() const;
 
         static constexpr char const *ACTION_AUTOBALANCE = "AUTO_BALANCE";
+        static constexpr char const *ACTION_TRADE_ALL_VEHICLES = "TRADE_ALL_VEHICLES";
+        static constexpr char const *ACTION_SELECT_TRADE_VEHICLE = "SELECT_TRADE_VEHICLE";
         static constexpr char const *ACTION_SWITCH_PANES = "SWITCH_LISTS";
         static constexpr char const *ACTION_TRADE_OK = "CONFIRM";
         static constexpr char const *ACTION_TRADE_CANCEL = "QUIT";
@@ -88,6 +93,8 @@ class trade_ui
         trade_result_t perform_trade();
         void recalc_values_cpane();
         void autobalance();
+        void toggle_all_vehicle_sources();
+        void toggle_vehicle_source();
         void resize();
 
         constexpr static int header_size = 5;
@@ -112,11 +119,18 @@ class trade_ui
         currency_t _cost = 0;
         currency_t _balance = 0;
         std::string const _title;
+        std::vector<vehicle *> _active_trade_vehicles;
         catacurses::window _header_w;
         ui_adaptor _header_ui;
 
         void _process( event const &ev );
         bool _confirm_trade() const;
+        std::vector<vehicle *> _reality_bubble_trade_vehicles() const;
+        void _refresh_active_trade_vehicles();
+        void _add_nearby_ground_items();
+        void _add_active_vehicle_items();
+        void _rebuild_you_pane();
+        std::string _you_source_name() const;
         void _draw_header();
 };
 

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -162,6 +162,10 @@ class uistatedata
         bool list_item_priority_active = false;
         bool list_item_init = false; // NOLINT(cata-serialize)
 
+        // Trade UI.  Lowercase c keeps the legacy "all reality-bubble vehicles"
+        // behavior enabled until the player toggles it off again.
+        bool trade_all_vehicle_cargo = false;
+
         // construction menu selections
         std::string construction_filter;
         construction_group_str_id last_construction = construction_group_str_id::NULL_ID();

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1803,7 +1803,11 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         .skip_theft_check()
         .skip_locked_check()
         .hotkey( "EXAMINE_VEHICLE" )
-        .on_submit( [this] { g->exam_vehicle( *this ); } );
+        .on_submit( [this, vp] {
+            const vpart_position non_fake( *this, get_non_fake_part( vp.part_index() ) );
+            const point start_pos = non_fake.mount().rotate( 2 );
+            g->exam_vehicle( *this, start_pos );
+        } );
 
         menu.add( tracking_on ? _( "Forget vehicle position" ) : _( "Remember vehicle position" ) )
         .skip_theft_check()


### PR DESCRIPTION
## 完整改动

本 PR 汇总 `feat/qol-vehicle-trade-v4` 相对 `main` 的完整差异，包含以下几类改动：

- **物品交易检测**：将玩家侧地面物品限制在附近范围；新增“全部载具”和“选择载具”交易来源切换，排除冰箱等家电载具，并保存选择状态；修复切换交易来源后已选物品丢失的问题。
- **自动采集分类**：拆分自动采集匹配逻辑，新增“花卉与药草”分类，避免仅选择灌木时误触发药草、花卉等采集提示。
- **抓扯掉落提示**：补充被抓扯、击飞或怪物卸除装备时的掉落物名称、方向/距离及地形提示，并保留弹窗和日志提示。
- **载具交互**：从载具部件按 E 打开载具界面时，将界面光标定位到对应部件。
- **配套内容**：补充交易与掉落提示的按键绑定、中文翻译和保存数据兼容处理。

## 关联 issues

- #1153 改进物品交易的载具检测
- #1152 自动采集灌木时不再采集药草花卉
- #1151 被怪物抓掉落的物品显示名称和掉落位置
- #1149 载具界面光标初始位置对应 E 交互部件位置

合并后将依据实际覆盖范围逐项关闭以上 issues。

## 验证

- `git diff --check` 通过。
- `Windows & Android Test` 的**运行编号 224**：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/32219412503
- 运行 head SHA：`7a1a98ed25d4d97bee1ddea61a5c9a75cb9c07cb`
- Android arm64 与 Windows Tiles x64 MSVC 均为 success。