### PR TITLE
移植三项功能：护甲破坏、上层生物阴影与彩色灯光

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -306,6 +306,16 @@
   },
   {
     "type": "effect_type",
+    "id": "shattered",
+    "name": [ "Shattered Armor" ],
+    "//": "Intended for monsters; creates a new weak point.",
+    "desc": [ "Your armor has been shattered by a heavy attack." ],
+    "apply_message": "Your armor has been shattered.",
+    "rating": "bad",
+    "show_in_info": true
+  },
+  {
+    "type": "effect_type",
     "id": "staggered",
     "name": [ "Staggered" ],
     "//": "Mainly for monsters",

--- a/data/json/monster_weakpoints/humanoid_weakpoints.json
+++ b/data/json/monster_weakpoints/humanoid_weakpoints.json
@@ -281,6 +281,79 @@
         "coverage": 1
       },
       {
+        "id": "armour_plate_bullet",
+        "name": "the body armor",
+        "armor_mult": { "cut": 1.5, "stab": 1.5, "bash": 1.5 },
+        "coverage_mult": { "ranged": 0.8, "melee": 0 },
+        "forbidden_effects": [ "shattered" ],
+        "//": "Most bullet hits may shatter the plate, but not every hit does enough damage to matter later.",
+        "effects": [
+          {
+            "effect": "shattered",
+            "chance": 25,
+            "message": "The armor is shattered!",
+            "damage_required": [ 1, 10 ],
+            "permanent": true
+          },
+          {
+            "effect": "shattered",
+            "chance": 50,
+            "message": "The armor is shattered!",
+            "damage_required": [ 11, 30 ],
+            "permanent": true
+          },
+          {
+            "effect": "shattered",
+            "chance": 75,
+            "message": "The armor is shattered!",
+            "damage_required": [ 31, 200 ],
+            "permanent": true
+          }
+        ],
+        "coverage": 50
+      },
+      {
+        "id": "armour_plate_melee",
+        "name": "the body armor",
+        "armor_mult": { "cut": 1.3, "stab": 1.15, "bash": 1.15 },
+        "coverage_mult": { "ranged": 0, "melee": 0.8 },
+        "forbidden_effects": [ "shattered" ],
+        "//": "Most melee hits may shatter the plate, but not every hit does enough damage to matter later.",
+        "effects": [
+          {
+            "effect": "shattered",
+            "chance": 15,
+            "message": "The armor is shattered!",
+            "damage_required": [ 5, 20 ],
+            "permanent": true
+          },
+          {
+            "effect": "shattered",
+            "chance": 40,
+            "message": "The armor is shattered!",
+            "damage_required": [ 21, 40 ],
+            "permanent": true
+          },
+          {
+            "effect": "shattered",
+            "chance": 60,
+            "message": "The armor is shattered!",
+            "damage_required": [ 41, 200 ],
+            "permanent": true
+          }
+        ],
+        "coverage": 50
+      },
+      {
+        "id": "armour_shattered",
+        "name": "the shattered armor plating",
+        "armor_mult": { "all": 0.25 },
+        "difficulty": { "broad": 3, "point": 2 },
+        "coverage_mult": { "ranged": 0.8 },
+        "coverage": 40,
+        "required_effects": [ "shattered" ]
+      },
+      {
         "id": "side_armour",
         "name": "the weak armor on the side",
         "armor_mult": { "bullet": 0.3, "cut": 0.3, "stab": 0.15, "bash": 0.15 },

--- a/data/json/vehicleparts/lights.json
+++ b/data/json/vehicleparts/lights.json
@@ -211,6 +211,7 @@
     "item": "light_emergency_blue",
     "color": "blue",
     "broken_color": "blue",
+    "light_color": [ 30, 60, 255 ],
     "extend": { "flags": [ "EVENTURN" ] }
   },
   {
@@ -221,6 +222,7 @@
     "item": "light_emergency_red",
     "color": "red",
     "broken_color": "red",
+    "light_color": [ 255, 30, 30 ],
     "extend": { "flags": [ "ODDTURN" ] }
   }
 ]

--- a/doc/TILESET.md
+++ b/doc/TILESET.md
@@ -63,6 +63,10 @@ Sprites can be referenced across tilesheet directories, but they must be stored 
 
 `id` can be an array of multiple game entity IDs sharing the same sprite configuration, like `"id": ["vp_door", "vp_hddoor"]`.  `id` game values that are used as-is include terrain, furniture, items (except corpses), monsters, fields, traps.
 
+#### Shadow sprite
+
+The optional `shadow` tile is drawn on the lowest visible tile when a visible creature is standing on an upper z-level.
+
 #### Hardcoded IDs
 
 The special ID `unknown` provides a sprite that is displayed when an entity has no other sprite. Other hardcoded IDs also exist, and most of them are referenced in [`src/cata_tiles.cpp`](/src/cata_tiles.cpp). A full list of hardcoded IDs _may_ be present in [`tools/json_tools/generate_overlay_ids.py`](/tools/json_tools/generate_overlay_ids.py) stored as `CPP_IDS` but it's updated manually and may lag behind.

--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -464901,6 +464901,36 @@ msgstr "你将当前套装收纳进了收纳包。"
 msgid "You change outfits."
 msgstr "你换上了另一套衣物。"
 
+#. ~ Effect name
+#: data/json/effects.json
+msgid "Shattered Armor"
+msgstr "护甲碎裂"
+
+#. ~ Effect description
+#: data/json/effects.json
+msgid "Your armor has been shattered by a heavy attack."
+msgstr "你的护甲被重击击碎了。"
+
+#. ~ Effect apply message
+#: data/json/effects.json
+msgid "Your armor has been shattered."
+msgstr "你的护甲碎裂了。"
+
+#. ~ Weakpoint name
+#: data/json/monster_weakpoints/humanoid_weakpoints.json
+msgid "the body armor"
+msgstr "躯干护甲"
+
+#. ~ Weakpoint name
+#: data/json/monster_weakpoints/humanoid_weakpoints.json
+msgid "the shattered armor plating"
+msgstr "碎裂的装甲板"
+
+#. ~ Weakpoint effect message
+#: data/json/monster_weakpoints/humanoid_weakpoints.json
+msgid "The armor is shattered!"
+msgstr "护甲碎裂了。"
+
 #. ~ Clause text of UI widget "bodypart_status_indicator_template"
 #: data/json/ui/bodypart_status.json
 msgid "bitten"

