### PR TITLE
修复微风发布的MSYS2依赖版本

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
           VCPKG_BINARY_SOURCES: clear
         with:
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          vcpkgGitCommitId: "9dd12f8d791f6fa4e396adbebc714d51cbee2143"
+          vcpkgGitCommitId: "f6672d8e480ccdecddfad3fd1b838ba369ffe6cd"
 
       - name: Install dependencies (windows msvc) (3/4)
         if: runner.os == 'Windows'
@@ -168,7 +168,7 @@ jobs:
         id: cache-vcpkg
         with:
           path: msvc-full-features/vcpkg_installed/
-          key: vcpkg-${{ hashFiles('msvc-full-features/vcpkg.json') }}-${{ hashFiles('.github/vcpkg_triplets/${{ matrix.arch }}-windows-static.cmake') }}-9dd12f8d791f6fa4e396adbebc714d51cbee2143
+          key: vcpkg-${{ hashFiles('msvc-full-features/vcpkg.json') }}-${{ hashFiles('.github/vcpkg_triplets/${{ matrix.arch }}-windows-static.cmake') }}-f6672d8e480ccdecddfad3fd1b838ba369ffe6cd
 
       - name: Install dependencies (windows msvc) (4/4)
         if: runner.os == 'Windows'


### PR DESCRIPTION
## 问题
微风发布运行编号397的 Windows Tiles x64 MSVC 作业在构建阶段失败。vcpkg 固定在 `9dd12f8d791f6fa4e396adbebc714d51cbee2143`，其 zlib `pkg-config` 修复流程需要下载已从 MSYS2 镜像移除的 `msys2-runtime-3.5.4-2-x86_64.pkg.tar.zst`，所有镜像均返回404。

运行链接：https://github.com/BreezeDevTeam/CDDA-Breeze/actions/runs/32562829485

## 修复
- 将发布工作流的 vcpkg 提交固定版本更新为 `f6672d8e480ccdecddfad3fd1b838ba369ffe6cd`。
- 同步更新 vcpkg 缓存键，避免继续复用旧依赖缓存。
- 该版本已被 Windows & Android Test 运行编号258使用并成功完成；本修复不改变发布版本号，重启发布时继续使用12.5。