### PR TITLE
猫和狗的陪伴能提高玩家心情

### DIFF
--- a/data/json/morale_types.json
+++ b/data/json/morale_types.json
@@ -335,6 +335,11 @@
     "text": "Spent time playing with a pet"
   },
   {
+    "id": "morale_pet_companionship",
+    "type": "morale_type",
+    "text": "宠物在身边"
+  },
+  {
     "id": "morale_pyromania_startfire",
     "type": "morale_type",
     "text": "Lit a fire"

--- a/lang/po/zh_CN.po
+++ b/lang/po/zh_CN.po
@@ -27426,6 +27426,11 @@ msgstr "逗过宠物"
 
 #. ~ Morale text
 #: data/json/morale_types.json
+msgid "宠物在身边"
+msgstr "宠物在身边"
+
+#. ~ Morale text
+#: data/json/morale_types.json
 msgid "Lit a fire"
 msgstr "点了把火"
 
@@ -414231,6 +414236,11 @@ msgstr "改变发型"
 #: src/activity_actor.cpp:5193
 msgid "Change facial hairstyle"
 msgstr "改变胡须风格"
+
+#: src/activity_actor.cpp:5314
+#, c-format
+msgid "你陪%s玩了一会儿，它看起来很开心，你的心情也轻松了一些。"
+msgstr "你陪%s玩了一会儿，它看起来很开心，你的心情也轻松了一些。"
 
 #. ~ Sound of a wood chopping tool at work!
 #: src/activity_actor.cpp:5400

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5309,7 +5309,7 @@ void play_with_pet_activity_actor::start( player_activity &act, Character & )
 
 void play_with_pet_activity_actor::finish( player_activity &act, Character &who )
 {
-    who.add_morale( MORALE_PLAY_WITH_PET, 5, 5, 5_hours, 25_minutes );
+    who.add_morale( MORALE_PLAY_WITH_PET, 5, 5, 5_hours, 1_hours, true );
 
     who.add_msg_if_player( m_good, _( "你陪%s玩了一会儿，它看起来很开心，你的心情也轻松了一些。" ),
                            pet_name );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5309,13 +5309,9 @@ void play_with_pet_activity_actor::start( player_activity &act, Character & )
 
 void play_with_pet_activity_actor::finish( player_activity &act, Character &who )
 {
-    who.add_morale( MORALE_PLAY_WITH_PET, rng( 3, 10 ), 10, 5_hours, 25_minutes );
+    who.add_morale( MORALE_PLAY_WITH_PET, 5, 5, 5_hours, 25_minutes );
 
-    if( !playstr.empty() ) {
-        who.add_msg_if_player( m_good, playstr, pet_name );
-    }
-
-    who.add_msg_if_player( m_good, _( "Playing with your %s has lifted your spirits a bit." ),
+    who.add_msg_if_player( m_good, _( "你陪%s玩了一会儿，它看起来很开心，你的心情也轻松了一些。" ),
                            pet_name );
     act.set_to_null();
 }

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -43,6 +43,9 @@ static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 
 static const bionic_id bio_alarm( "bio_alarm" );
 
+static const bodytype_id bodytype_cat( "cat" );
+static const bodytype_id bodytype_dog( "dog" );
+
 static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_npc_suspend( "npc_suspend" );
 static const efftype_id effect_ridden( "ridden" );
@@ -69,6 +72,40 @@ static const efftype_id effect_npc_run_away("npc_run_away");
 static const efftype_id effect_npc_flee_player("npc_flee_player");
 static const efftype_id effect_hallucination_npc_die_no_message("hallucination_npc_die_no_message");
 static const zone_type_id zone_type_trade_area("trade_area");
+
+static const morale_type morale_pet_companionship( "morale_pet_companionship" );
+
+static void update_pet_companionship_morale( avatar &u )
+{
+    bool has_pet_cat = false;
+    bool has_pet_dog = false;
+
+    // This runs only once per in-game hour. Scan the already-loaded monster list once,
+    // skip non-pets immediately, and stop as soon as both companion types are found.
+    for( monster &critter : g->all_monsters() ) {
+        if( !critter.is_pet() ) {
+            continue;
+        }
+
+        if( critter.type->bodytype == bodytype_cat ) {
+            has_pet_cat = true;
+        } else if( critter.type->bodytype == bodytype_dog ) {
+            has_pet_dog = true;
+        }
+
+        if( has_pet_cat && has_pet_dog ) {
+            break;
+        }
+    }
+
+    const int companionship_bonus = ( has_pet_cat ? 5 : 0 ) + ( has_pet_dog ? 5 : 0 );
+    if( companionship_bonus > 0 ) {
+        // Use the desired current value as both bonus and cap. This lets the hourly refresh
+        // move cleanly between +5 and +10 instead of leaving the previous larger value behind.
+        u.add_morale( morale_pet_companionship, companionship_bonus, companionship_bonus,
+                      90_minutes, 75_minutes, true );
+    }
+}
 
 #if defined(__ANDROID__)
 extern phmap::btree_map<std::string, std::list<input_event>> quick_shortcuts_map;
@@ -1238,6 +1275,10 @@ bool do_turn()
     u.update_bodytemp();
     u.update_body_wetness( *weather.weather_precise );
     u.apply_wetness_morale( weather.temperature );
+
+    if( calendar::once_every( 1_hours ) ) {
+        update_pet_companionship_morale( u );
+    }
 
     if( calendar::once_every( 1_minutes ) ) {
         u.update_morale();

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -43,8 +43,8 @@ static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 
 static const bionic_id bio_alarm( "bio_alarm" );
 
-static const bodytype_id bodytype_cat( "cat" );
-static const bodytype_id bodytype_dog( "dog" );
+static const mfaction_str_id monfaction_cat( "cat" );
+static const mfaction_str_id monfaction_dog( "dog" );
 
 static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_npc_suspend( "npc_suspend" );
@@ -87,9 +87,11 @@ static void update_pet_companionship_morale( avatar &u )
             continue;
         }
 
-        if( critter.type->bodytype == bodytype_cat ) {
+        const mtype &type = *critter.type;
+        if( type.default_faction == monfaction_cat && type.petfood.food.count( "CATFOOD" ) > 0 ) {
             has_pet_cat = true;
-        } else if( critter.type->bodytype == bodytype_dog ) {
+        } else if( type.default_faction == monfaction_dog &&
+                   type.petfood.food.count( "DOGFOOD" ) > 0 ) {
             has_pet_dog = true;
         }
 


### PR DESCRIPTION
#### Summary
Features "新增宠物陪伴士气与宠物识别修复"

## 核心改动
- 新增统一士气条目“宠物在身边”：现实气泡内存在至少 1 只符合条件的永久宠物猫或狗时，单类提供 `+5`，猫狗两类同时存在提供 `+10`。
- 每游戏时间 1 小时扫描一次已加载怪物，使用 `monster::is_pet()`、默认阵营和宠物食物类型识别有效猫狗；同类数量不叠加，两类都找到后提前结束扫描。
- 士气按当前猫狗组合刷新，持续 90 分钟、75 分钟后衰减；从双类变为单类时下一次刷新回落到 `+5`，宠物离开后自然衰减。
- 主动逗宠物改为固定 `+5`、上限 `+5`，持续 5 小时、1 小时后开始衰减，并统一使用中文提示。
- 补充 `zh_CN` 对新增士气名称和逗宠物提示的翻译。

## 完整改动范围
- `src/do_turn.cpp`：低频宠物扫描、猫狗判定和陪伴士气刷新。
- `src/activity_actor.cpp`：逗宠物士气参数与中文提示。
- `data/json/morale_types.json`：新增 `morale_pet_companionship`。
- `lang/po/zh_CN.po`：补充新增玩家可见文本的中文翻译。

## 获取与操作方式
本功能没有新增制造配方或物品。玩家通过现有游戏机制驯服永久宠物猫或狗，并让其处于玩家现实气泡的已加载范围内即可获得被动士气；主动使用现有“逗宠物”活动可获得固定 `+5` 逗宠物士气。

## 验证
- `git diff --check` 已通过。
- `Windows & Android Test` 运行编号 234 已成功，head SHA 为 `b42e72d8e369e0d1ec3c0bb15d30a24edb0c5301`：[运行链接](https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/32257885663)