--- a/lang/po_overrides/zh_CN.po
+++ b/lang/po_overrides/zh_CN.po
@@ -186,29 +186,17 @@ msgid "Skills required:"
 msgstr "所需技能："
 
 # Recent branch-visible strings
-msgid "View local files and logs"
-msgstr "查看本地文件与日志"
-
-msgid "You can view local files stored on this laptop."
-msgstr "你可以查看这台笔记本电脑中保存的本地文件。"
-
-msgid "You can view local files stored on this smartphone."
-msgstr "你可以查看这部智能手机中保存的本地文件。"
-
-msgid "You found nothing interesting in the local files."
-msgstr "你没有在本地文件里发现什么有趣的内容。"
-
 msgid "Shattered Armor"
 msgstr "护甲碎裂"
 
 msgid "Your armor has been shattered by a heavy attack."
-msgstr "你的护甲被猛烈攻击击碎了。"
+msgstr "你的护甲被重击击碎了。"
 
 msgid "Your armor has been shattered."
-msgstr "你的护甲已经碎裂。"
+msgstr "你的护甲碎裂了。"
 
 msgid "The armor is shattered!"
-msgstr "护甲碎裂了！"
+msgstr "护甲碎裂了。"
 
 msgid "the shattered armor plating"
 msgstr "碎裂的装甲板"

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1695,16 +1695,27 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         }
         }
 
+        const bool do_draw_shadow = find_tile_looks_like( "shadow", TILE_CATEGORY::NONE,
+                                       empty_string ).has_value();
         //const int height_3d_mult = is_isometric() ? 10 : 0;
         if (max_draw_depth <= 0) {
             // Legacy draw mode
             for (int row = min_row; row < max_row; row++) {
                 for (auto f : drawing_layers_legacy) {
                     for (tile_render_info& p : draw_points[row]) {
-                        (this->*f)(p.pos, p.ll, p.height_3d, p.invisible);
+                        if( f == &cata_tiles::draw_critter_at ) {
+                            const bool drew_critter = ( this->*f )( p.pos, p.ll, p.height_3d,
+                                                  p.invisible );
+                            if( !drew_critter && do_draw_shadow && !p.invisible[0] &&
+                                here.dont_draw_lower_floor( p.pos ) ) {
+                                draw_critter_above( p.pos, p.ll, p.height_3d, p.invisible );
+                            }
+                        } else {
+                            ( this->*f )( p.pos, p.ll, p.height_3d, p.invisible );
+                        }
                     }
+                }
             }
-        }
         }
         else {
             // Multi z-level draw mode
@@ -1729,8 +1740,16 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                             }
                             tripoint draw_loc = p.pos;
                             draw_loc.z = cur_zlevel;
-                            // Draw
-                            (this->*f)(draw_loc, p.ll, p.height_3d, p.invisible);
+                            if( f == &cata_tiles::draw_critter_at ) {
+                                const bool drew_critter = ( this->*f )( draw_loc, p.ll, p.height_3d,
+                                                      p.invisible );
+                                if( !drew_critter && do_draw_shadow && !p.invisible[0] &&
+                                    here.dont_draw_lower_floor( draw_loc ) ) {
+                                    draw_critter_above( draw_loc, p.ll, p.height_3d, p.invisible );
+                                }
+                            } else {
+                                ( this->*f )( draw_loc, p.ll, p.height_3d, p.invisible );
+                            }
                         }
 
                     }
@@ -3946,6 +3965,62 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
                    lit_level::MEMORIZED, nv_goggles_activated, height_3d_temp );
     }
     return false;
+}
+
+bool cata_tiles::draw_critter_above( const tripoint &p, lit_level ll, int &height_3d,
+                                      const std::array<bool, 5> &invisible )
+{
+    if( invisible[0] ) {
+        return false;
+    }
+
+    map &here = get_map();
+    const avatar &you = get_avatar();
+    tripoint scan_p = p + tripoint_above;
+    const Creature *pcritter = nullptr;
+    while( here.inbounds( scan_p ) && !here.dont_draw_lower_floor( scan_p ) &&
+           scan_p.z - you.posz() <= fov_3d_z_range ) {
+        pcritter = get_creature_tracker().creature_at( scan_p, true );
+        if( pcritter != nullptr ) {
+            break;
+        }
+        ++scan_p.z;
+    }
+
+    if( pcritter == nullptr || !you.sees( *pcritter ) ) {
+        return false;
+    }
+
+    if( !draw_from_id_string( "shadow", TILE_CATEGORY::NONE, empty_string, p,
+                              0, 0, ll, false, height_3d ) ) {
+        return false;
+    }
+
+    bool is_player = false;
+    bool sees_player = false;
+    Creature::Attitude attitude = Creature::Attitude::ANY;
+    if( const monster *m = dynamic_cast<const monster *>( pcritter ) ) {
+        sees_player = m->sees( you );
+        attitude = m->attitude_to( you );
+    } else if( const Character *ch = dynamic_cast<const Character *>( pcritter ) ) {
+        if( ch->is_avatar() ) {
+            is_player = true;
+        } else {
+            sees_player = ch->sees( you );
+            attitude = ch->attitude_to( you );
+        }
+    }
+
+    if( !is_player ) {
+        const std::string draw_id = "overlay_" + Creature::attitude_raw_string( attitude ) +
+                                    ( sees_player && !you.has_trait( trait_INATTENTIVE ) ?
+                                      "_sees_player" : "" );
+        if( find_tile_looks_like( draw_id, TILE_CATEGORY::NONE, empty_string ) ) {
+            draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
+                                 lit_level::LIT, false, height_3d );
+        }
+    }
+    return true;
 }
 
 bool cata_tiles::draw_critter_at_below( const tripoint &p, const lit_level, int &,

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -38,6 +38,7 @@
 #include "itype.h"
 #include "json.h"
 #include "json_loader.h"
+#include "lightmap.h"
 #include "map.h"
 #include "map_extras.h"
 #include "map_memory.h"
@@ -1697,6 +1698,60 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
         const bool do_draw_shadow = find_tile_looks_like( "shadow", TILE_CATEGORY::NONE,
                                        empty_string ).has_value();
+        const auto draw_light_overlays = [&]( const int zlevel ) {
+            const level_cache &light_cache = here.access_cache( zlevel );
+            SDL_BlendMode previous_blend_mode;
+            GetRenderDrawBlendMode( renderer, previous_blend_mode );
+            bool drew_light_tint = false;
+            for( int overlay_row = min_row; overlay_row < max_row; ++overlay_row ) {
+                for( const tile_render_info &p : draw_points[overlay_row] ) {
+                    if( p.invisible[0] || zlevel < p.draw_min_z ||
+                        p.ll == lit_level::DARK || p.ll == lit_level::BLANK ||
+                        p.ll == lit_level::MEMORIZED ) {
+                        continue;
+                    }
+                    const tripoint draw_loc( p.pos.xy(), zlevel );
+                    if( !here.inbounds( draw_loc ) ) {
+                        continue;
+                    }
+                    const light_color_rgb &lc = light_cache.light_color_cache[draw_loc.x][draw_loc.y];
+                    const float min_channel = std::min( { lc.r, lc.g, lc.b } );
+                    const float sat_r = lc.r - min_channel;
+                    const float sat_g = lc.g - min_channel;
+                    const float sat_b = lc.b - min_channel;
+                    const float sat_mag = std::max( { sat_r, sat_g, sat_b } );
+                    if( sat_mag < 0.01f ) {
+                        continue;
+                    }
+                    const float scalar = light_cache.lm[draw_loc.x][draw_loc.y].max();
+                    const float ratio = scalar > 0.1f ? std::min( 1.0f, sat_mag / scalar ) : 0.0f;
+                    const float color_strength = std::clamp(
+                                                     sat_mag / LIGHT_SOURCE_BRIGHT, 0.0f, 1.0f );
+                    const Uint8 alpha = static_cast<Uint8>( std::clamp(
+                                                 ratio * color_strength * 80.0f, 0.0f, 80.0f ) );
+                    if( alpha == 0 ) {
+                        continue;
+                    }
+                    const SDL_Color tint = {
+                        static_cast<Uint8>( std::clamp( sat_r / sat_mag * 255.0f, 0.0f, 255.0f ) ),
+                        static_cast<Uint8>( std::clamp( sat_g / sat_mag * 255.0f, 0.0f, 255.0f ) ),
+                        static_cast<Uint8>( std::clamp( sat_b / sat_mag * 255.0f, 0.0f, 255.0f ) ),
+                        alpha
+                    };
+                    const point screen = player_to_screen( draw_loc.xy() );
+                    const SDL_Rect draw_rect = { screen.x, screen.y - p.height_3d,
+                                                 tile_width, tile_height };
+                    if( !drew_light_tint ) {
+                        SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND );
+                        drew_light_tint = true;
+                    }
+                    geometry->rect( renderer, draw_rect, tint );
+                }
+            }
+            if( drew_light_tint ) {
+                SetRenderDrawBlendMode( renderer, previous_blend_mode );
+            }
+        };
         //const int height_3d_mult = is_isometric() ? 10 : 0;
         if (max_draw_depth <= 0) {
             // Legacy draw mode
@@ -1716,6 +1771,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     }
                 }
             }
+            draw_light_overlays( center.z );
         }
         else {
             // Multi z-level draw mode
@@ -1754,6 +1810,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
                     }
                 }
+                draw_light_overlays( cur_zlevel );
                 cur_zlevel += 1;
             } while (cur_zlevel <= center.z);
             z_overlay_depth = 0;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -555,6 +555,8 @@ class cata_tiles
                                        const std::array<bool, 5> &invisible );
         bool draw_critter_at( const tripoint &p, lit_level ll, int &height_3d,
                               const std::array<bool, 5> &invisible );
+        bool draw_critter_above( const tripoint &p, lit_level ll, int &height_3d,
+                                 const std::array<bool, 5> &invisible );
         bool draw_critter_at_below( const tripoint &p, lit_level ll, int &height_3d,
                                     const std::array<bool, 5> &invisible );
         bool draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d,

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -218,6 +218,23 @@ void field_type::load( const JsonObject &jo, const std::string & )
                   fallback_intensity_level.monster_spawn_group );
         optional( jao, was_loaded, "light_emitted", intensity_level.light_emitted,
                   fallback_intensity_level.light_emitted );
+        if( jao.has_array( "light_color" ) ) {
+            const JsonArray color = jao.get_array( "light_color" );
+            if( color.size() != 3 ) {
+                color.throw_error( "light_color must contain exactly 3 values" );
+            }
+            const int r = color.get_int( 0 );
+            const int g = color.get_int( 1 );
+            const int b = color.get_int( 2 );
+            if( r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255 ) {
+                color.throw_error( "light_color values must be between 0 and 255" );
+            }
+            intensity_level.light_color.r = r / 255.0f;
+            intensity_level.light_color.g = g / 255.0f;
+            intensity_level.light_color.b = b / 255.0f;
+        } else {
+            intensity_level.light_color = fallback_intensity_level.light_color;
+        }
         optional( jao, was_loaded, "light_override", intensity_level.local_light_override,
                   fallback_intensity_level.local_light_override );
         optional( jao, was_loaded, "translucency", intensity_level.translucency,

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -20,6 +20,7 @@
 #include "effect.h"
 #include "effect_source.h"
 #include "enums.h"
+#include "lightmap.h"
 #include "mapdata.h"
 #include "map_field.h"
 #include "translations.h"
@@ -108,6 +109,7 @@ struct field_intensity_level {
     int monster_spawn_radius = 0;
     mongroup_id monster_spawn_group;
     float light_emitted = 0.0f;
+    light_color_rgb light_color;
     float local_light_override = -1.0f;
     float translucency = 0.0f;
     int convection_temperature_mod = 0;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3869,6 +3869,12 @@ void game::draw_critter( const Creature &critter, const tripoint &center )
     }
     if( critter.posz() != center.z ) {
         static constexpr tripoint up_tripoint( tripoint_above );
+        static constexpr tripoint down_tripoint( tripoint_below );
+        if( critter.posz() == center.z + 1 &&
+            ( debug_mode || u.sees( critter ) ) &&
+            m.valid_move( critter.pos(), critter.pos() + down_tripoint, false, true ) ) {
+            mvwputch( w_terrain, point( mx, my ), c_green_cyan, '^' );
+        }
         if( critter.posz() == center.z - 1 &&
             ( debug_mode || u.sees( critter ) ) &&
             m.valid_move( critter.pos(), critter.pos() + up_tripoint, false, true ) ) {

--- a/src/level_cache.cpp
+++ b/src/level_cache.cpp
@@ -11,7 +11,8 @@ level_cache::level_cache()
     constexpr four_quadrants four_zeros( 0.0f );
     std::fill_n( &lm[0][0], map_dimensions, four_zeros );
     std::fill_n( &sm[0][0], map_dimensions, 0.0f );
-    std::fill_n( &light_source_buffer[0][0], map_dimensions, 0.0f );
+    std::fill_n( &light_color_cache[0][0], map_dimensions, light_color_rgb{} );
+    std::fill_n( &light_source_buffer[0][0], map_dimensions, buffered_light_source{} );
     std::fill_n( &outside_cache[0][0], map_dimensions, false );
     std::fill_n( &floor_cache[0][0], map_dimensions, false );
     std::fill_n( &transparency_cache[0][0], map_dimensions, 0.0f );

--- a/src/level_cache.h
+++ b/src/level_cache.h
@@ -32,9 +32,15 @@ struct level_cache {
 
         cata::mdarray<four_quadrants, point_bub_ms> lm;
         cata::mdarray<float, point_bub_ms> sm;
+        // Accumulated colored-light energy for each tile. Empty means white light only.
+        cata::mdarray<light_color_rgb, point_bub_ms> light_color_cache;
         // To prevent redundant ray casting into neighbors: precalculate bulk light source positions.
-        // This is only valid for the duration of generate_lightmap
-        cata::mdarray<float, point_bub_ms> light_source_buffer;
+        // This is only valid for the duration of generate_lightmap.
+        struct buffered_light_source {
+            float luminance = 0.0f;
+            light_color_rgb color;
+        };
+        cata::mdarray<buffered_light_source, point_bub_ms> light_source_buffer;
 
         // Cache of natural light level is useful if it needs to be in sync with the light cache.
         float natural_light_level_cache;

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -388,6 +388,7 @@ void map::generate_lightmap( const int zlev )
     bool top_floor = zlev == OVERMAP_DEPTH;
     lm.fill( four_quadrants{} );
     sm.fill( 0 );
+    map_cache.light_color_cache.fill( light_color_rgb{} );
 
     /* Bulk light sources wastefully cast rays into neighbors; a burning hospital can produce
          significant slowdown, so for stuff like fire and lava:
@@ -399,7 +400,7 @@ void map::generate_lightmap( const int zlev )
      * Step 4: Profit!
      */
     auto &light_source_buffer = map_cache.light_source_buffer;
-    light_source_buffer.fill( 0 );
+    light_source_buffer.fill( level_cache::buffered_light_source{} );
 
     constexpr std::array<int, 4> dir_x = { {  0, -1, 1, 0 } };    //    [0]
     constexpr std::array<int, 4> dir_y = { { -1,  0, 0, 1 } };    // [1][X][2]
@@ -464,20 +465,19 @@ void map::generate_lightmap( const int zlev )
 
                     const ter_id terrain = cur_submap->get_ter( { sx, sy } );
                     if( terrain->light_emitted > 0 ) {
-                        add_light_source( p, terrain->light_emitted );
+                        add_light_source( p, terrain->light_emitted, terrain->light_color );
                     }
                     const furn_id furniture = cur_submap->get_furn( {sx, sy } );
                     if( furniture->light_emitted > 0 ) {
-                        add_light_source( p, furniture->light_emitted );
+                        add_light_source( p, furniture->light_emitted, furniture->light_color );
                     }
 
                     for( const auto &fld : cur_submap->get_field( { sx, sy } ) ) {
-                        const field_entry *cur = &fld.second;
-                        const int light_emitted = cur->get_intensity_level().light_emitted;
-                        if( light_emitted > 0 ) {
-                            add_light_source( p, light_emitted );
+                        const field_intensity_level &fil = fld.second.get_intensity_level();
+                        if( fil.light_emitted > 0 ) {
+                            add_light_source( p, fil.light_emitted, fil.light_color );
                         }
-                        const float light_override = cur->get_intensity_level().local_light_override;
+                        const float light_override = fil.local_light_override;
                         if( light_override >= 0.0f ) {
                             lm_override.emplace_back( p, light_override );
                         }
@@ -534,21 +534,22 @@ void map::generate_lightmap( const int zlev )
 
             if( vp.has_flag( VPFLAG_CONE_LIGHT ) ) {
                 if( veh_luminance > lit_level::LIT ) {
-                    add_light_source( src, M_SQRT2 ); // Add a little surrounding light
+                    add_light_source( src, M_SQRT2, vp.light_color ); // Add a little surrounding light
                     apply_light_arc( src, v->face.dir() + pt->direction, veh_luminance,
-                                     45_degrees );
+                                     45_degrees, vp.light_color );
                 }
 
             } else if( vp.has_flag( VPFLAG_WIDE_CONE_LIGHT ) ) {
                 if( veh_luminance > lit_level::LIT ) {
-                    add_light_source( src, M_SQRT2 ); // Add a little surrounding light
+                    add_light_source( src, M_SQRT2, vp.light_color ); // Add a little surrounding light
                     apply_light_arc( src, v->face.dir() + pt->direction, veh_luminance,
-                                     90_degrees );
+                                     90_degrees, vp.light_color );
                 }
 
             } else if( vp.has_flag( VPFLAG_HALF_CIRCLE_LIGHT ) ) {
-                add_light_source( src, M_SQRT2 ); // Add a little surrounding light
-                apply_light_arc( src, v->face.dir() + pt->direction, vp.bonus, 180_degrees );
+                add_light_source( src, M_SQRT2, vp.light_color ); // Add a little surrounding light
+                apply_light_arc( src, v->face.dir() + pt->direction, vp.bonus, 180_degrees,
+                                 vp.light_color );
 
             } else if( vp.has_flag( VPFLAG_CIRCLE_LIGHT ) ) {
                 const bool odd_turn = calendar::once_every( 2_turns );
@@ -556,11 +557,11 @@ void map::generate_lightmap( const int zlev )
                     ( !odd_turn && vp.has_flag( VPFLAG_EVENTURN ) ) ||
                     ( !( vp.has_flag( VPFLAG_EVENTURN ) || vp.has_flag( VPFLAG_ODDTURN ) ) ) ) {
 
-                    add_light_source( src, vp.bonus );
+                    add_light_source( src, vp.bonus, vp.light_color );
                 }
 
             } else {
-                add_light_source( src, vp.bonus );
+                add_light_source( src, vp.bonus, vp.light_color );
             }
         }
 
@@ -585,8 +586,9 @@ void map::generate_lightmap( const int zlev )
     const tripoint cache_start( 0, 0, zlev );
     const tripoint cache_end( LIGHTMAP_CACHE_X, LIGHTMAP_CACHE_Y, zlev );
     for( const tripoint &p : points_in_rectangle( cache_start, cache_end ) ) {
-        if( light_source_buffer[p.x][p.y] > 0.0 ) {
-            apply_light_source( p, light_source_buffer[p.x][p.y] );
+        const level_cache::buffered_light_source &source = light_source_buffer[p.x][p.y];
+        if( source.luminance > 0.0f ) {
+            apply_light_source( p, source.luminance );
         }
     }
     for( const std::pair<tripoint, float> &elem : lm_override ) {
@@ -594,10 +596,45 @@ void map::generate_lightmap( const int zlev )
     }
 }
 
-void map::add_light_source( const tripoint &p, float luminance )
+void map::add_light_source( const tripoint &p, const float luminance,
+                            const light_color_rgb &color )
 {
     auto &light_source_buffer = get_cache( p.z ).light_source_buffer;
-    light_source_buffer[p.x][p.y] = std::max( luminance, light_source_buffer[p.x][p.y] );
+    auto &buffer = light_source_buffer[p.x][p.y];
+    buffer.luminance = std::max( luminance, buffer.luminance );
+    if( color.is_colored() ) {
+        buffer.color += color * luminance;
+    }
+}
+
+light_color_rgb light_color_rgb::from_hsv( float h, float s, float v )
+{
+    const float c = v * s;
+    const float x = c * ( 1.0f - std::abs( std::fmod( h / 60.0f, 2.0f ) - 1.0f ) );
+    const float m = v - c;
+    float r = 0.0f;
+    float g = 0.0f;
+    float b = 0.0f;
+    if( h < 60.0f ) {
+        r = c;
+        g = x;
+    } else if( h < 120.0f ) {
+        r = x;
+        g = c;
+    } else if( h < 180.0f ) {
+        g = c;
+        b = x;
+    } else if( h < 240.0f ) {
+        g = x;
+        b = c;
+    } else if( h < 300.0f ) {
+        r = x;
+        b = c;
+    } else {
+        r = c;
+        b = x;
+    }
+    return { r + m, g + m, b + m };
 }
 
 // Tile light/transparency: 3D
@@ -1125,6 +1162,16 @@ static bool light_check( const float &transparency, const float &intensity )
     return transparency > LIGHT_TRANSPARENCY_SOLID && intensity > LIGHT_AMBIENT_LOW;
 }
 
+static thread_local light_color_rgb current_light_source_color;
+
+static void update_light_color( light_color_rgb &tile_color, const float &intensity, quadrant )
+{
+    const light_color_rgb contribution = current_light_source_color * intensity;
+    tile_color.r = std::max( tile_color.r, contribution.r );
+    tile_color.g = std::max( tile_color.g, contribution.g );
+    tile_color.b = std::max( tile_color.b, contribution.b );
+}
+
 void map::apply_light_source( const tripoint &p, float luminance )
 {
     level_cache &cache = get_cache( p.z );
@@ -1132,8 +1179,8 @@ void map::apply_light_source( const tripoint &p, float luminance )
     cata::mdarray<float, point_bub_ms> &sm = cache.sm;
     cata::mdarray<float, point_bub_ms> &transparency_cache =
         cache.transparency_cache;
-    cata::mdarray<float, point_bub_ms> &light_source_buffer =
-        cache.light_source_buffer;
+    auto &light_source_buffer = cache.light_source_buffer;
+    auto &light_color_cache = cache.light_color_cache;
 
     const point p2( p.xy() );
 
@@ -1146,6 +1193,13 @@ void map::apply_light_source( const tripoint &p, float luminance )
         return;
     } else if( luminance <= lit_level::BRIGHT_ONLY ) {
         luminance = 1.49f;
+    }
+
+    const auto &source = light_source_buffer[p2.x][p2.y];
+    const bool has_color = source.color.is_colored() && source.luminance > 0.0f;
+    if( has_color ) {
+        current_light_source_color = source.color * ( 1.0f / source.luminance );
+        light_color_cache[p2.x][p2.y] += current_light_source_color * luminance;
     }
 
     /* If we're a 5 luminance fire , we skip casting rays into ey && sx if we have
@@ -1165,10 +1219,10 @@ void map::apply_light_source( const tripoint &p, float luminance )
            sy
     */
     const int peer_inbounds = LIGHTMAP_CACHE_X - 1;
-    bool north = p2.y != 0 && light_source_buffer[p2.x][p2.y - 1] < luminance;
-    bool south = p2.y != peer_inbounds && light_source_buffer[p2.x][p2.y + 1] < luminance;
-    bool east = p2.x != peer_inbounds && light_source_buffer[p2.x + 1][p2.y] < luminance;
-    bool west = p2.x != 0 && light_source_buffer[p2.x - 1][p2.y] < luminance;
+    bool north = p2.y != 0 && light_source_buffer[p2.x][p2.y - 1].luminance < luminance;
+    bool south = p2.y != peer_inbounds && light_source_buffer[p2.x][p2.y + 1].luminance < luminance;
+    bool east = p2.x != peer_inbounds && light_source_buffer[p2.x + 1][p2.y].luminance < luminance;
+    bool west = p2.x != 0 && light_source_buffer[p2.x - 1][p2.y].luminance < luminance;
 
     if( north ) {
         castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
@@ -1177,6 +1231,14 @@ void map::apply_light_source( const tripoint &p, float luminance )
         castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
                       lm, transparency_cache, p2, 0, luminance );
+        if( has_color ) {
+            castLight < 1, 0, 0, -1, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency > (
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+            castLight < -1, 0, 0, -1, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency > (
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+        }
     }
 
     if( east ) {
@@ -1186,6 +1248,14 @@ void map::apply_light_source( const tripoint &p, float luminance )
         castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
                       lm, transparency_cache, p2, 0, luminance );
+        if( has_color ) {
+            castLight < 0, -1, 1, 0, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency > (
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+            castLight < 0, -1, -1, 0, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency > (
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+        }
     }
 
     if( south ) {
@@ -1195,6 +1265,14 @@ void map::apply_light_source( const tripoint &p, float luminance )
         castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
                       lm, transparency_cache, p2, 0, luminance );
+        if( has_color ) {
+            castLight<1, 0, 0, 1, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency>(
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+            castLight < -1, 0, 0, 1, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency > (
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+        }
     }
 
     if( west ) {
@@ -1204,6 +1282,14 @@ void map::apply_light_source( const tripoint &p, float luminance )
         castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
                       lm, transparency_cache, p2, 0, luminance );
+        if( has_color ) {
+            castLight<0, 1, 1, 0, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency>(
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+            castLight < 0, 1, -1, 0, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency > (
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+        }
     }
 }
 
@@ -1248,7 +1334,7 @@ void map::apply_directional_light( const tripoint &p, int direction, float lumin
 }
 
 void map::apply_light_arc( const tripoint &p, const units::angle &angle, float luminance,
-                           const units::angle &wideangle )
+                           const units::angle &wideangle, const light_color_rgb &color )
 {
     if( luminance <= LIGHT_SOURCE_LOCAL ) {
         return;
@@ -1262,6 +1348,12 @@ void map::apply_light_arc( const tripoint &p, const units::angle &angle, float l
     cata::mdarray<four_quadrants, point_bub_ms> &lm = cache.lm;
     cata::mdarray<float, point_bub_ms> &transparency_cache =
         cache.transparency_cache;
+    auto &light_color_cache = cache.light_color_cache;
+    const bool has_color = color.is_colored();
+    if( has_color ) {
+        current_light_source_color = color;
+        light_color_cache[p2.x][p2.y] += color * LIGHT_SOURCE_LOCAL;
+    }
 
     const units::angle wangle = wideangle / 2.0;
     // Normalize so oangle is between 0 and 360 degrees
@@ -1288,49 +1380,46 @@ void map::apply_light_arc( const tripoint &p, const units::angle &angle, float l
         start_angle = std::max(45_degrees * start, oangle);
         end_angle = std::min(45_degrees * end, cangle);
 
-        // i is positive
-        switch (i % 8) {
-        case 0:
-            castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
-                update_light_quadrants, accumulate_transparency >(
-                    lm, transparency_cache, p2, 0, luminance, 1, tan(end_angle), tan(start_angle));
-            break;
-        case 1:
-            castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
-                update_light_quadrants, accumulate_transparency >(
-                    lm, transparency_cache, p2, 0, luminance, 1, cot(start_angle), cot(end_angle));
-            break;
-        case 2:
-            castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
-                update_light_quadrants, accumulate_transparency >(
-                    lm, transparency_cache, p2, 0, luminance, 1, -cot(end_angle), -cot(start_angle));
-            break;
-        case 3:
-            castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
-                update_light_quadrants, accumulate_transparency >(
-                    lm, transparency_cache, p2, 0, luminance, 1, -tan(start_angle), -tan(end_angle));
-            break;
-        case 4:
-            castLight < 0, 1, 1, 0, float, four_quadrants, light_calc, light_check,
-                update_light_quadrants, accumulate_transparency >(
-                    lm, transparency_cache, p2, 0, luminance, 1, tan(end_angle), tan(start_angle));
-            break;
-        case 5:
-            castLight < 1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
-                update_light_quadrants, accumulate_transparency >(
-                    lm, transparency_cache, p2, 0, luminance, 1, cot(start_angle), cot(end_angle));
-            break;
-        case 6:
-            castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
-                update_light_quadrants, accumulate_transparency >(
-                    lm, transparency_cache, p2, 0, luminance, 1, -cot(end_angle), -cot(start_angle));
-            break;
-        case 7:
-            castLight < 0, -1, 1, 0, float, four_quadrants, light_calc, light_check,
-                update_light_quadrants, accumulate_transparency >(
-                    lm, transparency_cache, p2, 0, luminance, 1, -tan(start_angle), -tan(end_angle));
-            break;
+        // i is positive. Keep scalar and color casts on the same octant and
+        // transparency path so colored light cannot leak through walls.
+#define CAST_ARC_OCTANT( DX, DY, SX, SY, START, END ) \
+        do { \
+            castLight < DX, DY, SX, SY, float, four_quadrants, light_calc, light_check, \
+                      update_light_quadrants, accumulate_transparency >( \
+                          lm, transparency_cache, p2, 0, luminance, 1, START, END ); \
+            if( has_color ) { \
+                castLight < DX, DY, SX, SY, float, light_color_rgb, light_calc, light_check, \
+                          update_light_color, accumulate_transparency >( \
+                              light_color_cache, transparency_cache, p2, 0, luminance, 1, START, END ); \
+            } \
+        } while( false )
+        switch( i % 8 ) {
+            case 0:
+                CAST_ARC_OCTANT( 0, -1, -1, 0, tan( end_angle ), tan( start_angle ) );
+                break;
+            case 1:
+                CAST_ARC_OCTANT( -1, 0, 0, -1, cot( start_angle ), cot( end_angle ) );
+                break;
+            case 2:
+                CAST_ARC_OCTANT( 1, 0, 0, -1, -cot( end_angle ), -cot( start_angle ) );
+                break;
+            case 3:
+                CAST_ARC_OCTANT( 0, 1, -1, 0, -tan( start_angle ), -tan( end_angle ) );
+                break;
+            case 4:
+                CAST_ARC_OCTANT( 0, 1, 1, 0, tan( end_angle ), tan( start_angle ) );
+                break;
+            case 5:
+                CAST_ARC_OCTANT( 1, 0, 0, 1, cot( start_angle ), cot( end_angle ) );
+                break;
+            case 6:
+                CAST_ARC_OCTANT( -1, 0, 0, 1, -cot( end_angle ), -cot( start_angle ) );
+                break;
+            case 7:
+                CAST_ARC_OCTANT( 0, -1, 1, 0, -tan( start_angle ), -tan( end_angle ) );
+                break;
         }
+#undef CAST_ARC_OCTANT
         ++i;
     }
 }

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -38,6 +38,29 @@ static constexpr float LIGHT_TRANSPARENCY_OPEN_AIR = 0.038376418216f;
 // indicates starting (full) visibility (for seen_cache)
 static constexpr float VISIBILITY_FULL = 1.0f;
 
+struct light_color_rgb {
+    float r = 0.0f;
+    float g = 0.0f;
+    float b = 0.0f;
+
+    bool is_colored() const {
+        return r > 0.0f || g > 0.0f || b > 0.0f;
+    }
+
+    light_color_rgb &operator+=( const light_color_rgb &rhs ) {
+        r += rhs.r;
+        g += rhs.g;
+        b += rhs.b;
+        return *this;
+    }
+
+    light_color_rgb operator*( const float scale ) const {
+        return { r * scale, g * scale, b * scale };
+    }
+
+    static light_color_rgb from_hsv( float h, float s, float v );
+};
+
 constexpr inline int LIGHT_RANGE( float b )
 {
     if( b <= LIGHT_AMBIENT_LOW ) {

--- a/src/map.h
+++ b/src/map.h
@@ -2124,11 +2124,13 @@ class map
         void apply_light_source( const tripoint &p, float luminance );
         // ...this, which will apply the light after at the end of generate_lightmap, and prevent redundant
         // light rays from causing massive slowdowns, if there's a huge amount of light.
-        void add_light_source( const tripoint &p, float luminance );
+        void add_light_source( const tripoint &p, float luminance,
+                               const light_color_rgb &color = {} );
         // Handle just cardinal directions and 45 deg angles.
         void apply_directional_light( const tripoint &p, int direction, float luminance );
         void apply_light_arc( const tripoint &p, const units::angle &angle, float luminance,
-                              const units::angle &wideangle = 30_degrees );
+                              const units::angle &wideangle = 30_degrees,
+                              const light_color_rgb &color = {} );
         void apply_light_ray( cata::mdarray<bool, point_bub_ms, MAPSIZE_X, MAPSIZE_Y> &lit,
                               const tripoint &s, const tripoint &e, float luminance );
         void add_light_from_items( const tripoint &p, const item_stack::iterator &begin,

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1425,6 +1425,22 @@ void map_data_common_t::load( const JsonObject &jo, const std::string & )
     mandatory( jo, was_loaded, "description", description );
     optional( jo, was_loaded, "curtain_transform", curtain_transform );
 
+    if( jo.has_array( "light_color" ) ) {
+        const JsonArray color = jo.get_array( "light_color" );
+        if( color.size() != 3 ) {
+            color.throw_error( "light_color must contain exactly 3 values" );
+        }
+        const int r = color.get_int( 0 );
+        const int g = color.get_int( 1 );
+        const int b = color.get_int( 2 );
+        if( r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255 ) {
+            color.throw_error( "light_color values must be between 0 and 255" );
+        }
+        light_color.r = r / 255.0f;
+        light_color.g = g / 255.0f;
+        light_color.b = b / 255.0f;
+    }
+
     if( jo.has_object( "shoot" ) ) {
         shoot = cata::make_value<map_shoot_info>();
         shoot->load( jo, "shoot", was_loaded );

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -15,6 +15,7 @@
 #include "color.h"
 #include "enum_bitset.h"
 #include "iexamine.h"
+#include "lightmap.h"
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
@@ -465,6 +466,7 @@ struct map_data_common_t {
 
     public:
         ter_str_id curtain_transform;
+        light_color_rgb light_color;
 
         bool has_curtains() const {
             return !( curtain_transform.is_empty() || curtain_transform.is_null() );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -563,6 +563,21 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
     if( jo.has_member( "broken_color" ) ) {
         def.color_broken = color_from_string( jo.get_string( "broken_color" ) );
     }
+    if( jo.has_array( "light_color" ) ) {
+        const JsonArray color = jo.get_array( "light_color" );
+        if( color.size() != 3 ) {
+            color.throw_error( "light_color must contain exactly 3 values" );
+        }
+        const int r = color.get_int( 0 );
+        const int g = color.get_int( 1 );
+        const int b = color.get_int( 2 );
+        if( r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255 ) {
+            color.throw_error( "light_color values must be between 0 and 255" );
+        }
+        def.light_color.r = r / 255.0f;
+        def.light_color.g = g / 255.0f;
+        def.light_color.b = b / 255.0f;
+    }
 
     if( jo.has_member( "breaks_into" ) ) {
         def.breaks_into_group = item_group::load_item_group(

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -18,6 +18,7 @@
 #include "color.h"
 #include "compatibility.h"
 #include "damage.h"
+#include "lightmap.h"
 #include <optional>
 #include "point.h"
 #include "requirements.h"
@@ -455,6 +456,7 @@ class vpart_info
         /** Color of part for different states */
         nc_color color = c_light_gray;
         nc_color color_broken = c_light_gray;
+        light_color_rgb light_color;
 
         /* Contains data for terrain transformer parts */
         transform_terrain_data transform_terrain;

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -421,6 +421,9 @@ void weakpoint::load( const JsonObject &jo )
     if( jo.has_array( "required_effects" ) ) {
         assign( jo, "required_effects", required_effects );
     }
+    if( jo.has_array( "forbidden_effects" ) ) {
+        assign( jo, "forbidden_effects", forbidden_effects );
+    }
     if( jo.has_array( "effects" ) ) {
         for( const JsonObject effect_jo : jo.get_array( "effects" ) ) {
             weakpoint_effect effect;
@@ -478,6 +481,12 @@ float weakpoint::hit_chance( const weakpoint_attack &attack ) const
             return 0.0f;
         }
     }
+    // Check for effects that disable this weakpoint.
+    for( const auto &effect : forbidden_effects ) {
+        if( attack.target->has_effect( effect ) ) {
+            return 0.0f;
+        }
+    }
     // Retrieve multipliers.
     float constant_mult = coverage_mult.of( attack );
     // Probability of a sample from a normal distribution centered on `skill` with `SD = 2`
@@ -516,7 +525,15 @@ const weakpoint *weakpoints::select_weakpoint( const weakpoint_attack &attack ) 
     float reweighed = 0.0f;
     float idx = rng_float( 0.0f, 100.0f );
     for( const weakpoint &weakpoint : weakpoint_list ) {
-        float new_base = base + weakpoint.hit_chance( attack );
+        const float base_hit_chance = weakpoint.hit_chance( attack );
+        if( base_hit_chance <= 0.0f ) {
+            add_msg_debug( debugmode::DF_MONSTER,
+                           "Weakpoint Selection: weakpoint %s, conditions not matched",
+                           weakpoint.id );
+            continue;
+        }
+
+        float new_base = base + base_hit_chance;
         float new_reweighed = 100.0f * reweigh( new_base / 100.0f, rolls );
         float hit_chance = new_reweighed - reweighed;
         add_msg_debug( debugmode::DF_MONSTER,

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -133,6 +133,8 @@ struct weakpoint {
     std::array<float, static_cast<int>( damage_type::NUM )>crit_mult;
     // A list of required effects.
     std::vector<efftype_id> required_effects;
+    // A list of effects that prevent this weak point from being selected.
+    std::vector<efftype_id> forbidden_effects;
     // A list of effects that may trigger by hitting this weak point.
     std::vector<weakpoint_effect> effects;
     // Constant coverage multipliers, depending on the attack type.

--- a/tools/json_tools/generate_overlay_ids.py
+++ b/tools/json_tools/generate_overlay_ids.py
@@ -30,7 +30,7 @@ CPP_IDS = (
     'explosion', 'explosion_weak', 'explosion_medium',
     'animation_hit', 'player_male', 'player_female', 'npc_male', 'npc_female',
     'animation_line', 'line_target', 'line_trail',
-    'infrared_creature',
+    'infrared_creature', 'shadow',
 )
 VP_STANDARD_SYMBOLS = {
     "cover": "^", "cross": "c", "horizontal": "h", "horizontal_2": "=",


### PR DESCRIPTION
## 概要

从 `origin/main`（`d0a02735c31930d4ac939ea2e3123b2bb67e582c`）重建并保留 3 项目标功能：

1. **DDA #72974 怪物护甲破坏**
   - 为护甲弱点加入 `armour_plate_bullet`、`armour_plate_melee`、`armour_shattered`。
   - 适配 Breeze 现有 `damage_required`、`required_effects`、`permanent` 机制，并新增 `forbidden_effects` 过滤，避免已碎裂护甲板重复命中。
   - 增加 `shattered` effect 及完整中文翻译；同步清理电子日志本地文件功能的残留翻译。
   - 这是数据驱动的怪物弱点功能，不新增制造配方，适用于已有相关 humanoid 怪物护甲弱点。

2. **DDA #66730 上层生物阴影投影**
   - 增加可选 `shadow` tileset overlay ID 和 `draw_critter_above`。
   - 当可见生物位于上方 z-level 时，在最低可见 tile 绘制阴影；终端模式保留上方生物的 `^` 提示。
   - 详见 `doc/TILESET.md`。Tileset 可提供名为 `shadow` 的 overlay sprite；没有该 sprite 时不绘制阴影。

3. **DDA #86066 彩色灯光**
   - 为地形、家具、字段强度和车辆部件增加 `[R,G,B]` `light_color` 数据解析与校验。
   - 在现有光照透明度和八方向传播路径上维护独立的彩色缓存；SDL Tiles 仅叠加色彩 tint，不改变普通亮度、lit level 或 FoV。
   - 蓝/红应急车灯分别加入蓝色和红色光源数据。

本 PR 不包含 #67434 高层 FoV、floor/ledge cache、lower-z renderer、dawn/dusk 或电子日志功能。

## 验证

- `git diff --check`：通过。
- `src/map.cpp`、`src/creature.cpp`：相对 `origin/main` 无差异。
- 三项范围等价检查：通过；由于验证环境没有可用 Python，未直接运行 `verify_exact_three.py`。
- Windows MSVC：运行编号 [228](https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/32246123956) 成功。
  - 分支：`feat/exact-three-clean`
  - SHA：`3506689b674b0a8e37e72a62dab757acd7b3adb2`

## 上游依据

- [CleverRaven/Cataclysm-DDA#72974](https://github.com/CleverRaven/Cataclysm-DDA/pull/72974)
- [CleverRaven/Cataclysm-DDA#66730](https://github.com/CleverRaven/Cataclysm-DDA/pull/66730)
- [CleverRaven/Cataclysm-DDA#86066](https://github.com/CleverRaven/Cataclysm-DDA/pull/86066)
